### PR TITLE
Add dashboard with shadcn config

### DIFF
--- a/talentify-next-frontend/app/dashboard/page.js
+++ b/talentify-next-frontend/app/dashboard/page.js
@@ -1,0 +1,104 @@
+"use client";
+import Link from 'next/link';
+import { Card, CardHeader, CardContent, CardFooter } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
+import { Calendar } from '@/components/ui/calendar';
+
+const mockNotifications = {
+  offers: 2,
+  messages: 3,
+  events: 1,
+};
+
+const upcomingEvents = [
+  { date: '2025-07-01', title: 'イベントA' },
+  { date: '2025-07-15', title: 'イベントB' },
+];
+
+const pendingOffers = [
+  { id: 1, title: '出演依頼1' },
+  { id: 2, title: '出演依頼2' },
+];
+
+export default function DashboardPage() {
+  return (
+    <div className="p-4 grid gap-4 md:grid-cols-2">
+      <Card>
+        <CardHeader className="flex items-center justify-between">
+          <span>通知</span>
+          <Badge>{mockNotifications.offers} オファー</Badge>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <Alert>
+            <AlertTitle>メッセージ</AlertTitle>
+            <AlertDescription>
+              未読メッセージ {mockNotifications.messages} 件
+            </AlertDescription>
+          </Alert>
+          <Alert>
+            <AlertTitle>イベント</AlertTitle>
+            <AlertDescription>
+              近日予定 {mockNotifications.events} 件
+            </AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>スケジュール</CardHeader>
+        <CardContent>
+          <Calendar events={upcomingEvents} />
+          <Link href="/schedule" className="text-blue-600 underline text-sm mt-2 block">
+            スケジュール詳細
+          </Link>
+        </CardContent>
+      </Card>
+
+      <Card className="md:col-span-2">
+        <CardHeader>保留中のオファー</CardHeader>
+        <CardContent>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left">
+                <th className="py-1">タイトル</th>
+                <th className="py-1">操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {pendingOffers.map((o) => (
+                <tr key={o.id} className="border-t">
+                  <td className="py-2">{o.title}</td>
+                  <td className="py-2 space-x-2">
+                    <button className="text-blue-600">詳細確認</button>
+                    <button className="text-green-600">承諾</button>
+                    <button className="text-red-600">辞退</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+
+      <Card className="md:col-span-2">
+        <CardHeader>プロフィール</CardHeader>
+        <CardContent className="space-y-2">
+          <div className="flex items-center space-x-2">
+            <span>公開設定:</span>
+            <Badge variant="secondary">公開</Badge>
+          </div>
+          <div>平均評価: ★★★★☆</div>
+          <div className="space-x-4">
+            <Link href="/profile/edit" className="text-blue-600 underline">
+              プロフィール編集
+            </Link>
+            <Link href="/reviews" className="text-blue-600 underline">
+              レビューを見る
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/talentify-next-frontend/app/profile/edit/page.js
+++ b/talentify-next-frontend/app/profile/edit/page.js
@@ -1,0 +1,3 @@
+export default function ProfileEditPage() {
+  return <h1>プロフィール編集</h1>;
+}

--- a/talentify-next-frontend/app/schedule/page.js
+++ b/talentify-next-frontend/app/schedule/page.js
@@ -1,0 +1,3 @@
+export default function SchedulePage() {
+  return <h1>スケジュール詳細</h1>;
+}

--- a/talentify-next-frontend/components.json
+++ b/talentify-next-frontend/components.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "default",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.js",
+    "css": "app/globals.css",
+    "baseColor": "slate",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "iconLibrary": "lucide"
+}

--- a/talentify-next-frontend/components/Header.js
+++ b/talentify-next-frontend/components/Header.js
@@ -9,6 +9,7 @@ export default function Header() {
       <nav className="space-x-4 text-sm">
         <a href="#about" className="hover:underline">このサイトについて</a>
         <Link href="/performers" className="hover:underline">演者検索</Link>
+        <Link href="/dashboard" className="hover:underline">ダッシュボード</Link>
         <Link href="/faq" className="hover:underline">FAQ</Link>
         <Link href="/contact" className="hover:underline">お問い合わせ</Link>
         <Link href="/login" className="font-semibold hover:underline">ログイン</Link>

--- a/talentify-next-frontend/components/ui/README.md
+++ b/talentify-next-frontend/components/ui/README.md
@@ -1,0 +1,1 @@
+// shadcn/ui components will be added here

--- a/talentify-next-frontend/components/ui/alert.js
+++ b/talentify-next-frontend/components/ui/alert.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+export function Alert({ className, variant = 'default', ...props }) {
+  const base = 'border rounded p-4 text-sm';
+  const variants = {
+    default: 'bg-gray-50 text-gray-700',
+    destructive: 'bg-red-50 text-red-700 border-red-300',
+  };
+  return <div role="alert" className={cn(base, variants[variant], className)} {...props} />;
+}
+
+export function AlertTitle({ className, ...props }) {
+  return <h3 className={cn('font-semibold mb-1', className)} {...props} />;
+}
+
+export function AlertDescription({ className, ...props }) {
+  return <div className={cn('text-sm', className)} {...props} />;
+}

--- a/talentify-next-frontend/components/ui/badge.js
+++ b/talentify-next-frontend/components/ui/badge.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+export function Badge({ className, variant = 'default', ...props }) {
+  const base = 'inline-flex items-center px-2 py-0.5 rounded text-xs font-medium';
+  const variants = {
+    default: 'bg-blue-600 text-white',
+    secondary: 'bg-gray-100 text-gray-800',
+    destructive: 'bg-red-600 text-white',
+    outline: 'border border-gray-300 text-gray-700',
+  };
+  return <span className={cn(base, variants[variant], className)} {...props} />;
+}

--- a/talentify-next-frontend/components/ui/calendar.js
+++ b/talentify-next-frontend/components/ui/calendar.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+export function Calendar({ className, events = [], ...props }) {
+  return (
+    <div className={cn('p-2', className)} {...props}>
+      <ul className="space-y-1">
+        {events.map((e) => (
+          <li key={e.date} className="text-sm">
+            {e.date}: {e.title}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/talentify-next-frontend/components/ui/card.js
+++ b/talentify-next-frontend/components/ui/card.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+export function Card({ className, ...props }) {
+  return <div className={cn('rounded-xl border bg-white p-4 shadow', className)} {...props} />;
+}
+
+export function CardHeader({ className, ...props }) {
+  return <div className={cn('mb-2 font-semibold text-lg', className)} {...props} />;
+}
+
+export function CardContent({ className, ...props }) {
+  return <div className={cn('mb-2', className)} {...props} />;
+}
+
+export function CardFooter({ className, ...props }) {
+  return <div className={cn('mt-2', className)} {...props} />;
+}

--- a/talentify-next-frontend/lib/utils.ts
+++ b/talentify-next-frontend/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/talentify-next-frontend/tailwind.config.js
+++ b/talentify-next-frontend/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './app/**/*.{js,jsx,ts,tsx,mdx}',
+    './components/**/*.{js,jsx,ts,tsx,mdx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
## Summary
- integrate minimal shadcn-style config (`components.json`, Tailwind config and utility helpers)
- create placeholder ui components (`Card`, `Badge`, `Alert`, `Calendar`)
- add dashboard page with notifications, calendar, offers and profile section
- link dashboard from the header navigation
- stub schedule detail and profile edit pages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685ad5d771708332b3e8b2dea2e05d5b