### PR TITLE
Implement CSRF token fetch in frontends

### DIFF
--- a/talentify-frontend/src/App.js
+++ b/talentify-frontend/src/App.js
@@ -10,6 +10,7 @@ function App() {
   const [email, setEmail] = useState(''); // フォーム入力用state: メールアドレス
   const [skills, setSkills] = useState(''); // フォーム入力用state: スキル (カンマ区切り)
   const [experienceYears, setExperienceYears] = useState(0); // フォーム入力用state: 経験年数
+  const [csrfToken, setCsrfToken] = useState('');
 
   // ページ読み込み時に人材情報を取得
   useEffect(() => {
@@ -32,6 +33,18 @@ function App() {
     }
   };
 
+  const fetchCsrfToken = async () => {
+    const res = await fetch(`${API_BASE}/api/csrf-token`, {
+      credentials: 'include',
+    });
+    if (!res.ok) {
+      throw new Error(`HTTP error! status: ${res.status}`);
+    }
+    const data = await res.json();
+    setCsrfToken(data.csrfToken);
+    return data.csrfToken;
+  };
+
   // 新しい人材を追加する関数
   const addTalent = async (e) => {
     e.preventDefault(); // フォームのデフォルト送信を防ぐ
@@ -40,11 +53,14 @@ function App() {
     const skillsArray = skills.split(',').map(skill => skill.trim()).filter(skill => skill !== '');
 
     try {
+      const token = await fetchCsrfToken();
+
       const response = await fetch(`${API_BASE}/api/talents`, {
         method: 'POST', // POSTリクエスト
         credentials: 'include', // ensure cookies are sent with request
         headers: {
           'Content-Type': 'application/json', // JSON形式で送信
+          'X-CSRF-Token': token,
         },
         body: JSON.stringify({ name, email, skills: skillsArray, experienceYears: Number(experienceYears) }), // JSON文字列に変換して送信
       });

--- a/talentify-frontend/src/App.test.js
+++ b/talentify-frontend/src/App.test.js
@@ -1,8 +1,43 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import App from './App';
 
 test('renders app heading', () => {
   render(<App />);
   const heading = screen.getByText(/Talentify - 人材管理/i);
   expect(heading).toBeInTheDocument();
+});
+
+test('fetches CSRF token before posting new talent', async () => {
+  const user = userEvent;
+
+  global.fetch = jest
+    .fn()
+    // initial fetchTalents on mount
+    .mockResolvedValueOnce({ ok: true, json: async () => [] })
+    // csrf token fetch
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ csrfToken: 'test' }) })
+    // post talent
+    .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+    // fetchTalents after adding
+    .mockResolvedValueOnce({ ok: true, json: async () => [] });
+
+  render(<App />);
+
+  await user.type(screen.getAllByRole('textbox')[0], 'John');
+  await user.type(screen.getAllByRole('textbox')[1], 'john@example.com');
+  await user.type(screen.getAllByRole('textbox')[2], 'skill');
+  await user.type(screen.getByRole('spinbutton'), '1');
+
+  await user.click(screen.getByRole('button', { name: '人材を追加' }));
+
+  await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(4));
+
+  const csrfCall = global.fetch.mock.calls.find(([url]) => url.includes('/api/csrf-token'));
+  const postCall = global.fetch.mock.calls.find(
+    ([url, options]) => url.includes('/api/talents') && options.method === 'POST'
+  );
+
+  expect(csrfCall).toBeTruthy();
+  expect(postCall[1].headers['X-CSRF-Token']).toBe('test');
 });

--- a/talentify-next-frontend/app/login/page.js
+++ b/talentify-next-frontend/app/login/page.js
@@ -8,14 +8,27 @@ export default function LoginPage() {
   const [password, setPassword] = useState('')
   const [showPassword, setShowPassword] = useState(false)
   const [error, setError] = useState(null)
+  const [csrfToken, setCsrfToken] = useState('')
 
   const handleSubmit = async (e) => {
     e.preventDefault()
     setError(null)
     try {
+      // CSRF トークンを取得
+      const tokenRes = await fetch(
+        `${process.env.NEXT_PUBLIC_API_BASE}/api/csrf-token`,
+        { credentials: 'include' }
+      )
+      if (!tokenRes.ok) throw new Error('failed to get csrf token')
+      const tokenData = await tokenRes.json()
+      setCsrfToken(tokenData.csrfToken)
+
       const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/api/login`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': tokenData.csrfToken,
+        },
         credentials: 'include',
         body: JSON.stringify({ email, password }),
       })


### PR DESCRIPTION
## Summary
- fetch `/api/csrf-token` before posting login credentials
- fetch `/api/csrf-token` before creating a new talent
- test that talent creation includes the CSRF token header

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685d6a4f41c48332995a5e0586d00e8d