### PR TITLE
Add schedule and auth API routes

### DIFF
--- a/talentify-next-frontend/app/api/csrf-token/route.ts
+++ b/talentify-next-frontend/app/api/csrf-token/route.ts
@@ -1,0 +1,9 @@
+import { cookies } from 'next/headers'
+import { randomBytes } from 'crypto'
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  const token = randomBytes(32).toString('hex')
+  cookies().set('csrfToken', token, { httpOnly: true, path: '/' })
+  return NextResponse.json({ csrfToken: token })
+}

--- a/talentify-next-frontend/app/api/logout/route.ts
+++ b/talentify-next-frontend/app/api/logout/route.ts
@@ -1,0 +1,10 @@
+import { createClient } from '@/lib/supabase/server'
+
+export async function POST() {
+  const supabase = createClient()
+  const { error } = await supabase.auth.signOut()
+  if (error) {
+    return new Response(JSON.stringify({ error: error.message }), { status: 500 })
+  }
+  return new Response(JSON.stringify({ success: true }), { status: 200 })
+}

--- a/talentify-next-frontend/app/api/password-reset/[token]/route.ts
+++ b/talentify-next-frontend/app/api/password-reset/[token]/route.ts
@@ -1,0 +1,24 @@
+import { createClient } from '@/lib/supabase/server'
+import { NextRequest } from 'next/server'
+
+export async function POST(request: NextRequest, { params }: any) {
+  const supabase = createClient()
+  const { password } = await request.json()
+  const { token } = params as { token: string }
+
+  const { error: verifyError } = await supabase.auth.verifyOtp({
+    type: 'recovery',
+    token,
+  })
+
+  if (verifyError) {
+    return new Response(JSON.stringify({ error: verifyError.message }), { status: 400 })
+  }
+
+  const { error } = await supabase.auth.updateUser({ password })
+  if (error) {
+    return new Response(JSON.stringify({ error: error.message }), { status: 500 })
+  }
+
+  return new Response(JSON.stringify({ success: true }), { status: 200 })
+}

--- a/talentify-next-frontend/app/api/password-reset/route.ts
+++ b/talentify-next-frontend/app/api/password-reset/route.ts
@@ -1,0 +1,19 @@
+import { createClient } from '@/lib/supabase/server'
+import { NextRequest } from 'next/server'
+
+export async function POST(req: NextRequest) {
+  const supabase = createClient()
+  const { email } = await req.json()
+
+  const { error } = await supabase.auth.resetPasswordForEmail(email, {
+    redirectTo: process.env.NEXT_PUBLIC_SITE_URL
+      ? `${process.env.NEXT_PUBLIC_SITE_URL}/password-reset`
+      : undefined,
+  })
+
+  if (error) {
+    return new Response(JSON.stringify({ error: error.message }), { status: 500 })
+  }
+
+  return new Response(JSON.stringify({ success: true }), { status: 200 })
+}

--- a/talentify-next-frontend/app/api/schedule/route.ts
+++ b/talentify-next-frontend/app/api/schedule/route.ts
@@ -1,0 +1,49 @@
+import { createClient } from '@/lib/supabase/server'
+import { NextRequest } from 'next/server'
+
+export async function GET() {
+  const supabase = createClient()
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  const query = supabase.from('schedules').select('*')
+  if (user) query.eq('user_id', user.id)
+  const { data, error } = await query
+
+  if (error || userError) {
+    return new Response(JSON.stringify({ error: (error || userError)?.message }), {
+      status: 500,
+    })
+  }
+
+  return new Response(JSON.stringify(data), { status: 200 })
+}
+
+export async function POST(req: NextRequest) {
+  const supabase = createClient()
+  const body = await req.json()
+  const { date, description } = body
+
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  if (!user || userError) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
+  }
+
+  const { data, error } = await supabase
+    .from('schedules')
+    .insert({ user_id: user.id, date, description })
+    .select()
+    .single()
+
+  if (error) {
+    return new Response(JSON.stringify({ error: error.message }), { status: 500 })
+  }
+
+  return new Response(JSON.stringify(data), { status: 201 })
+}


### PR DESCRIPTION
## Summary
- add schedule route with GET/POST handlers
- implement logout and password reset endpoints
- support CSRF token generation

## Testing
- `npm run lint`
- `npm run build` *(fails: Type error about dynamic API route)*

------
https://chatgpt.com/codex/tasks/task_e_68655eda67c88332bca75088412d47b4