### PR TITLE
Add schedule calendar and availability models

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ your backend URL (defaults to `http://localhost:5000`).
 
 Like the React app, it communicates with the backend at `http://localhost:5000/api/talents` (see `app/page.js`).
 
+### Calendar Features
+
+The schedule page in the Next.js app uses **FullCalendar** to display confirmed events and register availability.
+
+1. Install dependencies if not already:
+   ```bash
+   cd talentify-next-frontend
+   npm install
+   ```
+2. Ensure `NEXT_PUBLIC_API_BASE` in `.env` points to your backend URL.
+3. Start the dev server and navigate to `/schedule` to view the calendar. Clicking on a date will open a dialog to register availability. Clicking an event shows details with a link to its dedicated page.
+
 The Next.js app also provides a performer search interface at `/performers` where you can filter and browse registered talents.
 
 ## License

--- a/Talentify-backend/models/Availability.js
+++ b/Talentify-backend/models/Availability.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+
+const AvailabilitySchema = new mongoose.Schema({
+  performerId: { type: mongoose.Schema.Types.ObjectId, ref: 'Talent', required: true },
+  date: { type: Date, required: true },
+  startTime: String,
+  endTime: String,
+  area: String,
+  createdAt: { type: Date, default: Date.now }
+});
+
+module.exports = mongoose.model('Availability', AvailabilitySchema);

--- a/Talentify-backend/models/Event.js
+++ b/Talentify-backend/models/Event.js
@@ -1,0 +1,15 @@
+const mongoose = require('mongoose');
+
+const EventSchema = new mongoose.Schema({
+  performerId: { type: mongoose.Schema.Types.ObjectId, ref: 'Talent', required: true },
+  title: { type: String, required: true },
+  storeName: String,
+  location: String,
+  start: { type: Date, required: true },
+  end: { type: Date, required: true },
+  status: { type: String, default: 'confirmed' },
+  notes: String,
+  createdAt: { type: Date, default: Date.now }
+});
+
+module.exports = mongoose.model('Event', EventSchema);

--- a/Talentify-backend/models/Talent.js
+++ b/Talentify-backend/models/Talent.js
@@ -51,6 +51,7 @@ const TalentSchema = new mongoose.Schema({
     type: String,
     default: ''
   },
+  availabilities: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Availability' }],
   // その他の追加したい項目があればここに追加
   createdAt: { // 作成日時
     type: Date,

--- a/Talentify-backend/server.js
+++ b/Talentify-backend/server.js
@@ -4,6 +4,8 @@ const mongoose = require('mongoose');
 const dotenv = require('dotenv');
 const cors = require('cors'); // CORSエラー回避のため
 const Talent = require('./models/Talent'); // Talentモデルをインポート
+const Event = require('./models/Event');
+const Availability = require('./models/Availability');
 
 dotenv.config(); // .envファイルから環境変数を読み込む
 
@@ -83,6 +85,71 @@ app.post('/api/talents', async (req, res) => {
     } catch (err) {
         // バリデーションエラーなど、クライアント側の問題の場合は400 Bad Request
         res.status(400).json({ message: err.message }); 
+    }
+});
+
+// イベント一覧取得
+app.get('/api/events', async (req, res) => {
+    try {
+        const events = await Event.find();
+        res.json(events);
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+// イベント作成
+app.post('/api/events', async (req, res) => {
+    try {
+        const event = new Event(req.body);
+        const saved = await event.save();
+        res.status(201).json(saved);
+    } catch (err) {
+        res.status(400).json({ message: err.message });
+    }
+});
+
+// イベント更新
+app.put('/api/events/:id', async (req, res) => {
+    try {
+        const updated = await Event.findByIdAndUpdate(req.params.id, req.body, { new: true });
+        if (!updated) return res.status(404).json({ message: 'Event not found' });
+        res.json(updated);
+    } catch (err) {
+        res.status(400).json({ message: err.message });
+    }
+});
+
+// 空き日程取得
+app.get('/api/availability', async (req, res) => {
+    try {
+        const items = await Availability.find();
+        res.json(items);
+    } catch (err) {
+        res.status(500).json({ message: err.message });
+    }
+});
+
+// 空き日程登録
+app.post('/api/availability', async (req, res) => {
+    try {
+        const item = new Availability(req.body);
+        const saved = await item.save();
+        await Talent.findByIdAndUpdate(saved.performerId, { $push: { availabilities: saved._id } });
+        res.status(201).json(saved);
+    } catch (err) {
+        res.status(400).json({ message: err.message });
+    }
+});
+
+// 空き日程更新
+app.put('/api/availability/:id', async (req, res) => {
+    try {
+        const updated = await Availability.findByIdAndUpdate(req.params.id, req.body, { new: true });
+        if (!updated) return res.status(404).json({ message: 'Availability not found' });
+        res.json(updated);
+    } catch (err) {
+        res.status(400).json({ message: err.message });
     }
 });
 

--- a/talentify-next-frontend/app/schedule/page.js
+++ b/talentify-next-frontend/app/schedule/page.js
@@ -1,3 +1,91 @@
+'use client'
+import { useEffect, useState } from 'react'
+import FullCalendar from '@fullcalendar/react'
+import dayGridPlugin from '@fullcalendar/daygrid'
+import timeGridPlugin from '@fullcalendar/timegrid'
+import listPlugin from '@fullcalendar/list'
+import interactionPlugin from '@fullcalendar/interaction'
+import AvailabilityModal from '../../components/AvailabilityModal'
+import EventDetailModal from '../../components/EventDetailModal'
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000'
+
 export default function SchedulePage() {
-  return <h1>スケジュール詳細</h1>;
+  const [events, setEvents] = useState([])
+  const [selectedDate, setSelectedDate] = useState(null)
+  const [selectedEvent, setSelectedEvent] = useState(null)
+
+  useEffect(() => {
+    const fetchEvents = async () => {
+      try {
+        const res = await fetch(`${API_BASE}/api/events`)
+        if (res.ok) {
+          const data = await res.json()
+          setEvents(data.map(e => ({
+            id: e._id,
+            title: `${e.storeName} ${e.title}`,
+            start: e.start,
+            end: e.end,
+            extendedProps: e
+          })))
+        }
+      } catch (e) {
+        console.error(e)
+      }
+    }
+    fetchEvents()
+  }, [])
+
+  const handleDateClick = info => {
+    setSelectedDate(info.date)
+  }
+
+  const handleEventClick = info => {
+    setSelectedEvent(info.event.extendedProps)
+  }
+
+  const saveAvailability = async data => {
+    try {
+      await fetch(`${API_BASE}/api/availability`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          performerId: data.performerId,
+          date: data.date,
+          startTime: data.startTime,
+          endTime: data.endTime,
+          area: data.area
+        })
+      })
+    } catch (e) {
+      console.error(e)
+    }
+    setSelectedDate(null)
+  }
+
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold mb-4">スケジュール</h1>
+      <FullCalendar
+        plugins={[dayGridPlugin, timeGridPlugin, listPlugin, interactionPlugin]}
+        initialView="dayGridMonth"
+        headerToolbar={{ start: 'today', center: 'title', end: 'dayGridMonth,timeGridWeek,listWeek' }}
+        events={events}
+        dateClick={handleDateClick}
+        eventClick={handleEventClick}
+        height="auto"
+      />
+      <AvailabilityModal
+        open={!!selectedDate}
+        date={selectedDate}
+        onClose={() => setSelectedDate(null)}
+        onSave={saveAvailability}
+      />
+      <EventDetailModal
+        open={!!selectedEvent}
+        event={selectedEvent}
+        onClose={() => setSelectedEvent(null)}
+      />
+    </main>
+  )
 }

--- a/talentify-next-frontend/components/AvailabilityModal.js
+++ b/talentify-next-frontend/components/AvailabilityModal.js
@@ -1,0 +1,46 @@
+'use client'
+import React, { useState } from 'react'
+import Modal from './Modal'
+
+export default function AvailabilityModal({ date, open, onClose, onSave }) {
+  const [startTime, setStartTime] = useState('')
+  const [endTime, setEndTime] = useState('')
+  const [area, setArea] = useState('')
+
+  const handleSubmit = e => {
+    e.preventDefault()
+    onSave({ date, startTime, endTime, area })
+  }
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <h2 className="text-lg font-semibold mb-4">{date?.toLocaleDateString()} の空き登録</h2>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <input
+          type="time"
+          value={startTime}
+          onChange={e => setStartTime(e.target.value)}
+          className="border p-1 rounded w-full"
+          required
+        />
+        <input
+          type="time"
+          value={endTime}
+          onChange={e => setEndTime(e.target.value)}
+          className="border p-1 rounded w-full"
+          required
+        />
+        <input
+          type="text"
+          value={area}
+          onChange={e => setArea(e.target.value)}
+          placeholder="エリア(任意)"
+          className="border p-1 rounded w-full"
+        />
+        <button type="submit" className="bg-blue-600 text-white px-3 py-1 rounded w-full">
+          登録
+        </button>
+      </form>
+    </Modal>
+  )
+}

--- a/talentify-next-frontend/components/EventDetailModal.js
+++ b/talentify-next-frontend/components/EventDetailModal.js
@@ -1,0 +1,21 @@
+'use client'
+import React from 'react'
+import Modal from './Modal'
+import Link from 'next/link'
+
+export default function EventDetailModal({ event, open, onClose }) {
+  if (!event) return null
+  return (
+    <Modal open={open} onClose={onClose}>
+      <h2 className="text-lg font-semibold mb-2">{event.title}</h2>
+      <p className="text-sm mb-1">店舗: {event.storeName}</p>
+      <p className="text-sm mb-1">場所: {event.location}</p>
+      <p className="text-sm mb-1">開始: {new Date(event.start).toLocaleString()}</p>
+      <p className="text-sm mb-3">終了: {new Date(event.end).toLocaleString()}</p>
+      <p className="text-sm mb-3">ステータス: {event.status}</p>
+      <Link href={`/events/${event._id}`} className="text-blue-600 underline">
+        詳細ページへ
+      </Link>
+    </Modal>
+  )
+}

--- a/talentify-next-frontend/components/Modal.js
+++ b/talentify-next-frontend/components/Modal.js
@@ -1,0 +1,19 @@
+'use client'
+import React from 'react'
+
+export default function Modal({ open, onClose, children }) {
+  if (!open) return null
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded shadow-lg p-4 max-w-md w-full relative">
+        <button
+          className="absolute top-2 right-2 text-gray-500"
+          onClick={onClose}
+        >
+          ×
+        </button>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/talentify-next-frontend/package-lock.json
+++ b/talentify-next-frontend/package-lock.json
@@ -8,6 +8,11 @@
       "name": "talentify-next-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@fullcalendar/daygrid": "^6.1.17",
+        "@fullcalendar/interaction": "^6.1.17",
+        "@fullcalendar/list": "^6.1.17",
+        "@fullcalendar/react": "^6.1.17",
+        "@fullcalendar/timegrid": "^6.1.17",
         "@heroicons/react": "^2.2.0",
         "next": "15.3.4",
         "react": "^19.0.0",
@@ -233,6 +238,66 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fullcalendar/core": {
+      "version": "6.1.17",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-6.1.17.tgz",
+      "integrity": "sha512-0W7lnIrv18ruJ5zeWBeNZXO8qCWlzxDdp9COFEsZnyNjiEhUVnrW/dPbjRKYpL0edGG0/Lhs0ghp1z/5ekt8ZA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "preact": "~10.12.1"
+      }
+    },
+    "node_modules/@fullcalendar/daygrid": {
+      "version": "6.1.17",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-6.1.17.tgz",
+      "integrity": "sha512-K7m+pd7oVJ9fW4h7CLDdDGJbc9szJ1xDU1DZ2ag+7oOo1aCNLv44CehzkkknM6r8EYlOOhgaelxQpKAI4glj7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.17"
+      }
+    },
+    "node_modules/@fullcalendar/interaction": {
+      "version": "6.1.17",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-6.1.17.tgz",
+      "integrity": "sha512-AudvQvgmJP2FU89wpSulUUjeWv24SuyCx8FzH2WIPVaYg+vDGGYarI7K6PcM3TH7B/CyaBjm5Rqw9lXgnwt5YA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.17"
+      }
+    },
+    "node_modules/@fullcalendar/list": {
+      "version": "6.1.17",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/list/-/list-6.1.17.tgz",
+      "integrity": "sha512-fkyK49F9IxwlGUBVhJGsFpd/LTi/vRVERLIAe1HmBaGkjwpxnynm8TMLb9mZip97wvDk3CmZWduMe6PxscAlow==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.17"
+      }
+    },
+    "node_modules/@fullcalendar/react": {
+      "version": "6.1.17",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/react/-/react-6.1.17.tgz",
+      "integrity": "sha512-AA8soHhlfRH5dUeqHnfAtzDiXa2vrgWocJSK/F5qzw/pOxc9MqpuoS/nQBROWtHHg6yQUg3DoGqOOhi7dmylXQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.17",
+        "react": "^16.7.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.7.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/@fullcalendar/timegrid": {
+      "version": "6.1.17",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/timegrid/-/timegrid-6.1.17.tgz",
+      "integrity": "sha512-K4PlA3L3lclLOs3IX8cvddeiJI9ZVMD7RA9IqaWwbvac771971foc9tFze9YY+Pqesf6S+vhS2dWtEVlERaGlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fullcalendar/daygrid": "~6.1.17"
+      },
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.17"
       }
     },
     "node_modules/@heroicons/react": {
@@ -5005,6 +5070,17 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.12.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.12.1.tgz",
+      "integrity": "sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/prelude-ls": {

--- a/talentify-next-frontend/package.json
+++ b/talentify-next-frontend/package.json
@@ -9,6 +9,11 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@fullcalendar/daygrid": "^6.1.17",
+    "@fullcalendar/interaction": "^6.1.17",
+    "@fullcalendar/list": "^6.1.17",
+    "@fullcalendar/react": "^6.1.17",
+    "@fullcalendar/timegrid": "^6.1.17",
     "@heroicons/react": "^2.2.0",
     "next": "15.3.4",
     "react": "^19.0.0",


### PR DESCRIPTION
## Summary
- track performer availability and events in the backend
- expose CRUD APIs for `/api/events` and `/api/availability`
- render FullCalendar on the schedule page with modals for details and availability registration
- add simple reusable modal components
- document calendar setup in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685adb6b3f448332b85dd6b45c7eb9a5