### PR TITLE
Add missing About page and link to offer form

### DIFF
--- a/talentify-next-frontend/app/about/page.js
+++ b/talentify-next-frontend/app/about/page.js
@@ -1,0 +1,19 @@
+'use client'
+import Link from 'next/link'
+
+export default function AboutPage() {
+  return (
+    <main className="max-w-3xl mx-auto p-4 space-y-4">
+      <h1 className="text-2xl font-bold">このサイトについて</h1>
+      <p>
+        Talentifyはパチンコ店と演者をマッチングするためのプラットフォームです。
+        演者はプロフィールを公開し、店舗は条件に合った演者を検索して出演依頼を送信できます。
+      </p>
+      <p>
+        サービスは現在も開発中で、機能改善を続けています。ご意見・ご要望がございましたら
+        <Link href="/contact" className="text-blue-600 underline">お問い合わせ</Link>
+        よりお知らせください。
+      </p>
+    </main>
+  )
+}

--- a/talentify-next-frontend/app/performers/[id]/PerformerDetailPage.tsx
+++ b/talentify-next-frontend/app/performers/[id]/PerformerDetailPage.tsx
@@ -3,6 +3,7 @@
 import { FaTwitter, FaInstagram } from 'react-icons/fa'
 import { useEffect, useState } from 'react'
 import { useParams } from 'next/navigation'
+import Link from 'next/link'
 import { StarRating } from '@/components/StarRating'
 import { createClient } from '@/utils/supabase/client'
 import { useUserRole } from '@/utils/useRole'
@@ -90,9 +91,11 @@ export default function PerformerDetailPage() {
 
       <div className="mt-6 space-y-2">
         {role === 'store' && (
-          <button className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">
-            オファーを送る
-          </button>
+          <Link href={`/performers/${performer.id}/offer`}>
+            <button className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">
+              オファーを送る
+            </button>
+          </Link>
         )}
 
         {role === 'performer' && userId === performer.id && (

--- a/talentify-next-frontend/app/performers/[id]/PerformerDetailPageClient.tsx
+++ b/talentify-next-frontend/app/performers/[id]/PerformerDetailPageClient.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import Link from 'next/link'
 import { createClient } from '@/utils/supabase/client'
 import { useUserRole } from '@/utils/useRole'
 import { StarRating } from '@/components/StarRating'
@@ -92,9 +93,11 @@ export default function PerformerDetailPageClient({ id }: Props) {
 
       <div className="mt-6 space-y-2">
         {role === 'store' && (
-          <button className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">
-            オファーを送る
-          </button>
+          <Link href={`/performers/${performer.id}/offer`}>
+            <button className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">
+              オファーを送る
+            </button>
+          </Link>
         )}
 
         {role === 'performer' && userId === performer.id && (


### PR DESCRIPTION
## Summary
- add `/about` page so the header link works
- link "オファーを送る" buttons to the performer offer page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c8813da288332b9976e27225bd470