### PR TITLE
Add store contracts page

### DIFF
--- a/talentify-next-frontend/app/store/contracts/page.tsx
+++ b/talentify-next-frontend/app/store/contracts/page.tsx
@@ -1,0 +1,43 @@
+import { getContractsForStore } from '@/lib/contracts'
+
+export default async function StoreContractsPage() {
+  const contracts = await getContractsForStore()
+
+  return (
+    <main className="max-w-4xl mx-auto p-6 space-y-4">
+      <h1 className="text-2xl font-bold">契約書一覧</h1>
+      {contracts.length === 0 ? (
+        <p>契約書はまだありません。</p>
+      ) : (
+        <table className="w-full text-sm border-collapse">
+          <thead>
+            <tr className="text-left">
+              <th className="p-2 border-b">オファーID</th>
+              <th className="p-2 border-b">演者名</th>
+              <th className="p-2 border-b">出演日</th>
+              <th className="p-2 border-b">金額</th>
+              <th className="p-2 border-b">PDF</th>
+            </tr>
+          </thead>
+          <tbody>
+            {contracts.map((c) => (
+              <tr key={c.offer_id} className="border-t">
+                <td className="p-2">{c.offer_id}</td>
+                <td className="p-2">{c.talent_name}</td>
+                <td className="p-2">{c.performance_date}</td>
+                <td className="p-2">{c.amount != null ? `¥${c.amount.toLocaleString()}` : '-'}</td>
+                <td className="p-2">
+                  {c.pdf_url ? (
+                    <a href={c.pdf_url} target="_blank" className="text-blue-600 underline">ダウンロード</a>
+                  ) : (
+                    '---'
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </main>
+  )
+}

--- a/talentify-next-frontend/lib/contracts.ts
+++ b/talentify-next-frontend/lib/contracts.ts
@@ -1,0 +1,54 @@
+export type StoreContract = {
+  offer_id: string
+  talent_name: string
+  performance_date: string
+  amount: number | null
+  pdf_url: string | null
+}
+
+import { createClient } from '@/lib/supabase/server'
+
+export async function getContractsForStore(): Promise<StoreContract[]> {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return []
+
+  const { data: offers } = await supabase
+    .from('offers')
+    .select('id, talent_id, date')
+    .eq('user_id', user.id)
+
+  if (!offers) return []
+
+  const results: StoreContract[] = []
+
+  for (const offer of offers) {
+    const { data: talent } = await supabase
+      .from('talents')
+      .select('stage_name')
+      .eq('id', offer.talent_id)
+      .maybeSingle()
+
+    const { data: payment } = await supabase
+      .from('payments')
+      .select('amount')
+      .eq('offer_id', offer.id)
+      .maybeSingle()
+
+    const { data } = supabase.storage
+      .from('contracts')
+      .getPublicUrl(`${offer.id}.pdf`)
+
+    results.push({
+      offer_id: offer.id,
+      talent_name: talent?.stage_name || '',
+      performance_date: offer.date,
+      amount: payment?.amount ?? null,
+      pdf_url: data.publicUrl || null,
+    })
+  }
+
+  return results
+}


### PR DESCRIPTION
## Summary
- add helper to fetch contracts for a store
- show contract PDFs under `/store/contracts`

## Testing
- `npm install` in `talentify-next-frontend`
- `npx next lint` *(fails: Invalid Options)*

------
https://chatgpt.com/codex/tasks/task_e_6875adf30b3c8332b32e9e9a3a30016e