### PR TITLE
Add offer update notification webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ talentify-next-frontend 目に `.env.local` を作成し、下記を記述:
 
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+NOTIFICATION_WEBHOOK_URL=https://example.com/webhook
+
+`NOTIFICATION_WEBHOOK_URL` はオファーのステータス更新後に通知を送るWebフックのURLです。
 
 ※ `.env.local` は `.gitignore` に含まれています。
 

--- a/talentify-next-frontend/.env.example
+++ b/talentify-next-frontend/.env.example
@@ -2,3 +2,4 @@ NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 NEXT_PUBLIC_API_BASE=http://localhost:3000
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
+NOTIFICATION_WEBHOOK_URL=https://example.com/webhook

--- a/talentify-next-frontend/.env.local.example
+++ b/talentify-next-frontend/.env.local.example
@@ -2,3 +2,4 @@ NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 NEXT_PUBLIC_API_BASE=http://localhost:3000
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
+NOTIFICATION_WEBHOOK_URL=https://example.com/webhook

--- a/talentify-next-frontend/app/api/offers/[id]/route.ts
+++ b/talentify-next-frontend/app/api/offers/[id]/route.ts
@@ -18,7 +18,19 @@ export async function PUT(req: NextRequest) {
     })
   }
 
-  // TODO: Notify performer or store about status change
+  // Notify performer or store about status change via webhook if configured
+  const webhook = process.env.NOTIFICATION_WEBHOOK_URL
+  if (webhook) {
+    try {
+      await fetch(webhook, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ offerId: id, status }),
+      })
+    } catch (err) {
+      console.error('Failed to send notification:', err)
+    }
+  }
 
   return new Response(JSON.stringify({ message: '更新しました' }), {
     status: 200,


### PR DESCRIPTION
## Summary
- send POST request to `NOTIFICATION_WEBHOOK_URL` after offer status updates
- document the webhook variable in README
- add example to `.env.example` and `.env.local.example`

## Testing
- `npm --prefix talentify-next-frontend run lint` *(fails: Invalid Options)*

------
https://chatgpt.com/codex/tasks/task_e_68749edfd7e48332a921ef71bcd52073