### PR TITLE
Add environment variable support in frontends

### DIFF
--- a/talentify-frontend/.env.example
+++ b/talentify-frontend/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_API_BASE=http://localhost:5000

--- a/talentify-frontend/src/App.js
+++ b/talentify-frontend/src/App.js
@@ -3,6 +3,8 @@ import React, { useState, useEffect } from 'react';
 import './App.css'; // スタイルシートをインポート（必要に応じて）
 
 function App() {
+  const API_BASE = process.env.REACT_APP_API_BASE || 'http://localhost:5000';
+
   const [talents, setTalents] = useState([]); // 人材情報を保持するstate
   const [name, setName] = useState(''); // フォーム入力用state: 名前
   const [email, setEmail] = useState(''); // フォーム入力用state: メールアドレス
@@ -17,7 +19,7 @@ function App() {
   // バックエンドから人材情報を取得する関数
   const fetchTalents = async () => {
     try {
-      const response = await fetch('http://localhost:5000/api/talents'); // GETリクエスト
+      const response = await fetch(`${API_BASE}/api/talents`); // GETリクエスト
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
@@ -36,7 +38,7 @@ function App() {
     const skillsArray = skills.split(',').map(skill => skill.trim()).filter(skill => skill !== '');
 
     try {
-      const response = await fetch('http://localhost:5000/api/talents', {
+      const response = await fetch(`${API_BASE}/api/talents`, {
         method: 'POST', // POSTリクエスト
         headers: {
           'Content-Type': 'application/json', // JSON形式で送信

--- a/talentify-next-frontend/.env.example
+++ b/talentify-next-frontend/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_BASE=http://localhost:5000

--- a/talentify-next-frontend/.gitignore
+++ b/talentify-next-frontend/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/talentify-next-frontend/app/page.js
+++ b/talentify-next-frontend/app/page.js
@@ -12,7 +12,7 @@ export default function Home() {
   const [loading, setLoading] = useState(true); // ローディング状態
   const [error, setError] = useState(null); // エラーメッセージ
 
-  const API_BASE_URL = 'http://localhost:5000/api/talents'; // バックエンドAPIのURL
+  const API_BASE_URL = `${process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000'}/api/talents`; // バックエンドAPIのURL
 
   // ページ読み込み時に人材情報を取得
   useEffect(() => {


### PR DESCRIPTION
## Summary
- pull API base URLs from environment variables in React and Next.js apps
- provide `.env.example` files for both frontends
- allow `.env.example` to be tracked for the Next.js frontend

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm test -- --watchAll=false` in `talentify-next-frontend` *(fails: missing test script)*


------
https://chatgpt.com/codex/tasks/task_e_685a93222368833283a65f44a0d79a78