### PR TITLE
Add .env example file for backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,9 @@ Each project has its own `package.json` and dependencies. They can be developed 
    npm install
    ```
 
-2. Create a `.env` file inside `Talentify-backend` with the following variables:
+2. Copy the example environment file and update variables if needed:
    ```bash
-   MONGODB_URI=<your Mongo connection string>
-   PORT=5000 # optional, defaults to 5000
+   cp .env.example .env
    ```
 
 3. Start the API server:

--- a/Talentify-backend/.env.example
+++ b/Talentify-backend/.env.example
@@ -1,2 +1,2 @@
-MONGODB_URI=...
+MONGODB_URI=mongodb://localhost:27017/yourdb
 PORT=5000


### PR DESCRIPTION
## Summary
- provide `.env.example` with connection string defaults
- document copying `.env.example` to `.env`

## Testing
- `npm test` in backend (fails: Error: no test specified)
- `npm test --silent` in CRA frontend (fails: react-scripts not found)
- `npm test` in Next.js frontend (fails: missing script)


------
https://chatgpt.com/codex/tasks/task_e_685ab0ce4efc833295e222b5ea0ae318