### PR TITLE
Remove JWT secret fallback

### DIFF
--- a/Talentify-backend/auth.js
+++ b/Talentify-backend/auth.js
@@ -11,7 +11,7 @@ module.exports = function auth(allowedRoles = []) {
       if (!token) {
         return res.status(401).json({ message: '認証トークンがありません' });
       }
-      const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret');
+      const payload = jwt.verify(token, process.env.JWT_SECRET);
       req.user = { id: payload.userId, role: payload.role };
       if (allowedRoles.length && !allowedRoles.includes(payload.role)) {
         return res.status(403).json({ message: '権限がありません' });


### PR DESCRIPTION
## Summary
- ensure JWT verification uses only `process.env.JWT_SECRET`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e179ed5a48332b1ea08a755bfbee4