### PR TITLE
Add profile edit helper and form

### DIFF
--- a/talentify-next-frontend/app/profile/edit/page.js
+++ b/talentify-next-frontend/app/profile/edit/page.js
@@ -1,3 +1,10 @@
+import ProfileEditForm from '@/components/ProfileEditForm'
+
 export default function ProfileEditPage() {
-  return <h1>プロフィール編集</h1>;
+  return (
+    <main className="max-w-xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">プロフィール編集</h1>
+      <ProfileEditForm talentId="replace-with-id" />
+    </main>
+  )
 }

--- a/talentify-next-frontend/components/ProfileEditForm.js
+++ b/talentify-next-frontend/components/ProfileEditForm.js
@@ -1,0 +1,84 @@
+'use client'
+
+import { useState } from 'react'
+import { updateTalent } from '@/lib/api'
+
+export default function ProfileEditForm({ talentId, initialTalent = {} }) {
+  const [name, setName] = useState(initialTalent.name || '')
+  const [email, setEmail] = useState(initialTalent.email || '')
+  const [skills, setSkills] = useState(
+    initialTalent.skills ? initialTalent.skills.join(', ') : ''
+  )
+  const [success, setSuccess] = useState(null)
+  const [error, setError] = useState(null)
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setSuccess(null)
+    setError(null)
+    try {
+      await updateTalent(talentId, {
+        name,
+        email,
+        skills: skills
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean),
+      })
+      setSuccess('プロフィールを更新しました。')
+    } catch (err) {
+      console.error(err)
+      setError('更新に失敗しました。')
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {success && (
+        <div className="bg-green-100 border border-green-300 p-2 rounded">
+          {success}
+        </div>
+      )}
+      {error && (
+        <div className="bg-red-100 border border-red-300 p-2 rounded">
+          {error}
+        </div>
+      )}
+      <div>
+        <label className="block mb-1">名前</label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full p-2 border rounded"
+          required
+        />
+      </div>
+      <div>
+        <label className="block mb-1">メールアドレス</label>
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="w-full p-2 border rounded"
+          required
+        />
+      </div>
+      <div>
+        <label className="block mb-1">スキル (カンマ区切り)</label>
+        <input
+          type="text"
+          value={skills}
+          onChange={(e) => setSkills(e.target.value)}
+          className="w-full p-2 border rounded"
+        />
+      </div>
+      <button
+        type="submit"
+        className="w-full py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+      >
+        更新する
+      </button>
+    </form>
+  )
+}

--- a/talentify-next-frontend/lib/api.js
+++ b/talentify-next-frontend/lib/api.js
@@ -1,0 +1,15 @@
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000'
+
+export async function updateTalent(id, data) {
+  const res = await fetch(`${API_BASE}/api/talents/${id}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  })
+  if (!res.ok) {
+    throw new Error('Failed to update talent')
+  }
+  return res.json()
+}


### PR DESCRIPTION
## Summary
- add an API helper with `updateTalent`
- implement `ProfileEditForm` using the helper and showing success/error
- update the profile edit page to render the form

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685ad9101a1c833282858cb353272d65