### PR TITLE
Implement offer status workflow

### DIFF
--- a/talentify-next-frontend/app/api/offers/[id]/route.ts
+++ b/talentify-next-frontend/app/api/offers/[id]/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+export async function PUT(req: NextRequest) {
+  const supabase = await createClient()
+  const id = req.nextUrl.pathname.split('/').pop()
+  const { status } = await req.json()
+
+  const { error } = await supabase
+    .from('offers')
+    .update({ status })
+    .eq('id', id)
+
+  if (error) {
+    return new Response(JSON.stringify({ error: error.message }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // TODO: Notify performer or store about status change
+
+  return new Response(JSON.stringify({ message: '更新しました' }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}

--- a/talentify-next-frontend/app/dashboard/page.js
+++ b/talentify-next-frontend/app/dashboard/page.js
@@ -1,5 +1,6 @@
 "use client";
 import Link from 'next/link';
+import { useState } from 'react';
 import { Card, CardHeader, CardContent, CardFooter } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
@@ -22,6 +23,22 @@ const pendingOffers = [
 ];
 
 export default function DashboardPage() {
+  const [offers, setOffers] = useState(pendingOffers);
+
+  const handleStatus = async (id, status) => {
+    const res = await fetch(`/api/offers/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status }),
+    });
+    if (res.ok) {
+      setOffers((prev) => prev.filter((o) => o.id !== id));
+    } else {
+      const err = await res.text();
+      alert(`更新に失敗しました: ${err}`);
+    }
+  };
+
   return (
     <div className="p-4 grid gap-4 md:grid-cols-2">
       <Card>
@@ -66,13 +83,23 @@ export default function DashboardPage() {
               </tr>
             </thead>
             <tbody>
-              {pendingOffers.map((o) => (
+              {offers.map((o) => (
                 <tr key={o.id} className="border-t">
                   <td className="py-2">{o.title}</td>
                   <td className="py-2 space-x-2">
                     <button className="text-blue-600">詳細確認</button>
-                    <button className="text-green-600">承諾</button>
-                    <button className="text-red-600">辞退</button>
+                    <button
+                      className="text-green-600"
+                      onClick={() => handleStatus(o.id, 'accepted')}
+                    >
+                      承諾
+                    </button>
+                    <button
+                      className="text-red-600"
+                      onClick={() => handleStatus(o.id, 'rejected')}
+                    >
+                      辞退
+                    </button>
                   </td>
                 </tr>
               ))}

--- a/talentify-next-frontend/app/performers/[id]/offer/page.tsx
+++ b/talentify-next-frontend/app/performers/[id]/offer/page.tsx
@@ -30,6 +30,7 @@ export default function OfferPage() {
         talent_id: id,
         message: message,
         date: date,
+        status: 'pending',
       },
     ])
 

--- a/talentify-next-frontend/types/supabase.ts
+++ b/talentify-next-frontend/types/supabase.ts
@@ -30,6 +30,7 @@ export interface Database {
           message: string
           date: string
           created_at: string
+          status: string
         }
         Insert: {
           user_id: string
@@ -37,6 +38,7 @@ export interface Database {
           message: string
           date: string
           created_at?: string // サーバー側で自動生成される場合は optional に
+          status?: string
         }
         Update: Partial<{
           user_id: string
@@ -44,6 +46,7 @@ export interface Database {
           message: string
           date: string
           created_at: string
+          status: string
         }>
       }
     }

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -117,6 +117,36 @@ export type Database = {
         }
         Relationships: []
       }
+      offers: {
+        Row: {
+          id: string
+          user_id: string
+          talent_id: string
+          message: string
+          date: string
+          created_at: string | null
+          status: string | null
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          talent_id: string
+          message: string
+          date: string
+          created_at?: string | null
+          status?: string | null
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          talent_id?: string
+          message?: string
+          date?: string
+          created_at?: string | null
+          status?: string | null
+        }
+        Relationships: []
+      }
     }
     Views: {
       [_ in never]: never


### PR DESCRIPTION
## Summary
- expand Supabase types for offers table with `status`
- add API endpoint to update an offer's status
- store `status` when creating offers
- call the new API from the dashboard

## Testing
- `npm run lint` *(fails: Invalid Options)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686c79e6ee008332be43a9e69c834208