### PR TITLE
Update talent references to use id

### DIFF
--- a/talentify-next-frontend/app/performers/[id]/page.js
+++ b/talentify-next-frontend/app/performers/[id]/page.js
@@ -44,7 +44,7 @@ export default function PerformerDetailPage({ params }) {
       )}
       <p>
         <span className="font-medium">経験年数: </span>
-        {talent.experienceYears}年
+        {talent.experience_years}年
       </p>
       <hr />
       <p className="text-gray-500">プロフィール詳細は今後ここに表示されます。</p>

--- a/talentify-next-frontend/app/performers/page.js
+++ b/talentify-next-frontend/app/performers/page.js
@@ -42,7 +42,7 @@ export default function PerformersPage() {
       />
       <div className="grid gap-4 md:grid-cols-2">
         {filtered.map(t => (
-          <PerformerCard key={t._id} talent={t} />
+          <PerformerCard key={t.id} talent={t} />
         ))}
         {filtered.length === 0 && (
           <p>該当する演者が見つかりませんでした。</p>

--- a/talentify-next-frontend/app/schedule/page.js
+++ b/talentify-next-frontend/app/schedule/page.js
@@ -67,7 +67,7 @@ export default function SchedulePage() {
       </form>
       <ul className="space-y-2">
         {items.map((it) => (
-          <li key={it._id}>
+          <li key={it.id}>
             {new Date(it.date).toLocaleDateString()} - {it.description}
           </li>
         ))}

--- a/talentify-next-frontend/components/PerformerCard.js
+++ b/talentify-next-frontend/components/PerformerCard.js
@@ -17,11 +17,11 @@ export default function PerformerCard({ talent }) {
       )}
       <p className="text-sm mb-4">
         <span className="font-medium">経験年数: </span>
-        {talent.experienceYears}年
+        {talent.experience_years}年
       </p>
       <div className="mt-auto flex space-x-2">
         <Link
-          href={`/performers/${talent._id}`}
+          href={`/performers/${talent.id}`}
           className="flex-1 py-1 border rounded text-center hover:bg-gray-50"
         >
           詳細を見る


### PR DESCRIPTION
## Summary
- show experience years using `experience_years`
- update performer links to use `talent.id`
- update performers list keys
- use `id` for schedule items

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68655edaa75483329374647732211913