### PR TITLE
Integrate Supabase auth & API routes

### DIFF
--- a/talentify-next-frontend/.env.example
+++ b/talentify-next-frontend/.env.example
@@ -1,1 +1,3 @@
 NEXT_PUBLIC_API_BASE=https://talentify-production.up.railway.app
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=

--- a/talentify-next-frontend/app/api/profile/route.js
+++ b/talentify-next-frontend/app/api/profile/route.js
@@ -1,0 +1,18 @@
+import { supabase } from '@/lib/supabaseClient'
+
+export async function GET() {
+  const { data, error } = await supabase.from('profiles').select('*').maybeSingle()
+  if (error) {
+    return new Response(JSON.stringify({ message: error.message }), { status: 500 })
+  }
+  return Response.json(data)
+}
+
+export async function POST(request) {
+  const body = await request.json()
+  const { data, error } = await supabase.from('profiles').upsert(body).select().single()
+  if (error) {
+    return new Response(JSON.stringify({ message: error.message }), { status: 400 })
+  }
+  return Response.json(data)
+}

--- a/talentify-next-frontend/app/api/schedule/route.js
+++ b/talentify-next-frontend/app/api/schedule/route.js
@@ -1,0 +1,18 @@
+import { supabase } from '@/lib/supabaseClient'
+
+export async function GET() {
+  const { data, error } = await supabase.from('schedules').select('*')
+  if (error) {
+    return new Response(JSON.stringify({ message: error.message }), { status: 500 })
+  }
+  return Response.json(data || [])
+}
+
+export async function POST(request) {
+  const body = await request.json()
+  const { data, error } = await supabase.from('schedules').insert(body).select().single()
+  if (error) {
+    return new Response(JSON.stringify({ message: error.message }), { status: 400 })
+  }
+  return Response.json(data, { status: 201 })
+}

--- a/talentify-next-frontend/app/api/talents/[id]/route.js
+++ b/talentify-next-frontend/app/api/talents/[id]/route.js
@@ -1,0 +1,9 @@
+import { supabase } from '@/lib/supabaseClient'
+
+export async function GET(request, { params }) {
+  const { data, error } = await supabase.from('talents').select('*').eq('id', params.id).single()
+  if (error) {
+    return new Response(JSON.stringify({ message: error.message }), { status: 404 })
+  }
+  return Response.json(data)
+}

--- a/talentify-next-frontend/app/api/talents/route.js
+++ b/talentify-next-frontend/app/api/talents/route.js
@@ -1,0 +1,18 @@
+import { supabase } from '@/lib/supabaseClient'
+
+export async function GET() {
+  const { data, error } = await supabase.from('talents').select('*')
+  if (error) {
+    return new Response(JSON.stringify({ message: error.message }), { status: 500 })
+  }
+  return Response.json(data || [])
+}
+
+export async function POST(request) {
+  const body = await request.json()
+  const { data, error } = await supabase.from('talents').insert(body).select().single()
+  if (error) {
+    return new Response(JSON.stringify({ message: error.message }), { status: 400 })
+  }
+  return Response.json(data, { status: 201 })
+}

--- a/talentify-next-frontend/app/login/page.js
+++ b/talentify-next-frontend/app/login/page.js
@@ -2,8 +2,7 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
-
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000'
+import { supabase } from '@/lib/supabaseClient'
 
 export default function LoginPage() {
   const [email, setEmail] = useState('')
@@ -15,26 +14,13 @@ export default function LoginPage() {
     e.preventDefault()
     setError(null)
     try {
-      // CSRF トークンを取得
-      const tokenRes = await fetch(
-        `${API_BASE}/api/csrf-token`,
-        { credentials: 'include' }
-      )
-      if (!tokenRes.ok) throw new Error('failed to get csrf token')
-      const tokenData = await tokenRes.json()
-
-      const res = await fetch(`${API_BASE}/api/login`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRF-Token': tokenData.csrfToken,
-        },
-        credentials: 'include',
-        body: JSON.stringify({ email, password }),
+      const { error: signInError } = await supabase.auth.signInWithPassword({
+        email,
+        password,
       })
-      if (!res.ok) throw new Error('login failed')
-      await res.json()
+      if (signInError) throw signInError
     } catch (err) {
+      console.error(err)
       setError('メールアドレスまたはパスワードが間違っています')
     }
   }

--- a/talentify-next-frontend/components/RegisterForm.js
+++ b/talentify-next-frontend/components/RegisterForm.js
@@ -3,8 +3,7 @@
 import { useState } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import Link from 'next/link'
-
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000'
+import { supabase } from '@/lib/supabaseClient'
 
 export default function RegisterForm() {
   const searchParams = useSearchParams()
@@ -114,23 +113,15 @@ export default function RegisterForm() {
       return
     }
     try {
-      const csrfRes = await fetch(`${API_BASE}/api/csrf-token`, {
-        credentials: 'include',
+      const { error: signUpError } = await supabase.auth.signUp({
+        email,
+        password,
+        options: { data: { role } },
       })
-      const { csrfToken } = await csrfRes.json()
-      const res = await fetch(`${API_BASE}/api/register`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'CSRF-Token': csrfToken,
-        },
-        credentials: 'include',
-        body: JSON.stringify({ email, password, role }),
-      })
-      if (!res.ok) throw new Error('register failed')
-      await res.json()
+      if (signUpError) throw signUpError
       router.push('/login')
     } catch (err) {
+      console.error(err)
       setError('登録に失敗しました')
     }
   }

--- a/talentify-next-frontend/lib/supabaseClient.js
+++ b/talentify-next-frontend/lib/supabaseClient.js
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+export const supabase = createClient(url, key)

--- a/talentify-next-frontend/package-lock.json
+++ b/talentify-next-frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
+        "@supabase/supabase-js": "^2.50.2",
         "clsx": "^2.1.1",
         "next": "15.3.4",
         "react": "^19.0.0",
@@ -993,6 +994,81 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.70.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.70.0.tgz",
+      "integrity": "sha512-BaAK/tOAZFJtzF1sE3gJ2FwTjLf4ky3PSvcvLGEgEmO4BSBkwWKu8l67rLLIBZPDnCyV7Owk2uPyKHa0kj5QGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.4.tgz",
+      "integrity": "sha512-WL2p6r4AXNGwop7iwvul2BvOtuJ1YQy8EbOd0dhG1oN1q8el/BIRSFCFnWAMM/vJJlHWLi4ad22sKbKr9mvjoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.19.4.tgz",
+      "integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.11.15",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.11.15.tgz",
+      "integrity": "sha512-HQKRnwAqdVqJW/P9TjKVK+/ETpW4yQ8tyDPPtRMKOH4Uh3vQD74vmj353CYs8+YwVBKubeUOOEpI9CT8mT4obw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "isows": "^1.0.7",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.1.tgz",
+      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.50.2",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.50.2.tgz",
+      "integrity": "sha512-+27xlGgw7VyfwXXe+OiDJQosJNS+PPtjj1EnLR4uk+PKKZ91RA0/8NbIQybe6AGPanAaPtgOFFMMCArC6fZ++Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.70.0",
+        "@supabase/functions-js": "2.4.4",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.19.4",
+        "@supabase/realtime-js": "2.11.15",
+        "@supabase/storage-js": "2.7.1"
+      }
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -1315,6 +1391,30 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.0.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.7.tgz",
+      "integrity": "sha512-YIEUUr4yf8q8oQoXPpSlnvKNVKDQlPMWrmOcgzoduo7kvA2UF0/BwJ/eMKFTiTtkNL17I0M6Xe2tvwFU7be6iw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.34.1",
@@ -4076,6 +4176,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -5819,6 +5934,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -5976,6 +6097,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "license": "MIT"
+    },
     "node_modules/unrs-resolver": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.9.1.tgz",
@@ -6019,6 +6146,22 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -6134,6 +6277,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/talentify-next-frontend/package.json
+++ b/talentify-next-frontend/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
+    "@supabase/supabase-js": "^2.50.2",
     "clsx": "^2.1.1",
     "next": "15.3.4",
     "react": "^19.0.0",


### PR DESCRIPTION
## Summary
- add `@supabase/supabase-js`
- provide `lib/supabaseClient.js`
- call Supabase auth in login & registration
- expose talents, profile and schedule APIs using Next.js route handlers
- document new Supabase variables

## Testing
- `npm test` in `Talentify-backend`
- `npm run lint` in `talentify-next-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68628cea9e648332b96b2b79b0e771b9