### PR TITLE
Add password reset request form

### DIFF
--- a/talentify-next-frontend/app/password-reset/page.js
+++ b/talentify-next-frontend/app/password-reset/page.js
@@ -1,3 +1,48 @@
+"use client";
+import { useState } from "react";
+import Link from "next/link";
+
 export default function PasswordResetPage() {
-  return <h1>Password Reset</h1>;
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    setSubmitted(true);
+  };
+
+  return (
+    <main className="max-w-md mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-2">パスワード再設定</h1>
+      {!submitted ? (
+        <>
+          <p className="mb-6">登録済みのメールアドレスを入力してください</p>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className="block mb-1">メールアドレス</label>
+              <input
+                type="email"
+                className="w-full p-2 border rounded"
+                required
+              />
+            </div>
+            <button
+              type="submit"
+              className="w-full py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+            >
+              再設定メールを送信
+            </button>
+          </form>
+        </>
+      ) : (
+        <p className="mb-6">
+          入力されたメールアドレス宛に再設定リンクを送信しました。
+        </p>
+      )}
+      <div className="mt-6 text-sm">
+        <Link href="/login" className="text-blue-600 underline">
+          ログインへ戻る
+        </Link>
+      </div>
+    </main>
+  );
 }


### PR DESCRIPTION
## Summary
- add email-based password reset form with success message
- link to login page for navigation

## Testing
- `npm run lint` in `talentify-next-frontend`
- `npm test -- -w 1` in `talentify-frontend`

------
https://chatgpt.com/codex/tasks/task_e_685ab0cdb0b08332b478f0804ad2d414