### PR TITLE
Fix dynamic talent API route

### DIFF
--- a/talentify-next-frontend/app/api/talents/[id]/route.ts
+++ b/talentify-next-frontend/app/api/talents/[id]/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const supabase = createClient()
+  const { id } = params
+
+  const { data, error } = await supabase
+    .from('talents')
+    .select('*')
+    .eq('id', id)
+    .single()
+
+  if (error) {
+    return new Response(JSON.stringify({ error: error.message }), {
+      status: 500,
+    })
+  }
+
+  return new Response(JSON.stringify(data), {
+    status: 200,
+  })
+}


### PR DESCRIPTION
## Summary
- add missing dynamic route handler `GET` function that accepts `(req, context)` for `/api/talents/[id]`

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68650b44c0b48332a1846b0f0c1075b6