### PR TITLE
Update example API base URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ npm install
 npm start
 ```
 
-Copy `.env.example` to `.env` first and ensure `REACT_APP_API_BASE` points to your
-backend URL (defaults to `http://localhost:5000`).
+Copy `.env.example` to `.env` first and set `REACT_APP_API_BASE` to your backend
+URL. For online deployments you can use
+`https://talentify-production.up.railway.app` (defaults to
+`http://localhost:5000`).
 
 This frontend expects the backend API at `http://localhost:5000/api/talents` as referenced in `src/App.js`.
 
@@ -71,7 +73,9 @@ npm run dev
 ```
 
 Before starting, copy `.env.example` to `.env` and set `NEXT_PUBLIC_API_BASE` to
-your backend URL (defaults to `http://localhost:5000`).
+your backend URL. When deploying online you can use
+`https://talentify-production.up.railway.app` (defaults to
+`http://localhost:5000`).
 
 Like the React app, it communicates with the backend at `http://localhost:5000/api/talents` (see `app/page.js`).
 

--- a/talentify-frontend/.env.example
+++ b/talentify-frontend/.env.example
@@ -1,1 +1,1 @@
-REACT_APP_API_BASE=http://localhost:5000
+REACT_APP_API_BASE=https://talentify-production.up.railway.app

--- a/talentify-next-frontend/.env.example
+++ b/talentify-next-frontend/.env.example
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_API_BASE=http://localhost:5000
+NEXT_PUBLIC_API_BASE=https://talentify-production.up.railway.app


### PR DESCRIPTION
## Summary
- update `.env.example` files to show the production URL
- document the production API base URL in the README

## Testing
- `npm test` in `Talentify-backend`
- `npm test -- --watchAll=false` in `talentify-frontend`


------
https://chatgpt.com/codex/tasks/task_e_685dfeb827708332885d88decd2be204