### PR TITLE
Add root documentation and license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,57 @@
+# Talentify Monorepo
+
+This repository contains a sample backend API and two separate React front‑ends.
+
+## Repository Layout
+
+- `Talentify-backend/` – Node.js + Express API with a MongoDB model.
+- `talentify-frontend/` – Create React App project that interacts with the backend.
+- `talentify-next-frontend/` – Next.js project using the `app` directory.
+
+Each project has its own `package.json` and dependencies. They can be developed and deployed independently but all assume the backend runs locally on port `5000`.
+
+## Backend Setup
+
+1. Install dependencies:
+   ```bash
+   cd Talentify-backend
+   npm install
+   ```
+2. Create a `.env` file inside `Talentify-backend` with the following variables:
+   ```bash
+   MONGODB_URI=<your Mongo connection string>
+   PORT=5000 # optional, defaults to 5000
+   ```
+3. Start the API server:
+   ```bash
+   node server.js
+   ```
+   The server reads these values via `dotenv` as shown in `server.js`.
+
+## React Frontend
+
+The `talentify-frontend` directory contains a Create React App project.
+
+```bash
+cd talentify-frontend
+npm install
+npm start
+```
+
+This frontend expects the backend API at `http://localhost:5000/api/talents` as referenced in `src/App.js`.
+
+## Next.js Frontend
+
+The `talentify-next-frontend` directory is a Next.js application.
+
+```bash
+cd talentify-next-frontend
+npm install
+npm run dev
+```
+
+Like the React app, it communicates with the backend at `http://localhost:5000/api/talents` (see `app/page.js`).
+
+## License
+
+This repository is provided under the MIT License. See the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary
- document repository layout and setup steps
- add MIT license for clarity

## Testing
- `npm test` in `Talentify-backend` *(fails: no test specified)*
- `npm test --silent` in `talentify-frontend` *(fails: react-scripts not found)*
- `npm test` in `talentify-next-frontend` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_685a954492148332854de5612d7056ee