### PR TITLE
Fix CSRF header name

### DIFF
--- a/talentify-next-frontend/components/RegisterForm.js
+++ b/talentify-next-frontend/components/RegisterForm.js
@@ -120,7 +120,7 @@ export default function RegisterForm() {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'CSRF-Token': csrfToken,
+          'X-CSRF-Token': csrfToken,
         },
         credentials: 'include',
         body: JSON.stringify({ email, password, role }),


### PR DESCRIPTION
## Summary
- rename the CSRF header sent during registration to `X-CSRF-Token`

## Testing
- `npm run lint` in `talentify-next-frontend`
- `npm test -- -w` in `talentify-frontend`

------
https://chatgpt.com/codex/tasks/task_e_685d7f342c3c8332b67e2a73bcdf7d4d