### PR TITLE
Add new talent form

### DIFF
--- a/talentify-next-frontend/app/talents/new/page.tsx
+++ b/talentify-next-frontend/app/talents/new/page.tsx
@@ -10,26 +10,69 @@ export default function NewTalentPage() {
   const router = useRouter()
 
   const handleSubmit = async (e: React.FormEvent) => {
-  e.preventDefault()
-  try {
-    const res = await fetch('/api/talents', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ name, email, profile }),
-    })
+    e.preventDefault()
+    try {
+      const res = await fetch('/api/talents', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ name, email, profile }),
+      })
 
-    if (res.ok) {
-      router.push('/talents')
-    } else {
-      const error = await res.text()
-      alert(`登録に失敗しました：${error}`)
+      if (res.ok) {
+        router.push('/talents')
+      } else {
+        const error = await res.text()
+        alert(`登録に失敗しました：${error}`)
+      }
+    } catch (err) {
+      console.error('送信エラー:', err)
+      alert('通信エラーが発生しました')
     }
-  } catch (err) {
-    console.error('送信エラー:', err)
-    alert('通信エラーが発生しました')
   }
+
+  return (
+    <div className="max-w-md mx-auto mt-10 p-4 border rounded">
+      <h1 className="text-xl font-bold mb-4">新規演者登録</h1>
+      <form onSubmit={handleSubmit}>
+        <label className="block mb-2">
+          名前:
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="w-full mt-1 p-2 border rounded"
+            required
+          />
+        </label>
+        <label className="block mb-2">
+          メールアドレス:
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full mt-1 p-2 border rounded"
+            required
+          />
+        </label>
+        <label className="block mb-4">
+          プロフィール:
+          <textarea
+            value={profile}
+            onChange={(e) => setProfile(e.target.value)}
+            className="w-full mt-1 p-2 border rounded"
+            rows={4}
+          />
+        </label>
+        <button
+          type="submit"
+          className="bg-blue-500 text-white py-2 px-4 rounded"
+        >
+          登録
+        </button>
+      </form>
+    </div>
+  )
 }
 
-}


### PR DESCRIPTION
## Summary
- implement form UI in `app/talents/new/page.tsx`
- the page now renders a form and calls `handleSubmit`

## Testing
- `npm run lint` *(fails: Invalid Options)*
- `npm run build` *(fails: Supabase URL/API key required)*
- `npm run dev` and `curl http://127.0.0.1:3000/talents/new`

------
https://chatgpt.com/codex/tasks/task_e_68749edbb62c8332a94cd58cc8d9627d