### PR TITLE
Add optional fields to Talent model

### DIFF
--- a/Talentify-backend/models/Talent.js
+++ b/Talentify-backend/models/Talent.js
@@ -25,6 +25,32 @@ const TalentSchema = new mongoose.Schema({
     min: 0, // 0以上の数値
     default: 0
   },
+  avatarUrl: { // プロフィール画像のURL
+    type: String,
+    trim: true,
+    default: '' // 既存ドキュメントへの影響を避けるため空文字をデフォルトに
+  },
+  socialLinks: { // SNSなどのリンク
+    type: [String],
+    default: []
+  },
+  bio: { // 自己紹介文
+    type: String,
+    default: ''
+  },
+  location: { // 居住地など
+    type: String,
+    default: ''
+  },
+  rate: { // 単価
+    type: Number,
+    min: 0,
+    default: 0
+  },
+  availability: { // 稼働状況など
+    type: String,
+    default: ''
+  },
   // その他の追加したい項目があればここに追加
   createdAt: { // 作成日時
     type: Date,

--- a/Talentify-backend/server.js
+++ b/Talentify-backend/server.js
@@ -55,7 +55,13 @@ app.post('/api/talents', async (req, res) => {
         name: req.body.name,
         email: req.body.email,
         skills: req.body.skills,
-        experienceYears: req.body.experienceYears
+        experienceYears: req.body.experienceYears,
+        avatarUrl: req.body.avatarUrl,
+        socialLinks: req.body.socialLinks,
+        bio: req.body.bio,
+        location: req.body.location,
+        rate: req.body.rate,
+        availability: req.body.availability
     });
 
     try {


### PR DESCRIPTION
## Summary
- extend the Talent schema with optional profile fields
- forward new profile fields through the POST API

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685aced8a3288332b50453319149ceac