### PR TITLE
Add CSRF token usage

### DIFF
--- a/talentify-next-frontend/app/profile/edit/page.js
+++ b/talentify-next-frontend/app/profile/edit/page.js
@@ -31,9 +31,19 @@ export default function ProfileEditPage() {
     e.preventDefault()
     setMessage('')
     try {
+      // CSRF トークンを取得
+      const tokenRes = await fetch(`${API_BASE}/api/csrf-token`, {
+        credentials: 'include',
+      })
+      if (!tokenRes.ok) throw new Error('failed to get csrf token')
+      const { csrfToken } = await tokenRes.json()
+
       const res = await fetch(`${API_BASE}/api/profile`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': csrfToken,
+        },
         credentials: 'include',
         body: JSON.stringify({ displayName, bio }),
       })

--- a/talentify-next-frontend/app/schedule/page.js
+++ b/talentify-next-frontend/app/schedule/page.js
@@ -27,9 +27,19 @@ export default function SchedulePage() {
   const addItem = async (e) => {
     e.preventDefault()
     try {
+      // CSRF トークンを取得
+      const tokenRes = await fetch(`${API_BASE}/api/csrf-token`, {
+        credentials: 'include',
+      })
+      if (!tokenRes.ok) throw new Error('failed to get csrf token')
+      const { csrfToken } = await tokenRes.json()
+
       const res = await fetch(`${API_BASE}/api/schedule`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': csrfToken,
+        },
         credentials: 'include',
         body: JSON.stringify({ date, description }),
       })


### PR DESCRIPTION
## Summary
- fetch `/api/csrf-token` in profile edit and schedule pages
- send the token as `X-CSRF-Token` when posting updates

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d7f3585688332aedec22ce436073d