### PR TITLE
Implement logout route and integrate in frontend

### DIFF
--- a/Talentify-backend/server.js
+++ b/Talentify-backend/server.js
@@ -170,6 +170,17 @@ app.post('/api/refresh', (req, res) => {
   }
 });
 
+app.post('/api/logout', (req, res) => {
+  const cookieOpts = {
+    httpOnly : true,
+    secure   : process.env.NODE_ENV === 'production',
+    sameSite : 'strict'
+  };
+  res.clearCookie('access', cookieOpts);
+  res.clearCookie('refresh', cookieOpts);
+  res.json({ message: 'logged out' });
+});
+
 // -------------------------------------------------------------
 //  Talent API（要 JWT 認可）
 // -------------------------------------------------------------

--- a/talentify-next-frontend/app/logout/page.js
+++ b/talentify-next-frontend/app/logout/page.js
@@ -1,0 +1,23 @@
+'use client'
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+
+export default function LogoutPage() {
+  const router = useRouter()
+
+  useEffect(() => {
+    async function logout() {
+      try {
+        await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/api/logout`, {
+          method: 'POST',
+          credentials: 'include',
+        })
+      } finally {
+        router.push('/login')
+      }
+    }
+    logout()
+  }, [router])
+
+  return <p className="p-4">ログアウト中...</p>
+}

--- a/talentify-next-frontend/components/Header.js
+++ b/talentify-next-frontend/components/Header.js
@@ -20,6 +20,7 @@ export default function Header() {
         >
           新規登録
         </Link>
+        <Link href="/logout" className="hover:underline">ログアウト</Link>
       </nav>
     </header>
   );


### PR DESCRIPTION
## Summary
- add `/api/logout` route on backend to clear auth cookies
- link logout in Next.js header and redirect via new `/logout` page

## Testing
- `npm test` in `Talentify-backend` *(fails: Error: no test specified)*
- `CI=true npm test -- --watchAll=false` in `talentify-frontend` *(fails: react-scripts not found)*
- `npm run lint` in `talentify-next-frontend` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d8a05328483328e465a0b11a43e87