### PR TITLE
Add password reset pages

### DIFF
--- a/talentify-next-frontend/app/password-reset/[token]/page.js
+++ b/talentify-next-frontend/app/password-reset/[token]/page.js
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState } from "react";
+
+export default function PasswordResetNewPage({ params }) {
+  const { token } = params;
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [status, setStatus] = useState(null); // "success" | "error" | "mismatch"
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (password !== confirm) {
+      setStatus("mismatch");
+      return;
+    }
+    try {
+      // ここでトークンを用いたパスワード更新APIを呼び出す想定
+      // await fetch(`/api/password-reset/${token}`, { method: "POST", body: JSON.stringify({ password }) });
+      setStatus("success");
+    } catch (err) {
+      setStatus("error");
+    }
+  };
+
+  return (
+    <main className="max-w-md mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-2">新しいパスワードを設定</h1>
+      <p className="mb-4">新しいパスワードを入力してください。</p>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block mb-1">新しいパスワード</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            className="w-full p-2 border rounded"
+          />
+          <p className="text-xs text-gray-500 mt-1">8文字以上、大文字小文字、数字を含めてください</p>
+        </div>
+        <div>
+          <label className="block mb-1">新しいパスワード（確認用）</label>
+          <input
+            type="password"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            required
+            className="w-full p-2 border rounded"
+          />
+        </div>
+        {status === "mismatch" && (
+          <p className="text-red-600">パスワードが一致しません。</p>
+        )}
+        {status === "error" && (
+          <p className="text-red-600">パスワードの更新に失敗しました。</p>
+        )}
+        {status === "success" && (
+          <p className="text-green-600">パスワードを更新しました。</p>
+        )}
+        <button
+          type="submit"
+          className="w-full py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+        >
+          パスワードを更新
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/talentify-next-frontend/app/password-reset/page.js
+++ b/talentify-next-frontend/app/password-reset/page.js
@@ -1,3 +1,53 @@
+"use client";
+
+import { useState } from "react";
+
 export default function PasswordResetPage() {
-  return <h1>Password Reset</h1>;
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState(null); // "success" | "error"
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      // ここでパスワード再設定用メールを送信するAPIを呼び出す想定
+      // await fetch("/api/password-reset", { method: "POST", body: JSON.stringify({ email }) });
+      setStatus("success");
+    } catch (err) {
+      setStatus("error");
+    }
+  };
+
+  return (
+    <main className="max-w-md mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-2">パスワードを再設定</h1>
+      <p className="mb-4">
+        ご登録のメールアドレスを入力してください。パスワード再設定用のリンクをお送りします。
+      </p>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block mb-1">メールアドレス</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            className="w-full p-2 border rounded"
+            placeholder="ご登録のメールアドレス"
+          />
+        </div>
+        {status === "error" && (
+          <p className="text-red-600">メールアドレスの送信に失敗しました。</p>
+        )}
+        {status === "success" && (
+          <p className="text-green-600">パスワード再設定用のメールを送信しました。ご確認ください。</p>
+        )}
+        <button
+          type="submit"
+          className="w-full py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+        >
+          送信する
+        </button>
+      </form>
+    </main>
+  );
 }


### PR DESCRIPTION
## Summary
- add a password reset request form
- add page for entering a new password using token

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm test` in backend *(prints "Error: no test specified")*
- `npm test` in Next.js frontend *(no tests)*

------
https://chatgpt.com/codex/tasks/task_e_685abdea30388332bdfbc85ee0f02826