### PR TITLE
Improve talent detail pages

### DIFF
--- a/talentify-next-frontend/app/api/talents/[id]/route.ts
+++ b/talentify-next-frontend/app/api/talents/[id]/route.ts
@@ -19,6 +19,12 @@ export async function GET(
     })
   }
 
+  if (!data) {
+    return new Response(JSON.stringify({ error: 'Not found' }), {
+      status: 404,
+    })
+  }
+
   return new Response(JSON.stringify(data), {
     status: 200,
   })

--- a/talentify-next-frontend/app/performers/[id]/page.js
+++ b/talentify-next-frontend/app/performers/[id]/page.js
@@ -8,6 +8,7 @@ const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000'
 export default function PerformerDetailPage({ params }) {
   const { id } = params
   const [talent, setTalent] = useState(null)
+  const [notFound, setNotFound] = useState(false)
 
   useEffect(() => {
     const fetchTalent = async () => {
@@ -15,6 +16,10 @@ export default function PerformerDetailPage({ params }) {
         const res = await fetch(`${API_BASE}/api/talents/${id}`, {
           credentials: 'include', // include cookies for authenticated APIs
         })
+        if (res.status === 404) {
+          setNotFound(true)
+          return
+        }
         if (!res.ok) throw new Error('Failed to fetch')
         const data = await res.json()
         setTalent(data)
@@ -24,6 +29,17 @@ export default function PerformerDetailPage({ params }) {
     }
     fetchTalent()
   }, [id])
+
+  if (notFound) {
+    return (
+      <main className="max-w-3xl mx-auto p-4">
+        <p>演者が見つかりませんでした。</p>
+        <Link href="/performers" className="text-blue-600 underline">
+          演者一覧に戻る
+        </Link>
+      </main>
+    )
+  }
 
   if (!talent) {
     return (
@@ -46,8 +62,31 @@ export default function PerformerDetailPage({ params }) {
         <span className="font-medium">経験年数: </span>
         {talent.experienceYears}年
       </p>
-      <hr />
-      <p className="text-gray-500">プロフィール詳細は今後ここに表示されます。</p>
+      {talent.bio && (
+        <section>
+          <h2 className="font-medium">自己紹介</h2>
+          <p>{talent.bio}</p>
+        </section>
+      )}
+      {talent.social_links && talent.social_links.length > 0 && (
+        <section>
+          <h2 className="font-medium">SNS</h2>
+          <ul className="list-disc pl-5 space-y-1">
+            {talent.social_links.map((link) => (
+              <li key={link}>
+                <a
+                  href={link}
+                  className="text-blue-600 underline"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {link}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
       <Link href="/performers" className="text-blue-600 underline">
         演者一覧に戻る
       </Link>

--- a/talentify-next-frontend/app/talents/[id]/page.tsx
+++ b/talentify-next-frontend/app/talents/[id]/page.tsx
@@ -5,7 +5,10 @@ type Talent = {
   id: string
   name: string
   email: string
-  profile: string
+  profile: string | null
+  bio: string | null
+  skills: string[] | null
+  social_links: string[] | null
 }
 
 export default async function TalentDetailPage({
@@ -19,13 +22,48 @@ export default async function TalentDetailPage({
 
   if (!res.ok) return notFound()
 
-  const talent: Talent = await res.json()
+  const talent: Talent | null = await res.json()
+  if (!talent) return notFound()
 
   return (
-    <div className="p-4">
+    <div className="p-4 space-y-4">
       <h1 className="text-xl font-bold">{talent.name}</h1>
       <p>{talent.email}</p>
-      <p>{talent.profile}</p>
+      {talent.bio && (
+        <section>
+          <h2 className="font-medium">自己紹介</h2>
+          <p>{talent.bio}</p>
+        </section>
+      )}
+      {talent.skills && talent.skills.length > 0 && (
+        <section>
+          <h2 className="font-medium">スキル</h2>
+          <ul className="list-disc pl-5 space-y-1">
+            {talent.skills.map((skill) => (
+              <li key={skill}>{skill}</li>
+            ))}
+          </ul>
+        </section>
+      )}
+      {talent.social_links && talent.social_links.length > 0 && (
+        <section>
+          <h2 className="font-medium">SNS</h2>
+          <ul className="list-disc pl-5 space-y-1">
+            {talent.social_links.map((link) => (
+              <li key={link}>
+                <a
+                  href={link}
+                  className="text-blue-600 underline"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {link}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- fetch full talent details
- display bio, skills and social links on talent pages
- show not-found message when performers are missing
- return 404 for missing talents from API

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68672452851c83329ed3d15434c802d7