### PR TITLE
Add performers listing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ npm run dev
 
 Like the React app, it communicates with the backend at `http://localhost:5000/api/talents` (see `app/page.js`).
 
+The Next.js app also provides a performer search interface at `/performers` where you can filter and browse registered talents.
+
 ## License
 
 This repository is provided under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/talentify-next-frontend/app/performers/page.js
+++ b/talentify-next-frontend/app/performers/page.js
@@ -1,0 +1,51 @@
+'use client'
+import { useEffect, useState } from 'react'
+import PerformerCard from '../../components/PerformerCard'
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000'
+
+export default function PerformersPage() {
+  const [talents, setTalents] = useState([])
+  const [query, setQuery] = useState('')
+
+  useEffect(() => {
+    const fetchTalents = async () => {
+      try {
+        const res = await fetch(`${API_BASE}/api/talents`)
+        if (!res.ok) throw new Error('Failed to fetch')
+        const data = await res.json()
+        setTalents(data)
+      } catch (e) {
+        console.error(e)
+      }
+    }
+    fetchTalents()
+  }, [])
+
+  const normalized = query.toLowerCase()
+  const filtered = talents.filter(t =>
+    t.name.toLowerCase().includes(normalized) ||
+    (t.skills || []).some(s => s.toLowerCase().includes(normalized))
+  )
+
+  return (
+    <main className="max-w-4xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">演者を探す</h1>
+      <input
+        type="text"
+        value={query}
+        onChange={e => setQuery(e.target.value)}
+        placeholder="名前・スキルで検索"
+        className="w-full p-2 border rounded mb-6"
+      />
+      <div className="grid gap-4 md:grid-cols-2">
+        {filtered.map(t => (
+          <PerformerCard key={t._id} talent={t} />
+        ))}
+        {filtered.length === 0 && (
+          <p>該当する演者が見つかりませんでした。</p>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/talentify-next-frontend/components/Header.js
+++ b/talentify-next-frontend/components/Header.js
@@ -8,6 +8,7 @@ export default function Header() {
       </Link>
       <nav className="space-x-4 text-sm">
         <a href="#about" className="hover:underline">このサイトについて</a>
+        <Link href="/performers" className="hover:underline">演者検索</Link>
         <Link href="/faq" className="hover:underline">FAQ</Link>
         <Link href="/contact" className="hover:underline">お問い合わせ</Link>
         <Link href="/login" className="font-semibold hover:underline">ログイン</Link>

--- a/talentify-next-frontend/components/PerformerCard.js
+++ b/talentify-next-frontend/components/PerformerCard.js
@@ -1,0 +1,27 @@
+'use client'
+import Image from 'next/image'
+
+export default function PerformerCard({ talent }) {
+  return (
+    <div className="border rounded p-4 flex flex-col">
+      <div className="flex items-center mb-2">
+        <div className="w-16 h-16 bg-gray-200 rounded-full mr-3" />
+        <h2 className="text-lg font-semibold">{talent.name}</h2>
+      </div>
+      {talent.skills && talent.skills.length > 0 && (
+        <p className="text-sm mb-2">
+          <span className="font-medium">スキル: </span>
+          {talent.skills.join(', ')}
+        </p>
+      )}
+      <p className="text-sm mb-4">
+        <span className="font-medium">経験年数: </span>
+        {talent.experienceYears}年
+      </p>
+      <div className="mt-auto flex space-x-2">
+        <button className="flex-1 py-1 border rounded hover:bg-gray-50">詳細を見る</button>
+        <button className="flex-1 py-1 bg-blue-600 text-white rounded hover:bg-blue-700">オファーを送る</button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a performer search page to the Next.js frontend
- show performer cards via new `PerformerCard` component
- link the page from the header navigation
- document the new page in the repository README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685acc67ea408332904d50e40a18f689