### PR TITLE
Refactor profiles references

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,10 @@ Supabase Storage で画像/動画アップロード
 ## Migration Notes
 
 The role string previously stored as `performer` is now `talent`.
-Run the following SQL on Supabase to migrate existing profiles:
+Run the following SQL on Supabase to migrate existing data:
 
 ```sql
-UPDATE profiles SET role = 'talent' WHERE role = 'performer';
+UPDATE talents SET role = 'talent' WHERE role = 'performer';
 ```
 
 📄 ライセンス

--- a/talentify-next-frontend/app/api/profiles/route.ts
+++ b/talentify-next-frontend/app/api/profiles/route.ts
@@ -3,11 +3,10 @@ import { createClient } from '@/lib/supabase/server'
 
 export async function GET() {
   const supabase = await createClient()
-  const { data, error } = await supabase.from('profiles').select('*')
 
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 })
-  }
+  const { data: stores } = await supabase.from('stores').select('*')
+  const { data: talents } = await supabase.from('talents').select('*')
+  const { data: companies } = await supabase.from('companies').select('*')
 
-  return NextResponse.json(data)
+  return NextResponse.json({ stores, talents, companies })
 }

--- a/talentify-next-frontend/app/auth/callback/page.tsx
+++ b/talentify-next-frontend/app/auth/callback/page.tsx
@@ -22,22 +22,17 @@ export default function AuthCallbackPage() {
       const userId = session.user.id
       const role = localStorage.getItem('pending_role') ?? 'store'
 
-      // profiles にレコードがあるか確認
-      const { data: existingProfile } = await supabase
-        .from('profiles')
+      const table = role === 'talent' ? 'talents' : role === 'company' ? 'companies' : 'stores'
+      const { data: existing } = await supabase
+        .from(table)
         .select('id')
         .eq('user_id', userId)
-        .single()
+        .maybeSingle()
 
-      if (!existingProfile) {
-        const { error: insertError } = await supabase.from('profiles').insert([
-          {
-            user_id: userId,
-            role,
-          },
-        ])
+      if (!existing) {
+        const { error: insertError } = await supabase.from(table).insert([{ user_id: userId }])
         if (insertError) {
-          console.error('profiles insert error:', insertError)
+          console.error('profile insert error:', insertError)
           return
         }
       }

--- a/talentify-next-frontend/app/login/page.tsx
+++ b/talentify-next-frontend/app/login/page.tsx
@@ -29,21 +29,12 @@ export default function LoginPage() {
 
     const userId = session.user.id
 
-    // 🔽 profiles にレコードがあるかチェック
-    const { data: existingProfile, error: profileError } = await supabase
-      .from('profiles')
-      .select('id')
-      .eq('user_id', userId)
-      .single()
+    const { data: store } = await supabase.from('stores').select('id').eq('user_id', userId).maybeSingle()
+    const { data: talent } = await supabase.from('talents').select('id').eq('user_id', userId).maybeSingle()
+    const { data: company } = await supabase.from('companies').select('id').eq('user_id', userId).maybeSingle()
 
-    if (!existingProfile) {
-      // 🔽 なければ作成（必要なら role: 'store' や 'talent' を付与）
-      await supabase.from('profiles').insert([
-        {
-          user_id: userId,
-          role: 'store', // ←仮に "store" としておく。条件分岐してもOK
-        }
-      ])
+    if (!store && !talent && !company) {
+      await supabase.from('stores').insert([{ user_id: userId }])
     }
 
     router.push('/dashboard')

--- a/talentify-next-frontend/app/store/edit/page.tsx
+++ b/talentify-next-frontend/app/store/edit/page.tsx
@@ -25,7 +25,7 @@ export default function StoreProfileEditPage() {
       }
 
       const { data, error } = await supabase
-        .from('profiles')
+        .from('stores')
         .select('display_name, bio, avatar_url')
         .eq('user_id', user.id)
         .single()
@@ -64,7 +64,7 @@ export default function StoreProfileEditPage() {
   })
 
   const { error } = await supabase
-    .from('profiles')
+    .from('stores')
     .upsert(
       {
         ...profile,

--- a/talentify-next-frontend/app/talent/edit/page.tsx
+++ b/talentify-next-frontend/app/talent/edit/page.tsx
@@ -49,16 +49,7 @@ export default function TalentProfileEditPage() {
     const { data: { user } } = await supabase.auth.getUser()
     if (!user) return
 
-    // ✅ Step 1: profiles に user.id を upsert（存在しないとき用）
-    const { error: profileError } = await supabase
-      .from('profiles')
-      .upsert({ id: user.id })
 
-    if (profileError) {
-      console.error('profiles の作成に失敗:', profileError)
-      alert('保存に失敗しました（ユーザー情報）')
-      return
-    }
 
     // 🔸 Step 2: talents テーブルに保存 or 更新
     const updateData = {

--- a/talentify-next-frontend/components/Header.tsx
+++ b/talentify-next-frontend/components/Header.tsx
@@ -1,34 +1,16 @@
 'use client'
 
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { Menu, X } from 'lucide-react'
 import { createClient } from '@/utils/supabase/client'
+import { useUserRole } from '@/utils/useRole'
 
 const supabase = createClient()
 
 export default function Header() {
-  const [role, setRole] = useState<string | null>(null)
+  const { role } = useUserRole()
   const [isOpen, setIsOpen] = useState(false)
-
-  useEffect(() => {
-    const fetchRole = async () => {
-      const { data: { user } } = await supabase.auth.getUser()
-      if (!user) return
-
-      const { data } = await supabase
-        .from('profiles')
-        .select('role')
-        .eq('user_id', user.id)
-        .single()
-
-      if (data?.role) {
-        setRole(data.role)
-      }
-    }
-
-    fetchRole()
-  }, [])
 
   return (
     <header className="sticky top-0 z-50 bg-white/80 backdrop-blur border-b">

--- a/talentify-next-frontend/lib/supabase/types.ts
+++ b/talentify-next-frontend/lib/supabase/types.ts
@@ -2,11 +2,25 @@
 export type Database = {
   public: {
     Tables: {
-      profiles: {
+      stores: {
         Row: {
           id: string
-          role: 'talent' | 'store' | null
-          // 必要に応じて他のカラムも追記
+          user_id: string
+          role: 'store'
+        }
+      }
+      talents: {
+        Row: {
+          id: string
+          user_id: string
+          role: 'talent'
+        }
+      }
+      companies: {
+        Row: {
+          id: string
+          user_id: string
+          role: 'company'
         }
       }
     }

--- a/talentify-next-frontend/utils/useRole.ts
+++ b/talentify-next-frontend/utils/useRole.ts
@@ -11,15 +11,15 @@ export function useUserRole() {
   useEffect(() => {
     const fetchRole = async () => {
       const { data: { user } } = await supabase.auth.getUser()
-      if (!user) return
+      if (!user) { setLoading(false); return }
 
-      const { data, error } = await supabase
-        .from('profiles')
-        .select('role')
-        .eq('user_id', user.id)
-        .single()
+      const { data: store } = await supabase.from('stores').select('id').eq('user_id', user.id).maybeSingle()
+      const { data: talent } = await supabase.from('talents').select('id').eq('user_id', user.id).maybeSingle()
+      const { data: company } = await supabase.from('companies').select('id').eq('user_id', user.id).maybeSingle()
 
-      if (data?.role) setRole(data.role)
+      if (store) setRole('store')
+      else if (talent) setRole('talent')
+      else if (company) setRole('company')
       setLoading(false)
     }
 

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -9,7 +9,37 @@
 export type Database = {
   public: {
     Tables: {
-      profiles: {
+      stores: {
+        Row: {
+          avatar_url: string | null
+          bio: string | null
+          created_at: string | null
+          display_name: string
+          id: string
+          updated_at: string | null
+          user_id: string
+        }
+        Insert: {
+          avatar_url?: string | null
+          bio?: string | null
+          created_at?: string | null
+          display_name: string
+          id?: string
+          updated_at?: string | null
+          user_id: string
+        }
+        Update: {
+          avatar_url?: string | null
+          bio?: string | null
+          created_at?: string | null
+          display_name?: string
+          id?: string
+          updated_at?: string | null
+          user_id?: string
+        }
+        Relationships: []
+      }
+      companies: {
         Row: {
           avatar_url: string | null
           bio: string | null


### PR DESCRIPTION
## Summary
- use table-specific role detection across the app
- query stores, talents or companies instead of profiles
- update Supabase type definitions
- adjust API route to return all role tables
- fix login and dashboard role logic

## Testing
- `npm run lint` *(fails: Unknown options)*
- `npm run build` *(fails: Bus error)*

------
https://chatgpt.com/codex/tasks/task_e_68749edd7d708332a30e9bce6701a275