### PR TITLE
Add profile and schedule models and pages

### DIFF
--- a/Talentify-backend/models/Profile.js
+++ b/Talentify-backend/models/Profile.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+
+const ProfileSchema = new mongoose.Schema({
+  user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true, unique: true },
+  displayName: { type: String, required: true },
+  bio: { type: String, default: '' },
+  avatarUrl: { type: String, default: '' }
+}, { timestamps: true });
+
+module.exports = mongoose.model('Profile', ProfileSchema);

--- a/Talentify-backend/models/Schedule.js
+++ b/Talentify-backend/models/Schedule.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose');
+
+const ScheduleSchema = new mongoose.Schema({
+  user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  date: { type: Date, required: true },
+  description: { type: String, default: '' }
+}, { timestamps: true });
+
+module.exports = mongoose.model('Schedule', ScheduleSchema);

--- a/Talentify-backend/server.js
+++ b/Talentify-backend/server.js
@@ -11,6 +11,8 @@ const rateLimit      = require('express-rate-limit');
 
 const Talent         = require('./models/Talent');
 const User           = require('./models/User');
+const Profile        = require('./models/Profile');
+const Schedule       = require('./models/Schedule');
 const auth           = require('./auth');                 // ⬅︎ 役割チェック付き JWT 認可
 
 // -------------------------------------------------------------
@@ -209,6 +211,61 @@ app.post('/api/talents', auth(['store']), async (req, res) => {
   try {
     const newTalent = await talent.save();
     res.status(201).json(newTalent);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+// -------------------------------------------------------------
+//  Profile API
+// -------------------------------------------------------------
+app.get('/api/profile', auth(), async (req, res) => {
+  try {
+    const profile = await Profile.findOne({ user: req.user.id });
+    res.json(profile);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+app.post('/api/profile', auth(), async (req, res) => {
+  try {
+    const data = {
+      displayName: req.body.displayName,
+      bio: req.body.bio,
+      avatarUrl: req.body.avatarUrl,
+    };
+    const profile = await Profile.findOneAndUpdate(
+      { user: req.user.id },
+      data,
+      { new: true, upsert: true, setDefaultsOnInsert: true }
+    );
+    res.json(profile);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+// -------------------------------------------------------------
+//  Schedule API
+// -------------------------------------------------------------
+app.get('/api/schedule', auth(), async (req, res) => {
+  try {
+    const schedules = await Schedule.find({ user: req.user.id });
+    res.json(schedules);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+app.post('/api/schedule', auth(), async (req, res) => {
+  try {
+    const schedule = await Schedule.create({
+      user: req.user.id,
+      date: req.body.date,
+      description: req.body.description,
+    });
+    res.status(201).json(schedule);
   } catch (err) {
     res.status(400).json({ message: err.message });
   }

--- a/talentify-next-frontend/app/profile/edit/page.js
+++ b/talentify-next-frontend/app/profile/edit/page.js
@@ -1,3 +1,77 @@
+'use client'
+import { useState, useEffect } from 'react'
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000'
+
 export default function ProfileEditPage() {
-  return <h1>プロフィール編集</h1>;
+  const [displayName, setDisplayName] = useState('')
+  const [bio, setBio] = useState('')
+  const [message, setMessage] = useState('')
+
+  useEffect(() => {
+    const fetchProfile = async () => {
+      try {
+        const res = await fetch(`${API_BASE}/api/profile`, {
+          credentials: 'include',
+        })
+        if (!res.ok) throw new Error('failed')
+        const data = await res.json()
+        if (data) {
+          setDisplayName(data.displayName || '')
+          setBio(data.bio || '')
+        }
+      } catch (e) {
+        console.error(e)
+      }
+    }
+    fetchProfile()
+  }, [])
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setMessage('')
+    try {
+      const res = await fetch(`${API_BASE}/api/profile`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ displayName, bio }),
+      })
+      if (!res.ok) throw new Error('failed')
+      setMessage('保存しました')
+    } catch (err) {
+      console.error(err)
+      setMessage('更新に失敗しました')
+    }
+  }
+
+  return (
+    <main className="max-w-md mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">プロフィール編集</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block mb-1">表示名</label>
+          <input
+            type="text"
+            className="w-full p-2 border rounded"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label className="block mb-1">自己紹介</label>
+          <textarea
+            className="w-full p-2 border rounded"
+            value={bio}
+            onChange={(e) => setBio(e.target.value)}
+          />
+        </div>
+        {message && <p>{message}</p>}
+        <button type="submit" className="py-2 px-4 bg-blue-600 text-white rounded">
+          保存
+        </button>
+      </form>
+    </main>
+  )
 }

--- a/talentify-next-frontend/app/schedule/page.js
+++ b/talentify-next-frontend/app/schedule/page.js
@@ -1,3 +1,78 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000'
+
 export default function SchedulePage() {
-  return <h1>スケジュール詳細</h1>;
+  const [items, setItems] = useState([])
+  const [date, setDate] = useState('')
+  const [description, setDescription] = useState('')
+
+  useEffect(() => {
+    const fetchSchedule = async () => {
+      try {
+        const res = await fetch(`${API_BASE}/api/schedule`, {
+          credentials: 'include',
+        })
+        if (!res.ok) throw new Error('failed')
+        const data = await res.json()
+        setItems(data)
+      } catch (e) {
+        console.error(e)
+      }
+    }
+    fetchSchedule()
+  }, [])
+
+  const addItem = async (e) => {
+    e.preventDefault()
+    try {
+      const res = await fetch(`${API_BASE}/api/schedule`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ date, description }),
+      })
+      if (!res.ok) throw new Error('failed')
+      const newItem = await res.json()
+      setItems([...items, newItem])
+      setDate('')
+      setDescription('')
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  return (
+    <main className="max-w-md mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">スケジュール</h1>
+      <form onSubmit={addItem} className="space-y-2 mb-4">
+        <input
+          type="date"
+          className="w-full p-2 border rounded"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+          required
+        />
+        <input
+          type="text"
+          className="w-full p-2 border rounded"
+          placeholder="内容"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+        <button type="submit" className="py-2 px-4 bg-blue-600 text-white rounded">
+          追加
+        </button>
+      </form>
+      <ul className="space-y-2">
+        {items.map((it) => (
+          <li key={it._id}>
+            {new Date(it.date).toLocaleDateString()} - {it.description}
+          </li>
+        ))}
+        {items.length === 0 && <li>予定はありません</li>}
+      </ul>
+    </main>
+  )
 }


### PR DESCRIPTION
## Summary
- add `Profile` and `Schedule` mongoose models
- expose `/api/profile` and `/api/schedule` endpoints in the backend
- integrate profile editing and schedule management in Next.js pages

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685d6a52190c833284bd002a2667c112