### PR TITLE
Update Supabase talent types

### DIFF
--- a/talentify-next-frontend/types/supabase.ts
+++ b/talentify-next-frontend/types/supabase.ts
@@ -5,11 +5,27 @@ export interface Database {
         Row: {
           id: string
           name: string
+          stage_name: string
+          birthdate: string
+          gender: string
+          residence: string
+          birthplace: string
+          height_cm: number
+          agency_name: string
           email: string
           profile: string
           sns_links: string[]
+          social_x: string
+          social_instagram: string
+          social_youtube: string
+          social_tiktok: string
+          photos: string[]
           area: string
           bio: string
+          bio_hobby: string
+          bio_certifications: string
+          bio_others: string
+          media_appearance: string
           skills: string[]
           experience_years: number
           avatar_url: string

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -102,9 +102,25 @@ export type Database = {
           availability: string | null
           avatar_url: string | null
           bio: string | null
+          bio_hobby: string | null
+          bio_certifications: string | null
+          bio_others: string | null
           created_at: string | null
+          stage_name: string | null
+          birthdate: string | null
+          gender: string | null
+          residence: string | null
+          birthplace: string | null
+          height_cm: number | null
+          agency_name: string | null
           email: string
           experience_years: number | null
+          social_x: string | null
+          social_instagram: string | null
+          social_youtube: string | null
+          social_tiktok: string | null
+          photos: string[] | null
+          media_appearance: string | null
           id: string
           location: string | null
           name: string
@@ -118,9 +134,25 @@ export type Database = {
           availability?: string | null
           avatar_url?: string | null
           bio?: string | null
+          bio_hobby?: string | null
+          bio_certifications?: string | null
+          bio_others?: string | null
           created_at?: string | null
+          stage_name?: string | null
+          birthdate?: string | null
+          gender?: string | null
+          residence?: string | null
+          birthplace?: string | null
+          height_cm?: number | null
+          agency_name?: string | null
           email: string
           experience_years?: number | null
+          social_x?: string | null
+          social_instagram?: string | null
+          social_youtube?: string | null
+          social_tiktok?: string | null
+          photos?: string[] | null
+          media_appearance?: string | null
           id?: string
           location?: string | null
           name: string
@@ -134,9 +166,25 @@ export type Database = {
           availability?: string | null
           avatar_url?: string | null
           bio?: string | null
+          bio_hobby?: string | null
+          bio_certifications?: string | null
+          bio_others?: string | null
           created_at?: string | null
+          stage_name?: string | null
+          birthdate?: string | null
+          gender?: string | null
+          residence?: string | null
+          birthplace?: string | null
+          height_cm?: number | null
+          agency_name?: string | null
           email?: string
           experience_years?: number | null
+          social_x?: string | null
+          social_instagram?: string | null
+          social_youtube?: string | null
+          social_tiktok?: string | null
+          photos?: string[] | null
+          media_appearance?: string | null
           id?: string
           location?: string | null
           name?: string


### PR DESCRIPTION
## Summary
- expand `talents` table definition with additional profile fields in `types/supabase.ts`
- sync Next.js project's Supabase types

## Testing
- `npm install` *(fails: 1 high severity vulnerability)*
- `npm run lint` *(fails: Invalid Options)*

------
https://chatgpt.com/codex/tasks/task_e_6875a6e52a508332919b74536661f165