### PR TITLE
Update backend entry and add startup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Talentify
+
+This repository contains the backend and frontend for the Talentify project.
+
+## Starting the backend
+
+1. Install dependencies:
+
+```bash
+cd Talentify-backend
+npm install
+```
+
+2. Start the server:
+
+```bash
+npm start
+```
+
+The backend uses `server.js` as the entry point and listens on port `5000` by default (or the value of the `PORT` environment variable).

--- a/Talentify-backend/package.json
+++ b/Talentify-backend/package.json
@@ -1,9 +1,10 @@
 {
   "name": "talentify-backend",
   "version": "1.0.0",
-  "main": "index.js",
+  "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- use `server.js` as main entry point in backend package.json
- add a start script for the backend
- document how to start the backend in a new README

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm start` *(fails: MongoDB connection error)*

------
https://chatgpt.com/codex/tasks/task_e_685a926b77cc83329bc283775d21c6c4