### PR TITLE
Update performer paths to talent

### DIFF
--- a/talentify-next-frontend/app/performers/[id]/PerformerDetailPage.tsx
+++ b/talentify-next-frontend/app/performers/[id]/PerformerDetailPage.tsx
@@ -91,7 +91,7 @@ export default function PerformerDetailPage() {
 
       <div className="mt-6 space-y-2">
         {role === 'store' && (
-          <Link href={`/performers/${performer.id}/offer`}>
+          <Link href={`/talents/${performer.id}/offer`}>
             <button className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">
               オファーを送る
             </button>
@@ -101,7 +101,7 @@ export default function PerformerDetailPage() {
         {role === 'performer' && userId === performer.id && (
           <button
             className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
-            onClick={() => (window.location.href = '/performer/profile/edit')}
+            onClick={() => (window.location.href = '/talent/profile/edit')}
           >
             プロフィールを編集する
           </button>

--- a/talentify-next-frontend/app/performers/[id]/PerformerDetailPageClient.tsx
+++ b/talentify-next-frontend/app/performers/[id]/PerformerDetailPageClient.tsx
@@ -93,7 +93,7 @@ export default function PerformerDetailPageClient({ id }: Props) {
 
       <div className="mt-6 space-y-2">
         {role === 'store' && (
-          <Link href={`/performers/${performer.id}/offer`}>
+          <Link href={`/talents/${performer.id}/offer`}>
             <button className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">
               オファーを送る
             </button>
@@ -103,7 +103,7 @@ export default function PerformerDetailPageClient({ id }: Props) {
         {role === 'performer' && userId === performer.id && (
           <button
             className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
-            onClick={() => (window.location.href = '/performer/profile/edit')}
+            onClick={() => (window.location.href = '/talent/profile/edit')}
           >
             プロフィールを編集する
           </button>

--- a/talentify-next-frontend/app/profile/page.tsx
+++ b/talentify-next-frontend/app/profile/page.tsx
@@ -52,7 +52,7 @@ export default function ProfilePage() {
           <p><strong>YouTube:</strong> {profile.youtube}</p>
           <button
             className="mt-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
-            onClick={() => window.location.href = '/performer/profile/edit'}
+            onClick={() => window.location.href = '/talent/profile/edit'}
           >
             プロフィールを編集
           </button>

--- a/talentify-next-frontend/components/Header.tsx
+++ b/talentify-next-frontend/components/Header.tsx
@@ -48,7 +48,7 @@ export default function Header() {
         {/* メニュー（PC表示） */}
         <nav className="hidden md:flex space-x-4 text-sm items-center">
           <Link href="/about" className="hover:underline">このサイトについて</Link>
-          <Link href="/performers" className="hover:underline">演者検索</Link>
+          <Link href="/talents" className="hover:underline">演者検索</Link>
           <Link href="/dashboard" className="hover:underline">ダッシュボード</Link>
           <Link href="/faq" className="hover:underline">FAQ</Link>
           <Link href="/contact" className="hover:underline">お問い合わせ</Link>
@@ -58,7 +58,7 @@ export default function Header() {
           )}
 
           {role === 'performer' && (
-            <Link href="/performer/profile/edit" className="hover:underline text-blue-600 font-semibold">
+            <Link href="/talent/profile/edit" className="hover:underline text-blue-600 font-semibold">
               プロフィール編集
             </Link>
           )}
@@ -78,7 +78,7 @@ export default function Header() {
       {isOpen && (
         <nav className="md:hidden px-4 pb-4 space-y-2 text-sm font-medium">
           <Link href="/about" className="block">このサイトについて</Link>
-          <Link href="/performers" className="block">演者検索</Link>
+          <Link href="/talents" className="block">演者検索</Link>
           <Link href="/dashboard" className="block">ダッシュボード</Link>
           <Link href="/faq" className="block">FAQ</Link>
           <Link href="/contact" className="block">お問い合わせ</Link>
@@ -88,7 +88,7 @@ export default function Header() {
           )}
 
           {role === 'performer' && (
-            <Link href="/performer/profile/edit" className="block text-blue-600 font-semibold">
+            <Link href="/talent/profile/edit" className="block text-blue-600 font-semibold">
               プロフィール編集
             </Link>
           )}

--- a/talentify-next-frontend/components/PerformerCard.tsx
+++ b/talentify-next-frontend/components/PerformerCard.tsx
@@ -31,12 +31,12 @@ export default function PerformerCard({ talent }) {
       </p>
       <div className="mt-auto flex space-x-2">
         <Link
-          href={`/performers/${talent.id}`}
+          href={`/talents/${talent.id}`}
           className="flex-1 py-1 border rounded text-center hover:bg-gray-50"
         >
           詳細を見る
         </Link>
-        <Link href={`/performers/${talent.id}/offer`} className="flex-1">
+        <Link href={`/talents/${talent.id}/offer`} className="flex-1">
           <button className="w-full py-1 bg-blue-600 text-white rounded hover:bg-blue-700">
             オファーを送る
           </button>


### PR DESCRIPTION
## Summary
- update performer links in Header to `/talents`
- update all profile edit links to `/talent/profile/edit`
- update performer detail and card links to `/talents`

## Testing
- `npm run lint` *(fails: Invalid Options)*

------
https://chatgpt.com/codex/tasks/task_e_68708247d19083329b94be7b633f3aed