### PR TITLE
Add env var fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Each project has its own `package.json` and dependencies. They can be developed 
    PORT=5000
    ```
    The server will exit on startup if any of these variables are missing.
+   If you're migrating from an older setup, the legacy names `MONGO_URI` and
+   `SESSION_SECRET` are also accepted and automatically mapped to
+   `MONGODB_URI` and `JWT_SECRET`.
 
 3. Start the API server:
    ```bash

--- a/Talentify-backend/app.js
+++ b/Talentify-backend/app.js
@@ -16,10 +16,26 @@ const auth = require('./auth');
 
 dotenv.config();
 
-const requiredEnv = ['MONGODB_URI', 'JWT_SECRET', 'PORT'];
-const missing = requiredEnv.filter(v => !process.env[v]);
+// Support legacy environment variable names
+if (!process.env.MONGODB_URI && process.env.MONGO_URI) {
+  process.env.MONGODB_URI = process.env.MONGO_URI;
+}
+if (!process.env.JWT_SECRET && process.env.SESSION_SECRET) {
+  process.env.JWT_SECRET = process.env.SESSION_SECRET;
+}
+const requiredEnv = [
+  ['MONGODB_URI', 'MONGO_URI'],
+  ['JWT_SECRET', 'SESSION_SECRET'],
+  'PORT'
+];
+const missing = requiredEnv.filter(v =>
+  Array.isArray(v) ? v.every(n => !process.env[n]) : !process.env[v]
+);
 if (missing.length) {
-  console.error(`Missing required environment variables: ${missing.join(', ')}`);
+  const names = missing
+    .map(v => (Array.isArray(v) ? v.join(' or ') : v))
+    .join(', ');
+  console.error(`Missing required environment variables: ${names}`);
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
- support `MONGO_URI` and `SESSION_SECRET` as legacy env vars
- document the legacy env var behavior in the README

## Testing
- `npm --prefix Talentify-backend test`

------
https://chatgpt.com/codex/tasks/task_e_685e1f1d4f908332a89e3be37369d953