### PR TITLE
Update env setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ npm install
 npm start
 ```
 
+Copy `.env.example` to `.env` first and ensure `REACT_APP_API_BASE` points to your
+backend URL (defaults to `http://localhost:5000`).
+
 This frontend expects the backend API at `http://localhost:5000/api/talents` as referenced in `src/App.js`.
 
 ## Next.js Frontend
@@ -50,6 +53,9 @@ cd talentify-next-frontend
 npm install
 npm run dev
 ```
+
+Before starting, copy `.env.example` to `.env` and set `NEXT_PUBLIC_API_BASE` to
+your backend URL (defaults to `http://localhost:5000`).
 
 Like the React app, it communicates with the backend at `http://localhost:5000/api/talents` (see `app/page.js`).
 


### PR DESCRIPTION
## Summary
- document copying `.env.example` to `.env` in both frontend apps
- note that `REACT_APP_API_BASE` and `NEXT_PUBLIC_API_BASE` should point to the backend URL

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685aced969308332b6f7d12a130281db