### PR TITLE
Implement Supabase chat API and realtime messages

### DIFF
--- a/supabase/migrations/0001_create_messages.sql
+++ b/supabase/migrations/0001_create_messages.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS public.messages (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  sender_id uuid REFERENCES auth.users (id) NOT NULL,
+  receiver_id uuid REFERENCES auth.users (id) NOT NULL,
+  text text NOT NULL,
+  created_at timestamp with time zone DEFAULT now()
+);

--- a/talentify-next-frontend/app/api/messages/route.ts
+++ b/talentify-next-frontend/app/api/messages/route.ts
@@ -1,0 +1,52 @@
+import { createClient } from '@/lib/supabase/server'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  if (!user || userError) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data, error } = await supabase
+    .from('messages')
+    .select('*')
+    .or(`sender_id.eq.${user.id},receiver_id.eq.${user.id}`)
+    .order('created_at', { ascending: true })
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json(data)
+}
+
+export async function POST(req: NextRequest) {
+  const supabase = await createClient()
+  const { receiver_id, text } = await req.json()
+
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  if (!user || userError) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data, error } = await supabase
+    .from('messages')
+    .insert({ sender_id: user.id, receiver_id, text })
+    .select()
+    .single()
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json(data, { status: 201 })
+}

--- a/talentify-next-frontend/app/messages/page.js
+++ b/talentify-next-frontend/app/messages/page.js
@@ -1,50 +1,106 @@
 'use client'
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useMemo } from 'react'
 import Image from 'next/image'
+import { createClient } from '@/utils/supabase/client'
 
-const initialThreads = [
-  {
-    id: 1,
-    name: '山田太郎',
-    avatar: '/avatar-default.svg',
-    latest: '次回のスケジュールについてご確認ください',
-    unread: 2,
-    updatedAt: '2025/04/25 12:00',
-    messages: [
-      { id: 1, from: 'store', text: 'こんにちは、次回のスケジュールですが…', time: '2025/04/24 09:00' },
-      { id: 2, from: 'performer', text: 'はい、承知しました！', time: '2025/04/24 09:10' }
-    ]
-  },
-  {
-    id: 2,
-    name: '佐藤花子',
-    avatar: '/avatar-default.svg',
-    latest: '契約書をお送りしました',
-    unread: 0,
-    updatedAt: '2025/04/20 16:30',
-    messages: [
-      { id: 1, from: 'store', text: '契約書をお送りします。ご確認ください。', time: '2025/04/20 16:30' }
-    ]
+const supabase = createClient()
+
+function groupMessages(messages, userId) {
+  const map = new Map()
+  for (const m of messages) {
+    const otherId = m.sender_id === userId ? m.receiver_id : m.sender_id
+    if (!map.has(otherId)) {
+      map.set(otherId, {
+        id: otherId,
+        name: `User ${otherId.slice(0, 8)}`,
+        avatar: '/avatar-default.svg',
+        latest: m.text,
+        unread: 0,
+        updatedAt: m.created_at,
+        messages: []
+      })
+    }
+    const th = map.get(otherId)
+    th.messages.push({
+      id: m.id,
+      from: m.sender_id === userId ? 'store' : 'performer',
+      text: m.text,
+      time: m.created_at
+    })
+    if (new Date(th.updatedAt) < new Date(m.created_at)) {
+      th.updatedAt = m.created_at
+      th.latest = m.text
+    }
   }
-]
+  return Array.from(map.values())
+}
 
 export default function MessageBoxPage() {
-  const [threads, setThreads] = useState(initialThreads)
-  const [activeId, setActiveId] = useState(initialThreads[0].id)
+  const [messages, setMessages] = useState([])
+  const [userId, setUserId] = useState(null)
+  const [activeId, setActiveId] = useState(null)
   const [input, setInput] = useState('')
   const messagesEndRef = useRef(null)
 
   useEffect(() => {
+    const init = async () => {
+      const { data: { user } } = await supabase.auth.getUser()
+      if (user) setUserId(user.id)
+
+      try {
+        const res = await fetch('/api/messages')
+        if (res.ok) {
+          const data = await res.json()
+          setMessages(data)
+        }
+      } catch (e) {
+        console.error(e)
+      }
+    }
+    init()
+  }, [])
+
+  useEffect(() => {
+    if (!userId) return
+    const channel = supabase
+      .channel('public:messages')
+      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'messages' }, payload => {
+        const m = payload.new
+        if (m.sender_id === userId || m.receiver_id === userId) {
+          setMessages(prev => [...prev, m])
+        }
+      })
+    channel.subscribe()
+    return () => {
+      supabase.removeChannel(channel)
+    }
+  }, [userId])
+
+  const threads = useMemo(() => groupMessages(messages, userId), [messages, userId])
+
+  useEffect(() => {
+    if (threads.length && !activeId) setActiveId(threads[0].id)
+  }, [threads, activeId])
+
+  useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [activeId, threads])
+  }, [activeId, messages])
 
   const activeThread = threads.find(t => t.id === activeId)
 
-  const handleSend = () => {
-    if (!input) return
-    const newMessage = { id: Date.now(), from: 'store', text: input, time: new Date().toLocaleString() }
-    setThreads(prev => prev.map(t => t.id === activeId ? { ...t, messages: [...t.messages, newMessage], latest: input, updatedAt: newMessage.time, unread: 0 } : t))
-    setInput('')
+  const handleSend = async () => {
+    if (!input || !activeId) return
+    try {
+      const res = await fetch('/api/messages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ receiver_id: activeId, text: input })
+      })
+      if (!res.ok) throw new Error('failed')
+      setInput('')
+    } catch (err) {
+      console.error(err)
+    }
   }
 
   return (
@@ -65,7 +121,7 @@ export default function MessageBoxPage() {
       </aside>
       <section className="flex flex-col flex-1">
         <div className="flex-1 overflow-y-auto p-4 space-y-2">
-          {activeThread.messages.map(msg => (
+          {activeThread?.messages.map(msg => (
             <div key={msg.id} className={`flex ${msg.from === 'store' ? 'justify-end' : 'justify-start'}`}>
               <div className={`rounded px-3 py-2 max-w-xs ${msg.from === 'store' ? 'bg-blue-100' : 'bg-gray-100'}`}>{msg.text}</div>
             </div>

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -117,6 +117,31 @@ export type Database = {
         }
         Relationships: []
       }
+
+      messages: {
+        Row: {
+          id: string
+          sender_id: string
+          receiver_id: string
+          text: string
+          created_at: string | null
+        }
+        Insert: {
+          id?: string
+          sender_id: string
+          receiver_id: string
+          text: string
+          created_at?: string | null
+        }
+        Update: {
+          id?: string
+          sender_id?: string
+          receiver_id?: string
+          text?: string
+          created_at?: string | null
+        }
+        Relationships: []
+      }
     }
     Views: {
       [_ in never]: never


### PR DESCRIPTION
## Summary
- add SQL migration to create `messages` table
- implement `/api/messages` route for fetching and posting chat messages
- extend Supabase TypeScript types with `messages` table
- load chat threads from API and subscribe to Realtime in UI

## Testing
- `npm install` *(fails: 1 high severity vulnerability)*
- `npm run lint` *(fails: Invalid Options)*

------
https://chatgpt.com/codex/tasks/task_e_686c79e4f09c83328572cf01d983f968