### PR TITLE
Remove unused supabase client

### DIFF
--- a/talentify-next-frontend/lib/supabaseClient.ts
+++ b/talentify-next-frontend/lib/supabaseClient.ts
@@ -1,6 +1,0 @@
-import { createClient } from '@supabase/supabase-js'
-
-const supabaseUrl = 'http://localhost:54321' // ローカルのAPI URL
-const supabaseAnonKey = '上記のanon key'
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey)


### PR DESCRIPTION
## Summary
- delete unused `lib/supabaseClient.ts`
- confirm all remaining Supabase clients use environment variables

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6864fa862a9c83328df12e57e271adb8