### PR TITLE
Add env var validation on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ Each project has its own `package.json` and dependencies. They can be developed 
 2. Copy `.env.example` to `.env` inside `Talentify-backend` and edit the values:
    ```bash
    cp .env.example .env
-   # then update the following variables
+   # then update the following **required** variables
    MONGODB_URI=<your Mongo connection string>
-   PORT=5000 # optional, defaults to 5000
+   JWT_SECRET=<secret used for JWT signing>
+   PORT=5000
    ```
+   The server will exit on startup if any of these variables are missing.
 
 3. Start the API server:
    ```bash

--- a/Talentify-backend/.env.example
+++ b/Talentify-backend/.env.example
@@ -1,3 +1,4 @@
+# Required environment variables for the API server
 MONGODB_URI=mongodb://localhost:27017/yourdb
-PORT=5000
 JWT_SECRET=your_jwt_secret
+PORT=5000

--- a/Talentify-backend/server.js
+++ b/Talentify-backend/server.js
@@ -10,8 +10,16 @@ const User = require('./models/User');
 
 dotenv.config(); // .envファイルから環境変数を読み込む
 
+// 必須環境変数をチェック
+const requiredEnv = ['MONGODB_URI', 'JWT_SECRET', 'PORT'];
+const missing = requiredEnv.filter((name) => !process.env[name]);
+if (missing.length) {
+    console.error(`Missing required environment variables: ${missing.join(', ')}`);
+    process.exit(1);
+}
+
 const app = express();
-const port = process.env.PORT || 5000;
+const port = process.env.PORT;
 
 // ミドルウェア
 app.use(cors()); // CORSを許可


### PR DESCRIPTION
## Summary
- ensure backend checks for required environment variables
- document required variables in README and .env.example

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint` in Next.js frontend *(fails: next not found)*
- `npm test` in CRA frontend *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d4a282254833287c8ebee8c68d36d