### PR TITLE
Add payments management

### DIFF
--- a/Talentify-backend/models/BankAccount.js
+++ b/Talentify-backend/models/BankAccount.js
@@ -1,0 +1,16 @@
+const mongoose = require('mongoose');
+
+const BankAccountSchema = new mongoose.Schema({
+  bankName: { type: String, required: true, trim: true },
+  branchName: { type: String, required: true, trim: true },
+  accountType: {
+    type: String,
+    enum: ['普通', '当座'],
+    default: '普通',
+  },
+  accountNumber: { type: String, required: true, trim: true },
+  accountHolder: { type: String, required: true, trim: true },
+  createdAt: { type: Date, default: Date.now },
+});
+
+module.exports = mongoose.model('BankAccount', BankAccountSchema);

--- a/Talentify-backend/models/Payment.js
+++ b/Talentify-backend/models/Payment.js
@@ -1,0 +1,31 @@
+const mongoose = require('mongoose');
+
+const PaymentSchema = new mongoose.Schema({
+  eventDate: {
+    type: Date,
+    required: true,
+  },
+  venue: {
+    type: String,
+    required: true,
+    trim: true,
+  },
+  amount: {
+    type: Number,
+    required: true,
+    min: 0,
+  },
+  status: {
+    type: String,
+    enum: ['未払い', '支払済', '振込手続中'],
+    default: '未払い',
+  },
+  transferDate: Date,
+  invoiceUrl: String,
+  createdAt: {
+    type: Date,
+    default: Date.now,
+  },
+});
+
+module.exports = mongoose.model('Payment', PaymentSchema);

--- a/Talentify-backend/server.js
+++ b/Talentify-backend/server.js
@@ -4,6 +4,8 @@ const mongoose = require('mongoose');
 const dotenv = require('dotenv');
 const cors = require('cors'); // CORSエラー回避のため
 const Talent = require('./models/Talent'); // Talentモデルをインポート
+const Payment = require('./models/Payment');
+const BankAccount = require('./models/BankAccount');
 
 dotenv.config(); // .envファイルから環境変数を読み込む
 
@@ -83,6 +85,42 @@ app.post('/api/talents', async (req, res) => {
     } catch (err) {
         // バリデーションエラーなど、クライアント側の問題の場合は400 Bad Request
         res.status(400).json({ message: err.message }); 
+    }
+});
+
+// ギャラ受取履歴取得
+app.get('/api/payments', async (req, res) => {
+    try {
+        const payments = await Payment.find().sort({ eventDate: -1 });
+        res.json(payments);
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+// 銀行口座情報取得
+app.get('/api/bank-account', async (req, res) => {
+    try {
+        const account = await BankAccount.findOne();
+        res.json(account || {});
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+// 銀行口座情報登録・更新
+app.post('/api/bank-account', async (req, res) => {
+    try {
+        let account = await BankAccount.findOne();
+        if (account) {
+            account.set(req.body);
+        } else {
+            account = new BankAccount(req.body);
+        }
+        const saved = await account.save();
+        res.json(saved);
+    } catch (err) {
+        res.status(400).json({ message: err.message });
     }
 });
 

--- a/talentify-next-frontend/app/payments/page.js
+++ b/talentify-next-frontend/app/payments/page.js
@@ -1,0 +1,118 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000'
+
+export default function PaymentsPage() {
+  const [payments, setPayments] = useState([])
+  const [account, setAccount] = useState({
+    bankName: '',
+    branchName: '',
+    accountType: '普通',
+    accountNumber: '',
+    accountHolder: '',
+  })
+  const [banner, setBanner] = useState(false)
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const resPay = await fetch(`${API_BASE}/api/payments`)
+        if (resPay.ok) {
+          const data = await resPay.json()
+          setPayments(data)
+          setBanner(data.some(p => p.status === '未払い'))
+        }
+        const resAcc = await fetch(`${API_BASE}/api/bank-account`)
+        if (resAcc.ok) {
+          const acc = await resAcc.json()
+          if (acc) setAccount(acc)
+        }
+      } catch (e) {
+        console.error(e)
+      }
+    }
+    fetchData()
+  }, [])
+
+  const handleChange = e => {
+    setAccount({ ...account, [e.target.name]: e.target.value })
+  }
+
+  const saveAccount = async e => {
+    e.preventDefault()
+    try {
+      const res = await fetch(`${API_BASE}/api/bank-account`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(account),
+      })
+      if (!res.ok) throw new Error('failed')
+      alert('保存しました')
+    } catch (e) {
+      console.error(e)
+      alert('保存に失敗しました')
+    }
+  }
+
+  return (
+    <main className="max-w-3xl mx-auto p-4 space-y-6">
+      <h1 className="text-xl font-bold">決済管理</h1>
+      {banner && (
+        <div className="p-3 bg-yellow-100 border text-sm">
+          未払いのイベント報酬があります。口座情報をご確認ください
+        </div>
+      )}
+      <section>
+        <h2 className="font-semibold mb-2">ギャラ受取履歴</h2>
+        <ul className="space-y-2">
+          {payments.map(p => (
+            <li key={p._id} className="border p-2 flex justify-between">
+              <div>
+                <div>{new Date(p.eventDate).toLocaleDateString()} {p.venue}</div>
+                <div className="text-sm">ステータス: {p.status} {p.transferDate ? `(${new Date(p.transferDate).toLocaleDateString()}振込)` : ''}</div>
+              </div>
+              <div className="flex flex-col items-end">
+                <div>¥{p.amount.toLocaleString()}</div>
+                {p.invoiceUrl && <a href={p.invoiceUrl} className="text-blue-600 text-xs underline">明細を見る</a>}
+              </div>
+            </li>
+          ))}
+          {payments.length === 0 && (
+            <li className="text-sm">履歴がありません</li>
+          )}
+        </ul>
+      </section>
+      <section>
+        <h2 className="font-semibold mb-2">銀行口座情報</h2>
+        <form onSubmit={saveAccount} className="space-y-2">
+          <div>
+            <label className="block text-sm mb-1">銀行名</label>
+            <input name="bankName" value={account.bankName} onChange={handleChange} className="border p-1 rounded w-full" />
+          </div>
+          <div>
+            <label className="block text-sm mb-1">支店名</label>
+            <input name="branchName" value={account.branchName} onChange={handleChange} className="border p-1 rounded w-full" />
+          </div>
+          <div>
+            <label className="block text-sm mb-1">種別</label>
+            <select name="accountType" value={account.accountType} onChange={handleChange} className="border p-1 rounded">
+              <option value="普通">普通</option>
+              <option value="当座">当座</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm mb-1">口座番号</label>
+            <input name="accountNumber" value={account.accountNumber} onChange={handleChange} className="border p-1 rounded w-full" />
+          </div>
+          <div>
+            <label className="block text-sm mb-1">名義(カナ)</label>
+            <input name="accountHolder" value={account.accountHolder} onChange={handleChange} className="border p-1 rounded w-full" />
+          </div>
+          <button type="submit" className="px-3 py-1 border rounded bg-blue-600 text-white">保存する</button>
+        </form>
+        <p className="text-xs mt-2">支払予定はイベント終了後○営業日以内です</p>
+      </section>
+    </main>
+  )
+}

--- a/talentify-next-frontend/components/Header.js
+++ b/talentify-next-frontend/components/Header.js
@@ -13,6 +13,7 @@ export default function Header() {
         <Link href="/faq" className="hover:underline">FAQ</Link>
         <Link href="/contact" className="hover:underline">お問い合わせ</Link>
         <Link href="/manage" className="hover:underline">管理ページ</Link>
+        <Link href="/payments" className="hover:underline">決済管理</Link>
         <Link href="/login" className="font-semibold hover:underline">ログイン</Link>
         <Link
           href="/register"


### PR DESCRIPTION
## Summary
- track payments in the backend with `Payment` and `BankAccount` models
- expose REST endpoints for payment history and bank account info
- add UI under `/payments` to view payment history and edit bank account
- link the new page in the header navigation

## Testing
- `npm test` within `Talentify-backend` *(fails: no test specified)*
- `npm test` within `talentify-next-frontend` *(fails: missing script)*
- `npm test` within `talentify-frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685adb6248d48332ac3a5c8ce8d68d6b