### PR TITLE
Secure user signup

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Each project has its own `package.json` and dependencies. They can be developed 
 - `POST /api/talents` - Add a new talent.
 - `GET /api/talents/:id` - Retrieve a talent by its MongoDB `_id` (returns `404` if not found).
 
+Passwords sent to `/api/register` are hashed automatically before being stored.
+
 ## React Frontend
 
 The `talentify-frontend` directory contains a Create React App project.

--- a/Talentify-backend/models/User.js
+++ b/Talentify-backend/models/User.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const bcrypt = require('bcryptjs');
 
 const UserSchema = new mongoose.Schema({
   email: {
@@ -21,6 +22,20 @@ const UserSchema = new mongoose.Schema({
     type: Date,
     default: Date.now,
   },
+});
+
+// Hash password whenever passwordHash is modified
+UserSchema.pre('save', async function (next) {
+  if (!this.isModified('passwordHash')) {
+    return next();
+  }
+  try {
+    const hashed = await bcrypt.hash(this.passwordHash, 10);
+    this.passwordHash = hashed;
+    next();
+  } catch (err) {
+    next(err);
+  }
 });
 
 module.exports = mongoose.model('User', UserSchema);

--- a/Talentify-backend/server.js
+++ b/Talentify-backend/server.js
@@ -54,8 +54,7 @@ app.post('/api/register', async (req, res) => {
         if (existing) {
             return res.status(409).json({ message: '既に登録されています' });
         }
-        const passwordHash = await bcrypt.hash(password, 10);
-        await User.create({ email, passwordHash, role });
+        await User.create({ email, passwordHash: password, role });
         res.status(201).json({ message: 'ユーザーを作成しました' });
     } catch (err) {
         res.status(500).json({ message: err.message });


### PR DESCRIPTION
## Summary
- hash passwords in a mongoose pre-save hook
- rely on the hook in `/api/register`
- mention automatic hashing in the README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685d4a2483088332b1bbeb3b7deb4eee