### PR TITLE
Add backend test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ Like the React app, it communicates with the backend at `http://localhost:5000/a
 
 The Next.js app also provides a performer search interface at `/performers` where you can filter and browse registered talents.
 
+## Running Backend Tests
+
+The Jest test suite lives in `Talentify-backend/tests`. Make sure the backend
+dependencies are installed before running `npm test`:
+
+```bash
+cd Talentify-backend
+npm install
+npm test
+```
+
+Without installing dependencies first, the `jest` command will not be available.
+
 ### Password Reset Flow
 
 1. Visit `/password-reset` in the Next.js app and submit your email address.


### PR DESCRIPTION
## Summary
- update README to mention running `npm install` before `npm test`

## Testing
- `npm install` in `Talentify-backend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dfec7054c8332a019b23aaaba837c