### PR TITLE
Implement payments API and UI integration

### DIFF
--- a/talentify-next-frontend/app/api/payments/route.ts
+++ b/talentify-next-frontend/app/api/payments/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+export async function GET(req: NextRequest) {
+  const supabase = await createClient()
+  const offerId = req.nextUrl.searchParams.get('offer_id')
+
+  let query = supabase.from('payments').select('*')
+  if (offerId) query.eq('offer_id', offerId)
+
+  const { data, error } = await query
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json(data)
+}
+
+export async function PATCH(req: NextRequest) {
+  const supabase = await createClient()
+  const body = await req.json()
+  const { id, ...fields } = body
+
+  if (!id) {
+    return NextResponse.json({ error: 'id is required' }, { status: 400 })
+  }
+
+  const { data, error } = await supabase
+    .from('payments')
+    .update(fields)
+    .eq('id', id)
+    .select()
+    .maybeSingle()
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json(data)
+}

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -116,6 +116,33 @@ export type Database = {
           social_links?: string[] | null
         }
         Relationships: []
+      },
+      payments: {
+        Row: {
+          id: string
+          offer_id: string | null
+          amount: number | null
+          status: string | null
+          invoice_url: string | null
+          created_at: string | null
+        }
+        Insert: {
+          id?: string
+          offer_id?: string | null
+          amount?: number | null
+          status?: string | null
+          invoice_url?: string | null
+          created_at?: string | null
+        }
+        Update: {
+          id?: string
+          offer_id?: string | null
+          amount?: number | null
+          status?: string | null
+          invoice_url?: string | null
+          created_at?: string | null
+        }
+        Relationships: []
       }
     }
     Views: {


### PR DESCRIPTION
## Summary
- add payments table types
- create `/api/payments` endpoint to read and update payments
- connect payments tab on manage page to API

## Testing
- `npm install`
- `npm run lint` *(fails: Invalid Options)*

------
https://chatgpt.com/codex/tasks/task_e_686c79e8ec408332846e6cf20d3236f1