### PR TITLE
Implement single talent GET API

### DIFF
--- a/talentify-next-frontend/app/api/talents/[id]/route.ts
+++ b/talentify-next-frontend/app/api/talents/[id]/route.ts
@@ -1,0 +1,21 @@
+import { createClient } from '@/lib/supabase/server'
+
+export async function GET(_req: Request, { params }: { params: { id: string } }) {
+  const supabase = createClient()
+
+  const { data, error } = await supabase
+    .from('talents')
+    .select('*')
+    .eq('id', params.id)
+    .single()
+
+  if (error || !data) {
+    return new Response(JSON.stringify({ error: error?.message ?? 'Not found' }), {
+      status: 404,
+    })
+  }
+
+  return new Response(JSON.stringify(data), {
+    status: 200,
+  })
+}


### PR DESCRIPTION
## Summary
- add `/api/talents/[id]` route to fetch one talent by id using Supabase client

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864fa8590b883328d38ff079d6626ea