### PR TITLE
Fix register page suspense usage

### DIFF
--- a/talentify-next-frontend/app/register/page.js
+++ b/talentify-next-frontend/app/register/page.js
@@ -1,9 +1,11 @@
+'use client'
+
 import { Suspense } from 'react'
 import RegisterForm from '../../components/RegisterForm'
 
 export default function RegisterPage() {
   return (
-    <Suspense fallback={null}>
+    <Suspense fallback={<div>Loading...</div>}>
       <RegisterForm />
     </Suspense>
   )


### PR DESCRIPTION
## Summary
- mark `/register` page as a client component
- show a fallback while loading `RegisterForm`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685ab73e417c83329c17c3d037efa2f0