### PR TITLE
Fix sign-up profile insertion and profile lookups

### DIFF
--- a/talentify-next-frontend/app/login/page.tsx
+++ b/talentify-next-frontend/app/login/page.tsx
@@ -33,14 +33,14 @@ export default function LoginPage() {
     const { data: existingProfile, error: profileError } = await supabase
       .from('profiles')
       .select('id')
-      .eq('id', userId)
+      .eq('user_id', userId)
       .single()
 
     if (!existingProfile) {
       // 🔽 なければ作成（必要なら role: 'store' や 'performer' を付与）
       await supabase.from('profiles').insert([
         {
-          id: userId,
+          user_id: userId,
           role: 'store', // ←仮に "store" としておく。条件分岐してもOK
         }
       ])

--- a/talentify-next-frontend/app/profile/page.tsx
+++ b/talentify-next-frontend/app/profile/page.tsx
@@ -21,7 +21,7 @@ export default function ProfilePage() {
       const { data, error } = await supabase
         .from('profiles')
         .select('*')
-        .eq('id', userId)
+        .eq('user_id', userId)
         .single();
 
       if (error) {

--- a/talentify-next-frontend/components/RegisterForm.tsx
+++ b/talentify-next-frontend/components/RegisterForm.tsx
@@ -62,7 +62,7 @@ export default function RegisterForm() {
     if (user) {
       const { error: profileError } = await supabase.from('profiles').insert([
         {
-          id: user.id,
+          user_id: user.id,
           display_name: '',
           bio: '',
         },


### PR DESCRIPTION
## Summary
- create profile rows using `user_id` on sign-up
- query `profiles` by `user_id` on login and profile page

## Testing
- `npm install` *(fails: 1 high severity vulnerability)*
- `npm run lint` *(fails: Invalid Options)*

------
https://chatgpt.com/codex/tasks/task_e_686e1f3a8f4c8332bcf103567abcca31