### PR TITLE
Update API base usage

### DIFF
--- a/talentify-next-frontend/.env.example
+++ b/talentify-next-frontend/.env.example
@@ -1,4 +1,5 @@
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+# Base URL for API requests. Leave blank to use the same origin as the frontend.
 NEXT_PUBLIC_API_BASE=http://localhost:3000
 NEXT_PUBLIC_SITE_URL=http://localhost:3000

--- a/talentify-next-frontend/.env.local.example
+++ b/talentify-next-frontend/.env.local.example
@@ -1,4 +1,5 @@
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+# Base URL for API requests. Leave blank to use the same origin as the frontend.
 NEXT_PUBLIC_API_BASE=http://localhost:3000
 NEXT_PUBLIC_SITE_URL=http://localhost:3000

--- a/talentify-next-frontend/app/logout/page.js
+++ b/talentify-next-frontend/app/logout/page.js
@@ -1,8 +1,7 @@
 'use client'
 import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
-
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000'
+import { API_BASE } from '@/lib/api'
 
 export default function LogoutPage() {
   const router = useRouter()

--- a/talentify-next-frontend/app/manage/page.js
+++ b/talentify-next-frontend/app/manage/page.js
@@ -1,5 +1,6 @@
-'use client'
+"use client"
 import { useState, useEffect } from 'react'
+import { API_BASE } from '@/lib/api'
 
 const TABS = ['進行中の契約', 'スケジュール', '履歴', '支払い']
 
@@ -25,7 +26,6 @@ const history = [
   { id: 2, date: '2025/05/28', label: '△△さんトークイベント', reviewed: false },
 ]
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE || ''
 
 function usePayments() {
   const [payments, setPayments] = useState([])

--- a/talentify-next-frontend/app/password-reset/[token]/page.js
+++ b/talentify-next-frontend/app/password-reset/[token]/page.js
@@ -4,8 +4,7 @@ import { useState, useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { EyeIcon, EyeSlashIcon } from "@heroicons/react/24/outline";
-
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE || "http://localhost:5000";
+import { API_BASE } from "@/lib/api";
 
 function isPasswordValid(pwd) {
   return (

--- a/talentify-next-frontend/app/password-reset/page.js
+++ b/talentify-next-frontend/app/password-reset/page.js
@@ -1,8 +1,7 @@
 "use client";
 
 import { useState } from "react";
-
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE || "http://localhost:5000";
+import { API_BASE } from "@/lib/api";
 
 export default function PasswordResetPage() {
   const [email, setEmail] = useState("");

--- a/talentify-next-frontend/app/schedule/page.js
+++ b/talentify-next-frontend/app/schedule/page.js
@@ -1,7 +1,6 @@
 'use client'
 import { useEffect, useState } from 'react'
-
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000'
+import { API_BASE } from '@/lib/api'
 
 export default function SchedulePage() {
   const [items, setItems] = useState([])

--- a/talentify-next-frontend/lib/api.ts
+++ b/talentify-next-frontend/lib/api.ts
@@ -1,0 +1,1 @@
+export const API_BASE = process.env.NEXT_PUBLIC_API_BASE || '';


### PR DESCRIPTION
## Summary
- centralize API base constant in `lib/api.ts`
- replace hard-coded localhost URLs with `API_BASE`
- document `NEXT_PUBLIC_API_BASE` in `.env.example`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Invalid Options)*

------
https://chatgpt.com/codex/tasks/task_e_68749edc48908332b85f80cd85bc97ba