### PR TITLE
Implement cast search UI

### DIFF
--- a/talentify-next-frontend/app/talents/page.tsx
+++ b/talentify-next-frontend/app/talents/page.tsx
@@ -1,49 +1,5 @@
-'use client'
-
-import { useEffect, useState } from 'react'
-import TalentCard from '../../components/TalentCard'
-import { supabase } from '@/lib/supabase'  // ← ここを追加
+import TalentSearchPage from '@/components/talent-search/TalentSearchPage'
 
 export default function TalentsPage() {
-  const [talents, setTalents] = useState([])
-  const [query, setQuery] = useState('')
-
-  useEffect(() => {
-    const fetchTalents = async () => {
-      const { data, error } = await supabase.from('talents').select('*')
-      if (error) {
-        console.error('Failed to fetch talents:', error)
-      } else {
-        setTalents(data || [])
-      }
-    }
-    fetchTalents()
-  }, [])
-
-  const normalized = query.toLowerCase()
-  const filtered = talents.filter(t =>
-    t.name.toLowerCase().includes(normalized) ||
-    (t.skills || []).some(s => s.toLowerCase().includes(normalized))
-  )
-
-  return (
-    <main className="max-w-4xl mx-auto p-4">
-      <h1 className="text-2xl font-bold mb-4">演者を探す</h1>
-      <input
-        type="text"
-        value={query}
-        onChange={e => setQuery(e.target.value)}
-        placeholder="名前・スキルで検索"
-        className="w-full p-2 border rounded mb-6"
-      />
-      <div className="grid gap-4 md:grid-cols-2">
-        {filtered.map(t => (
-          <TalentCard key={t.id} talent={t} />
-        ))}
-        {filtered.length === 0 && (
-          <p>該当する演者が見つかりませんでした。</p>
-        )}
-      </div>
-    </main>
-  )
+  return <TalentSearchPage />
 }

--- a/talentify-next-frontend/components/talent-search/TalentCard.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentCard.tsx
@@ -1,0 +1,41 @@
+import Image from 'next/image'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card'
+
+export type Talent = {
+  id: number
+  name: string
+  genre: string
+  gender: string
+  ageGroup: string
+  location: string
+  bio: string
+  agency?: string
+  avatar: string
+}
+
+export default function TalentCard({ talent }: { talent: Talent }) {
+  return (
+    <Card className="flex flex-col transition-transform hover:shadow-md hover:scale-[1.02]">
+      <CardHeader className="flex items-center gap-3">
+        <div className="w-16 h-16 rounded-full overflow-hidden bg-gray-100">
+          <Image src={talent.avatar} alt={talent.name} width={64} height={64} className="object-cover w-full h-full" />
+        </div>
+        <div className="text-lg font-semibold">{talent.name}</div>
+      </CardHeader>
+      <CardContent className="text-sm space-y-1">
+        <p className="text-gray-600">
+          {talent.genre}・{talent.location}
+        </p>
+        <p className="line-clamp-2">{talent.bio}</p>
+        {talent.agency && <p className="text-xs text-gray-500">所属: {talent.agency}</p>}
+      </CardContent>
+      <CardFooter className="mt-auto flex gap-2">
+        <Button variant="outline" className="flex-1">
+          詳細を見る
+        </Button>
+        <Button className="flex-1">オファーする</Button>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/talentify-next-frontend/components/talent-search/TalentList.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentList.tsx
@@ -1,0 +1,18 @@
+import TalentCard, { Talent } from './TalentCard'
+
+export default function TalentList({ talents }: { talents: Talent[] }) {
+  if (talents.length === 0) {
+    return <p className="p-4">該当するキャストが見つかりませんでした。</p>
+  }
+
+  return (
+    <>
+      <p className="mb-4 text-sm text-gray-700">検索結果：{talents.length}件</p>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {talents.map(t => (
+          <TalentCard key={t.id} talent={t} />
+        ))}
+      </div>
+    </>
+  )
+}

--- a/talentify-next-frontend/components/talent-search/TalentSearchForm.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentSearchForm.tsx
@@ -1,0 +1,68 @@
+'use client'
+import { useState } from 'react'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+export type SearchFilters = {
+  keyword: string
+  genre: string
+  gender: string
+  age: string
+  location: string
+}
+
+const GENRES = ['バラエティ', 'アイドル', 'お笑い', 'レポーター']
+const GENDERS = ['男性', '女性', 'その他']
+const AGES = ['10代', '20代', '30代', '40代', '50代以上']
+const LOCATIONS = ['東京', '大阪', '福岡', '北海道']
+
+export default function TalentSearchForm({ onSearch }: { onSearch: (f: SearchFilters) => void }) {
+  const [keyword, setKeyword] = useState('')
+  const [genre, setGenre] = useState('')
+  const [gender, setGender] = useState('')
+  const [age, setAge] = useState('')
+  const [location, setLocation] = useState('')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    onSearch({ keyword, genre, gender, age, location })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2 md:grid md:grid-cols-5 md:gap-3 md:space-y-0">
+      <Input
+        placeholder="キーワード"
+        value={keyword}
+        onChange={e => setKeyword(e.target.value)}
+        className="md:col-span-1"
+      />
+      <select value={genre} onChange={e => setGenre(e.target.value)} className="h-9 rounded-md border px-2 md:col-span-1">
+        <option value="">ジャンル</option>
+        {GENRES.map(g => (
+          <option key={g} value={g}>{g}</option>
+        ))}
+      </select>
+      <select value={gender} onChange={e => setGender(e.target.value)} className="h-9 rounded-md border px-2 md:col-span-1">
+        <option value="">性別</option>
+        {GENDERS.map(g => (
+          <option key={g} value={g}>{g}</option>
+        ))}
+      </select>
+      <select value={age} onChange={e => setAge(e.target.value)} className="h-9 rounded-md border px-2 md:col-span-1">
+        <option value="">年齢層</option>
+        {AGES.map(a => (
+          <option key={a} value={a}>{a}</option>
+        ))}
+      </select>
+      <select value={location} onChange={e => setLocation(e.target.value)} className="h-9 rounded-md border px-2 md:col-span-1">
+        <option value="">居住地</option>
+        {LOCATIONS.map(l => (
+          <option key={l} value={l}>{l}</option>
+        ))}
+      </select>
+      <div className="md:col-span-5 text-right">
+        <Button type="submit">検索</Button>
+      </div>
+    </form>
+  )
+}

--- a/talentify-next-frontend/components/talent-search/TalentSearchPage.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentSearchPage.tsx
@@ -1,0 +1,96 @@
+'use client'
+import { useState } from 'react'
+import TalentSearchForm, { SearchFilters } from './TalentSearchForm'
+import TalentList from './TalentList'
+import { Talent } from './TalentCard'
+
+const SAMPLE_TALENTS: Talent[] = [
+  {
+    id: 1,
+    name: '山田 花子',
+    genre: 'アイドル',
+    gender: '女性',
+    ageGroup: '20代',
+    location: '東京',
+    bio: '歌とダンスが得意です。明るく元気に盛り上げます！',
+    agency: 'ABCプロダクション',
+    avatar: 'https://example.com/avatar1.jpg',
+  },
+  {
+    id: 2,
+    name: '佐藤 太郎',
+    genre: 'お笑い',
+    gender: '男性',
+    ageGroup: '30代',
+    location: '大阪',
+    bio: '関西弁で楽しくトークします。テレビ出演経験あり。',
+    agency: 'XYZエンターテインメント',
+    avatar: 'https://example.com/avatar2.jpg',
+  },
+  {
+    id: 3,
+    name: '鈴木 一郎',
+    genre: 'レポーター',
+    gender: '男性',
+    ageGroup: '40代',
+    location: '福岡',
+    bio: '冷静な実況レポートが得意です。全国各地の取材経験豊富。',
+    avatar: 'https://example.com/avatar3.jpg',
+  },
+  {
+    id: 4,
+    name: '高橋 真美',
+    genre: 'バラエティ',
+    gender: '女性',
+    ageGroup: '30代',
+    location: '東京',
+    bio: 'バラエティ番組を中心に活動中。明るさが武器です。',
+    avatar: 'https://example.com/avatar4.jpg',
+  },
+]
+
+const ITEMS_PER_PAGE = 6
+
+export default function TalentSearchPage() {
+  const [talents] = useState<Talent[]>(SAMPLE_TALENTS)
+  const [results, setResults] = useState<Talent[]>(SAMPLE_TALENTS)
+  const [page, setPage] = useState(1)
+
+  const handleSearch = (f: SearchFilters) => {
+    const keyword = f.keyword.toLowerCase()
+    const filtered = talents.filter(t =>
+      (!f.keyword || t.name.toLowerCase().includes(keyword) || t.genre.includes(keyword)) &&
+      (!f.genre || t.genre === f.genre) &&
+      (!f.gender || t.gender === f.gender) &&
+      (!f.age || t.ageGroup === f.age) &&
+      (!f.location || t.location === f.location)
+    )
+    setResults(filtered)
+    setPage(1)
+  }
+
+  const totalPages = Math.ceil(results.length / ITEMS_PER_PAGE) || 1
+  const paginated = results.slice((page - 1) * ITEMS_PER_PAGE, page * ITEMS_PER_PAGE)
+
+  return (
+    <main className="max-w-5xl mx-auto p-4 space-y-6">
+      <TalentSearchForm onSearch={handleSearch} />
+      <TalentList talents={paginated} />
+      {totalPages > 1 && (
+        <div className="flex justify-center mt-6">
+          <nav className="flex space-x-2">
+            {Array.from({ length: totalPages }, (_, i) => i + 1).map(p => (
+              <button
+                key={p}
+                onClick={() => setPage(p)}
+                className={`px-3 py-1 border rounded ${p === page ? 'bg-blue-600 text-white' : 'bg-white'}`}
+              >
+                {p}
+              </button>
+            ))}
+          </nav>
+        </div>
+      )}
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- add a component suite for searching talents
- show example search page with dummy data
- replace `/talents` route with the new `TalentSearchPage`

## Testing
- `npm run lint` *(fails: Invalid Options)*

------
https://chatgpt.com/codex/tasks/task_e_6874c9c776148332bdbbf0d38e1378de