### PR TITLE
Add default API base url for Next frontend

### DIFF
--- a/talentify-next-frontend/app/login/page.js
+++ b/talentify-next-frontend/app/login/page.js
@@ -3,6 +3,8 @@
 import { useState } from 'react'
 import Link from 'next/link'
 
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000'
+
 export default function LoginPage() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
@@ -15,13 +17,13 @@ export default function LoginPage() {
     try {
       // CSRF トークンを取得
       const tokenRes = await fetch(
-        `${process.env.NEXT_PUBLIC_API_BASE}/api/csrf-token`,
+        `${API_BASE}/api/csrf-token`,
         { credentials: 'include' }
       )
       if (!tokenRes.ok) throw new Error('failed to get csrf token')
       const tokenData = await tokenRes.json()
 
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/api/login`, {
+      const res = await fetch(`${API_BASE}/api/login`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/talentify-next-frontend/app/logout/page.js
+++ b/talentify-next-frontend/app/logout/page.js
@@ -2,13 +2,15 @@
 import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000'
+
 export default function LogoutPage() {
   const router = useRouter()
 
   useEffect(() => {
     async function logout() {
       try {
-        await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/api/logout`, {
+        await fetch(`${API_BASE}/api/logout`, {
           method: 'POST',
           credentials: 'include',
         })

--- a/talentify-next-frontend/components/RegisterForm.js
+++ b/talentify-next-frontend/components/RegisterForm.js
@@ -4,6 +4,8 @@ import { useState } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import Link from 'next/link'
 
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000'
+
 export default function RegisterForm() {
   const searchParams = useSearchParams()
   const roleParam = searchParams.get('role')
@@ -112,11 +114,11 @@ export default function RegisterForm() {
       return
     }
     try {
-      const csrfRes = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/api/csrf-token`, {
+      const csrfRes = await fetch(`${API_BASE}/api/csrf-token`, {
         credentials: 'include',
       })
       const { csrfToken } = await csrfRes.json()
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/api/register`, {
+      const res = await fetch(`${API_BASE}/api/register`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- default API base to `http://localhost:5000` when env var is missing
- update RegisterForm, LoginPage and LogoutPage to use new constant

## Testing
- `npm run lint`
- `node -e "console.log('env var:', process.env.NEXT_PUBLIC_API_BASE); console.log('computed:', process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000');"`

------
https://chatgpt.com/codex/tasks/task_e_68628541ab688332a4dd974f321f7cb5