### PR TITLE
Improve type safety for API routes and profile page

### DIFF
--- a/talentify-next-frontend/app/api/offers/[id]/route.ts
+++ b/talentify-next-frontend/app/api/offers/[id]/route.ts
@@ -1,9 +1,12 @@
-import { NextRequest } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 
-export async function PUT(req: NextRequest) {
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
   const supabase = await createClient()
-  const id = req.nextUrl.pathname.split('/').pop()
+  const { id } = params
   const { status } = await req.json()
 
   const { error } = await supabase
@@ -12,16 +15,10 @@ export async function PUT(req: NextRequest) {
     .eq('id', id)
 
   if (error) {
-    return new Response(JSON.stringify({ error: error.message }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return NextResponse.json<{ error: string }>({ error: error.message }, { status: 500 })
   }
 
   // TODO: Notify performer or store about status change
 
-  return new Response(JSON.stringify({ message: '更新しました' }), {
-    status: 200,
-    headers: { 'Content-Type': 'application/json' },
-  })
+  return NextResponse.json<{ message: string }>({ message: '更新しました' }, { status: 200 })
 }

--- a/talentify-next-frontend/app/api/password-reset/[token]/route.ts
+++ b/talentify-next-frontend/app/api/password-reset/[token]/route.ts
@@ -1,7 +1,10 @@
 import { createClient } from '@/lib/supabase/server'
-import { NextRequest } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 
-export async function POST(request: NextRequest, { params }: any) {
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { token: string } }
+) {
   // Supabaseクライアントをawaitで取得
   const supabase = await createClient()
 
@@ -9,7 +12,7 @@ export async function POST(request: NextRequest, { params }: any) {
   const { password, email } = await request.json()
 
   // URLパラメータから token を取得
-  const { token } = params as { token: string }
+  const { token } = params
 
   // OTP（ワンタイムパスワード）検証に email も渡す
   const { error: verifyError } = await supabase.auth.verifyOtp({
@@ -20,15 +23,15 @@ export async function POST(request: NextRequest, { params }: any) {
 
   // 検証エラーの場合は400で返す
   if (verifyError) {
-    return new Response(JSON.stringify({ error: verifyError.message }), { status: 400 })
+    return NextResponse.json<{ error: string }>({ error: verifyError.message }, { status: 400 })
   }
 
   // パスワード更新
   const { error } = await supabase.auth.updateUser({ password })
   if (error) {
-    return new Response(JSON.stringify({ error: error.message }), { status: 500 })
+    return NextResponse.json<{ error: string }>({ error: error.message }, { status: 500 })
   }
 
   // 成功レスポンス
-  return new Response(JSON.stringify({ success: true }), { status: 200 })
+  return NextResponse.json<{ success: boolean }>({ success: true }, { status: 200 })
 }

--- a/talentify-next-frontend/app/api/password-reset/route.ts
+++ b/talentify-next-frontend/app/api/password-reset/route.ts
@@ -1,5 +1,5 @@
 import { createClient } from '@/lib/supabase/server'
-import { NextRequest } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 
 export async function POST(req: NextRequest) {
   // createClient は async 関数なので await を付ける
@@ -13,8 +13,8 @@ export async function POST(req: NextRequest) {
   })
 
   if (error) {
-    return new Response(JSON.stringify({ error: error.message }), { status: 500 })
+    return NextResponse.json<{ error: string }>({ error: error.message }, { status: 500 })
   }
 
-  return new Response(JSON.stringify({ success: true }), { status: 200 })
+  return NextResponse.json<{ success: boolean }>({ success: true }, { status: 200 })
 }

--- a/talentify-next-frontend/app/api/talents/[id]/route.ts
+++ b/talentify-next-frontend/app/api/talents/[id]/route.ts
@@ -1,10 +1,13 @@
-import { NextRequest } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 
-export async function GET(req: NextRequest) {
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
   const supabase = await createClient()
 
-  const id = req.nextUrl.pathname.split('/').pop()
+  const { id } = params
 
   const { data, error } = await supabase
     .from('talents')
@@ -13,21 +16,18 @@ export async function GET(req: NextRequest) {
     .maybeSingle()
 
   if (error) {
-    return new Response(JSON.stringify({ error: error.message }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return NextResponse.json<{ error: string }>({ error: error.message }, { status: 500 })
   }
 
-  return new Response(JSON.stringify(data), {
-    status: 200,
-    headers: { 'Content-Type': 'application/json' },
-  })
+  return NextResponse.json(data, { status: 200 })
 }
 
-export async function PUT(req: NextRequest) {
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
   const supabase = await createClient()
-  const id = req.nextUrl.pathname.split('/').pop()
+  const { id } = params
   const body = await req.json()
 
   const {
@@ -64,21 +64,18 @@ export async function PUT(req: NextRequest) {
     .eq('id', id)
 
   if (error) {
-    return new Response(JSON.stringify({ error: error.message }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return NextResponse.json<{ error: string }>({ error: error.message }, { status: 500 })
   }
 
-  return new Response(JSON.stringify({ message: '更新しました' }), {
-    status: 200,
-    headers: { 'Content-Type': 'application/json' },
-  })
+  return NextResponse.json<{ message: string }>({ message: '更新しました' }, { status: 200 })
 }
 
-export async function DELETE(req: NextRequest) {
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
   const supabase = await createClient()
-  const id = req.nextUrl.pathname.split('/').pop()
+  const { id } = params
 
   const { error } = await supabase
     .from('talents')
@@ -86,14 +83,8 @@ export async function DELETE(req: NextRequest) {
     .eq('id', id)
 
   if (error) {
-    return new Response(JSON.stringify({ error: error.message }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return NextResponse.json<{ error: string }>({ error: error.message }, { status: 500 })
   }
 
-  return new Response(JSON.stringify({ message: '削除しました' }), {
-    status: 200,
-    headers: { 'Content-Type': 'application/json' },
-  })
+  return NextResponse.json<{ message: string }>({ message: '削除しました' }, { status: 200 })
 }

--- a/talentify-next-frontend/app/profile/page.tsx
+++ b/talentify-next-frontend/app/profile/page.tsx
@@ -3,9 +3,18 @@
 import { useEffect, useState } from 'react';
 import { createClient } from '@/utils/supabase/client';
 
+interface Profile {
+  name: string
+  bio: string | null
+  role?: string
+  twitter?: string
+  instagram?: string
+  youtube?: string
+}
+
 export default function ProfilePage() {
   const supabase = createClient();
-  const [profile, setProfile] = useState<any>(null);
+  const [profile, setProfile] = useState<Profile | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- type API responses and params for password reset, talents, and offers
- add profile interface and use typed state in profile page

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Invalid Options)*

------
https://chatgpt.com/codex/tasks/task_e_68749edea3148332b7bd9cf300e67d5f