### PR TITLE
Fix supabase imports and ts compile

### DIFF
--- a/talentify-next-frontend/app/api/csrf-token/route.ts
+++ b/talentify-next-frontend/app/api/csrf-token/route.ts
@@ -1,9 +1,9 @@
-import { cookies } from 'next/headers'
 import { randomBytes } from 'crypto'
 import { NextResponse } from 'next/server'
 
 export async function GET() {
   const token = randomBytes(32).toString('hex')
-  cookies().set('csrfToken', token, { httpOnly: true, path: '/' })
-  return NextResponse.json({ csrfToken: token })
+  const res = NextResponse.json({ csrfToken: token })
+  res.cookies.set('csrfToken', token, { httpOnly: true, path: '/' })
+  return res
 }

--- a/talentify-next-frontend/app/api/password-reset/[token]/route.ts
+++ b/talentify-next-frontend/app/api/password-reset/[token]/route.ts
@@ -8,7 +8,7 @@ export async function POST(request: NextRequest, { params }: any) {
 
   const { error: verifyError } = await supabase.auth.verifyOtp({
     type: 'recovery',
-    token,
+    token_hash: token,
   })
 
   if (verifyError) {

--- a/talentify-next-frontend/lib/supabase/server.ts
+++ b/talentify-next-frontend/lib/supabase/server.ts
@@ -1,6 +1,6 @@
 import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
 import { cookies } from 'next/headers'
-import { Database } from '@/types/supabase' // ←ここ直す
+import { Database } from '@/types/supabase'
 
 export function createClient() {
   return createServerComponentClient<Database>({


### PR DESCRIPTION
## Summary
- clean up comment in supabase server client
- fix CSRF token route cookie usage
- adjust verifyOtp call for recovery token

## Testing
- `npx tsc -p talentify-next-frontend/tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6867245b2d2c8332834c7c25e49a1b3b