### PR TITLE
Add password visibility toggle

### DIFF
--- a/talentify-next-frontend/app/password-reset/[token]/page.js
+++ b/talentify-next-frontend/app/password-reset/[token]/page.js
@@ -1,11 +1,14 @@
 "use client";
 
 import { useState } from "react";
+import { EyeIcon, EyeSlashIcon } from "@heroicons/react/24/outline";
 
 export default function PasswordResetNewPage({ params }) {
   const { token } = params;
   const [password, setPassword] = useState("");
   const [confirm, setConfirm] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
   const [status, setStatus] = useState(null); // "success" | "error" | "mismatch"
 
   const handleSubmit = async (e) => {
@@ -30,24 +33,52 @@ export default function PasswordResetNewPage({ params }) {
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
           <label className="block mb-1">新しいパスワード</label>
-          <input
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-            className="w-full p-2 border rounded"
-          />
+          <div className="relative">
+            <input
+              type={showPassword ? "text" : "password"}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              className="w-full p-2 border rounded pr-10"
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword((prev) => !prev)}
+              aria-label="パスワード表示切り替え"
+              className="absolute inset-y-0 right-0 flex items-center px-2"
+            >
+              {showPassword ? (
+                <EyeSlashIcon className="h-5 w-5 text-gray-500" />
+              ) : (
+                <EyeIcon className="h-5 w-5 text-gray-500" />
+              )}
+            </button>
+          </div>
           <p className="text-xs text-gray-500 mt-1">8文字以上、大文字小文字、数字を含めてください</p>
         </div>
         <div>
           <label className="block mb-1">新しいパスワード（確認用）</label>
-          <input
-            type="password"
-            value={confirm}
-            onChange={(e) => setConfirm(e.target.value)}
-            required
-            className="w-full p-2 border rounded"
-          />
+          <div className="relative">
+            <input
+              type={showConfirm ? "text" : "password"}
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              required
+              className="w-full p-2 border rounded pr-10"
+            />
+            <button
+              type="button"
+              onClick={() => setShowConfirm((prev) => !prev)}
+              aria-label="パスワード表示切り替え"
+              className="absolute inset-y-0 right-0 flex items-center px-2"
+            >
+              {showConfirm ? (
+                <EyeSlashIcon className="h-5 w-5 text-gray-500" />
+              ) : (
+                <EyeIcon className="h-5 w-5 text-gray-500" />
+              )}
+            </button>
+          </div>
         </div>
         {status === "mismatch" && (
           <p className="text-red-600">パスワードが一致しません。</p>

--- a/talentify-next-frontend/package-lock.json
+++ b/talentify-next-frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "talentify-next-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@heroicons/react": "^2.2.0",
         "next": "15.3.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -232,6 +233,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanfs/core": {

--- a/talentify-next-frontend/package.json
+++ b/talentify-next-frontend/package.json
@@ -9,15 +9,16 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@heroicons/react": "^2.2.0",
+    "next": "15.3.4",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "next": "15.3.4"
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.3.4",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4"
   }
 }


### PR DESCRIPTION
## Summary
- add heroicons dependency for icons
- implement show/hide password buttons for password reset form

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685ac01a2f1883328e6be630039eff67