### PR TITLE
Implement logout endpoint and UI buttons

### DIFF
--- a/talentify-frontend/src/App.js
+++ b/talentify-frontend/src/App.js
@@ -12,6 +12,23 @@ function App() {
   const [experienceYears, setExperienceYears] = useState(0); // フォーム入力用state: 経験年数
   const [csrfToken, setCsrfToken] = useState('');
 
+  const logout = async () => {
+    try {
+      const tokenRes = await fetch(`${API_BASE}/api/csrf-token`, { credentials: 'include' });
+      if (!tokenRes.ok) throw new Error('failed');
+      const { csrfToken } = await tokenRes.json();
+      const res = await fetch(`${API_BASE}/api/logout`, {
+        method: 'POST',
+        headers: { 'X-CSRF-Token': csrfToken },
+        credentials: 'include',
+      });
+      if (!res.ok) throw new Error('logout failed');
+      alert('ログアウトしました');
+    } catch (err) {
+      console.error('ログアウトに失敗しました', err);
+    }
+  };
+
   // ページ読み込み時に人材情報を取得
   useEffect(() => {
     fetchTalents();
@@ -86,6 +103,7 @@ function App() {
   return (
     <div className="App">
       <h1>Talentify - 人材管理</h1>
+      <button onClick={logout}>ログアウト</button>
 
       {/* 人材追加フォーム */}
       <form onSubmit={addTalent}>

--- a/talentify-next-frontend/components/Header.js
+++ b/talentify-next-frontend/components/Header.js
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import LogoutButton from './LogoutButton';
 
 export default function Header() {
   return (
@@ -14,6 +15,7 @@ export default function Header() {
         <Link href="/contact" className="hover:underline">お問い合わせ</Link>
         <Link href="/manage" className="hover:underline">管理ページ</Link>
         <Link href="/login" className="font-semibold hover:underline">ログイン</Link>
+        <LogoutButton />
         <Link
           href="/register"
           className="ml-2 px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700"

--- a/talentify-next-frontend/components/LogoutButton.js
+++ b/talentify-next-frontend/components/LogoutButton.js
@@ -1,0 +1,37 @@
+'use client'
+import { useState } from 'react'
+
+export default function LogoutButton() {
+  const [error, setError] = useState(null)
+
+  const handleLogout = async () => {
+    setError(null)
+    try {
+      const tokenRes = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/api/csrf-token`, {
+        credentials: 'include'
+      })
+      if (!tokenRes.ok) throw new Error('token')
+      const { csrfToken } = await tokenRes.json()
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/api/logout`, {
+        method: 'POST',
+        headers: {
+          'X-CSRF-Token': csrfToken
+        },
+        credentials: 'include'
+      })
+      if (!res.ok) throw new Error('logout failed')
+      console.log('logout success')
+    } catch (e) {
+      setError('ログアウトに失敗しました')
+    }
+  }
+
+  return (
+    <div className="inline-block">
+      <button onClick={handleLogout} className="font-semibold hover:underline">
+        ログアウト
+      </button>
+      {error && <span className="ml-2 text-red-600 text-sm">{error}</span>}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- support logout on the backend with `/api/logout`
- centralize cookie options for reuse
- add logout button to CRA frontend
- add logout component to Next.js frontend and include in header

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test --silent` in CRA frontend *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d7f363f908332917019d94d61c094