### PR TITLE
Add performer detail page

### DIFF
--- a/talentify-next-frontend/app/performers/[id]/page.js
+++ b/talentify-next-frontend/app/performers/[id]/page.js
@@ -1,0 +1,54 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000'
+
+export default function PerformerDetailPage({ params }) {
+  const { id } = params
+  const [talent, setTalent] = useState(null)
+
+  useEffect(() => {
+    const fetchTalent = async () => {
+      try {
+        const res = await fetch(`${API_BASE}/api/talents/${id}`)
+        if (!res.ok) throw new Error('Failed to fetch')
+        const data = await res.json()
+        setTalent(data)
+      } catch (e) {
+        console.error(e)
+      }
+    }
+    fetchTalent()
+  }, [id])
+
+  if (!talent) {
+    return (
+      <main className="max-w-3xl mx-auto p-4">
+        <p>Loading...</p>
+      </main>
+    )
+  }
+
+  return (
+    <main className="max-w-3xl mx-auto p-4 space-y-4">
+      <h1 className="text-2xl font-bold">{talent.name}</h1>
+      {talent.skills && talent.skills.length > 0 && (
+        <p>
+          <span className="font-medium">スキル: </span>
+          {talent.skills.join(', ')}
+        </p>
+      )}
+      <p>
+        <span className="font-medium">経験年数: </span>
+        {talent.experienceYears}年
+      </p>
+      <hr />
+      <p className="text-gray-500">プロフィール詳細は今後ここに表示されます。</p>
+      <Link href="/performers" className="text-blue-600 underline">
+        演者一覧に戻る
+      </Link>
+    </main>
+  )
+}

--- a/talentify-next-frontend/components/PerformerCard.js
+++ b/talentify-next-frontend/components/PerformerCard.js
@@ -1,5 +1,6 @@
 'use client'
 import Image from 'next/image'
+import Link from 'next/link'
 
 export default function PerformerCard({ talent }) {
   return (
@@ -19,7 +20,12 @@ export default function PerformerCard({ talent }) {
         {talent.experienceYears}年
       </p>
       <div className="mt-auto flex space-x-2">
-        <button className="flex-1 py-1 border rounded hover:bg-gray-50">詳細を見る</button>
+        <Link
+          href={`/performers/${talent._id}`}
+          className="flex-1 py-1 border rounded text-center hover:bg-gray-50"
+        >
+          詳細を見る
+        </Link>
         <button className="flex-1 py-1 bg-blue-600 text-white rounded hover:bg-blue-700">オファーを送る</button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- link PerformerCard to new profile page
- fetch performer data on `/performers/[id]`
- show core fields and placeholder for details

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685aced7b78883328655a8fcec713e1c