### PR TITLE
Add manage page

### DIFF
--- a/talentify-next-frontend/app/manage/page.js
+++ b/talentify-next-frontend/app/manage/page.js
@@ -1,0 +1,136 @@
+'use client'
+import { useState } from 'react'
+
+const TABS = ['進行中の契約', 'スケジュール', '履歴', '支払い']
+
+const ongoingContracts = [
+  {
+    id: 1,
+    event: '7月10日 ○○店来店実践',
+    performer: '○○さん',
+    datetime: '2025/07/10 14:00',
+    location: '○○ホール',
+    status: '契約済',
+    document: '署名済み',
+  },
+]
+
+const scheduleEvents = [
+  { date: '2025-07-10', label: '○○さん来店 14:00' },
+  { date: '2025-07-22', label: '△△さん実践撮影 11:00' },
+]
+
+const history = [
+  { id: 1, date: '2025/06/12', label: '○○さん来店＠○○ホール', reviewed: true },
+  { id: 2, date: '2025/05/28', label: '△△さんトークイベント', reviewed: false },
+]
+
+const payments = [
+  { id: 1, label: '○○さん', amount: 40000, status: '未払い', invoice: '#' },
+  { id: 2, label: '△△さん', amount: 35000, status: '支払済' },
+]
+
+function TabButton({ current, tab, setTab }) {
+  return (
+    <button
+      onClick={() => setTab(tab)}
+      className={`px-3 py-1 rounded border whitespace-nowrap ${current === tab ? 'bg-blue-600 text-white' : 'bg-white'}`}
+    >
+      {tab}
+    </button>
+  )
+}
+
+function OngoingContracts() {
+  return (
+    <div className="space-y-4">
+      {ongoingContracts.map(c => (
+        <div key={c.id} className="border rounded p-4">
+          <div className="flex flex-col md:flex-row md:justify-between">
+            <div className="space-y-1">
+              <div>{c.event}</div>
+              <div>演者: {c.performer}</div>
+              <div>日時: {c.datetime}</div>
+              <div>場所: {c.location}</div>
+            </div>
+            <div className="space-y-1 md:text-right mt-2 md:mt-0">
+              <div className="text-sm">状態: {c.status}</div>
+              <div className="text-sm">書類: {c.document}</div>
+            </div>
+          </div>
+          <div className="mt-2 flex space-x-2">
+            <button className="px-3 py-1 border rounded">契約書確認</button>
+            <button className="px-3 py-1 border rounded">メッセージ</button>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function Schedule() {
+  return (
+    <div className="border rounded p-4">
+      <h3 className="font-semibold mb-2">2025年7月</h3>
+      <ul className="space-y-1">
+        {scheduleEvents.map(e => (
+          <li key={e.date}>{e.label}</li>
+        ))}
+      </ul>
+      <button className="mt-4 px-3 py-1 border rounded">新しい依頼作成</button>
+    </div>
+  )
+}
+
+function History() {
+  return (
+    <div className="space-y-2">
+      {history.map(h => (
+        <div key={h.id} className="border rounded p-2 flex items-center justify-between">
+          <div>{h.date} {h.label}</div>
+          {h.reviewed ? (
+            <span className="text-sm text-gray-500">★レビュー済</span>
+          ) : (
+            <button className="text-sm text-blue-600 underline">レビューを書く</button>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function Payments() {
+  return (
+    <div className="space-y-2">
+      {payments.map(p => (
+        <div key={p.id} className="border rounded p-2 flex items-center justify-between">
+          <div>{p.label} ¥{p.amount.toLocaleString()}</div>
+          <div className="flex items-center space-x-2 text-sm">
+            <span>{p.status}</span>
+            {p.invoice && (
+              <a href={p.invoice} className="text-blue-600 underline">請求書DL</a>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default function ManagePage() {
+  const [tab, setTab] = useState('進行中の契約')
+
+  return (
+    <main className="max-w-4xl mx-auto p-4">
+      <div className="flex space-x-2 mb-4 overflow-x-auto">
+        {TABS.map(t => (
+          <TabButton key={t} tab={t} current={tab} setTab={setTab} />
+        ))}
+      </div>
+      {tab === '進行中の契約' && <OngoingContracts />}
+      {tab === 'スケジュール' && <Schedule />}
+      {tab === '履歴' && <History />}
+      {tab === '支払い' && <Payments />}
+    </main>
+  )
+}

--- a/talentify-next-frontend/components/Header.js
+++ b/talentify-next-frontend/components/Header.js
@@ -11,6 +11,7 @@ export default function Header() {
         <Link href="/performers" className="hover:underline">演者検索</Link>
         <Link href="/faq" className="hover:underline">FAQ</Link>
         <Link href="/contact" className="hover:underline">お問い合わせ</Link>
+        <Link href="/manage" className="hover:underline">管理ページ</Link>
         <Link href="/login" className="font-semibold hover:underline">ログイン</Link>
         <Link
           href="/register"


### PR DESCRIPTION
## Summary
- add a basic management screen with tabs for contracts, schedule, history and payments
- link Manage page from site header

## Testing
- `npm run lint` in `talentify-next-frontend`
- `npm test` in `talentify-frontend` *(no tests found)*
- `npm test` in `Talentify-backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685ad430ca3883329d83a369739d0db3