### PR TITLE
Add credentials to fetch calls

### DIFF
--- a/talentify-frontend/src/App.js
+++ b/talentify-frontend/src/App.js
@@ -19,7 +19,9 @@ function App() {
   // バックエンドから人材情報を取得する関数
   const fetchTalents = async () => {
     try {
-      const response = await fetch(`${API_BASE}/api/talents`); // GETリクエスト
+      const response = await fetch(`${API_BASE}/api/talents`, {
+        credentials: 'include', // ensure cookies are sent with request
+      }); // GETリクエスト
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
@@ -40,6 +42,7 @@ function App() {
     try {
       const response = await fetch(`${API_BASE}/api/talents`, {
         method: 'POST', // POSTリクエスト
+        credentials: 'include', // ensure cookies are sent with request
         headers: {
           'Content-Type': 'application/json', // JSON形式で送信
         },

--- a/talentify-next-frontend/app/performers/[id]/page.js
+++ b/talentify-next-frontend/app/performers/[id]/page.js
@@ -12,7 +12,9 @@ export default function PerformerDetailPage({ params }) {
   useEffect(() => {
     const fetchTalent = async () => {
       try {
-        const res = await fetch(`${API_BASE}/api/talents/${id}`)
+        const res = await fetch(`${API_BASE}/api/talents/${id}`, {
+          credentials: 'include', // include cookies for authenticated APIs
+        })
         if (!res.ok) throw new Error('Failed to fetch')
         const data = await res.json()
         setTalent(data)

--- a/talentify-next-frontend/app/performers/page.js
+++ b/talentify-next-frontend/app/performers/page.js
@@ -11,7 +11,9 @@ export default function PerformersPage() {
   useEffect(() => {
     const fetchTalents = async () => {
       try {
-        const res = await fetch(`${API_BASE}/api/talents`)
+        const res = await fetch(`${API_BASE}/api/talents`, {
+          credentials: 'include', // include cookies for authenticated APIs
+        })
         if (!res.ok) throw new Error('Failed to fetch')
         const data = await res.json()
         setTalents(data)


### PR DESCRIPTION
## Summary
- ensure fetch in CRA uses credentials to include cookies
- include credentials in nextjs performer pages

## Testing
- `npm install` in `talentify-frontend`
- `CI=true npm test --silent`
- manual check of cookie-based auth via curl on local server

------
https://chatgpt.com/codex/tasks/task_e_685d5f6086a4833293bbde19830959f4