### PR TITLE
Protect csrf token endpoint

### DIFF
--- a/Talentify-backend/server.js
+++ b/Talentify-backend/server.js
@@ -76,7 +76,7 @@ app.get('/', (req, res) => {
   res.send('Talentify API 稼働中！');
 });
 
-app.get('/api/csrf-token', (req, res) => {
+app.get('/api/csrf-token', csrfProtection, (req, res) => {
   res.json({ csrfToken: req.csrfToken() });
 });
 


### PR DESCRIPTION
## Summary
- secure `/api/csrf-token` by adding the `csrfProtection` middleware

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685d5f5ddb548332949cd869e3e2db09