### PR TITLE
Implement /api/talents/:id endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Each project has its own `package.json` and dependencies. They can be developed 
    node server.js
    ```
 
+### API Endpoints
+
+- `GET /api/talents` - Retrieve all registered talents.
+- `POST /api/talents` - Add a new talent.
+- `GET /api/talents/:id` - Retrieve a talent by its MongoDB `_id` (returns `404` if not found).
+
 ## React Frontend
 
 The `talentify-frontend` directory contains a Create React App project.

--- a/Talentify-backend/server.js
+++ b/Talentify-backend/server.js
@@ -49,6 +49,19 @@ app.get('/api/talents', async (req, res) => {
     }
 });
 
+// IDで特定の人材情報を取得するAPI
+app.get('/api/talents/:id', async (req, res) => {
+    try {
+        const talent = await Talent.findById(req.params.id);
+        if (!talent) {
+            return res.status(404).json({ message: 'Talent not found' });
+        }
+        res.json(talent);
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
 // 新しい人材情報を追加するAPI
 app.post('/api/talents', async (req, res) => {
     const talent = new Talent({


### PR DESCRIPTION
## Summary
- add route to fetch a single talent by `_id`
- document backend API endpoints

## Testing
- `npm test` (fails: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_685aced690e88332bcc7238b9e837e54