### PR TITLE
Fix Supabase client in profiles API

### DIFF
--- a/talentify-next-frontend/app/api/profiles/route.ts
+++ b/talentify-next-frontend/app/api/profiles/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server'
-import { supabase } from '@/lib/supabase'
+import { createClient } from '@/lib/supabase/server'
 
 export async function GET() {
+  const supabase = await createClient()
   const { data, error } = await supabase.from('profiles').select('*')
 
   if (error) {


### PR DESCRIPTION
## Summary
- use `createClient` from server utility in profiles API

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_686c71243f108332be2faf9e7f09edc5