### PR TITLE
Add store offers page with shadcn UI

### DIFF
--- a/talentify-next-frontend/app/store/offers/page.tsx
+++ b/talentify-next-frontend/app/store/offers/page.tsx
@@ -1,0 +1,132 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { getOffersForStore, Offer } from '@/utils/getOffersForStore'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { Button } from '@/components/ui/button'
+import {
+  Modal,
+  ModalTrigger,
+  ModalContent,
+  ModalHeader,
+  ModalTitle,
+  ModalFooter,
+  ModalClose,
+} from '@/components/ui/modal'
+
+const statusLabels: Record<string, string> = {
+  pending: '保留中',
+  approved: '承認済み',
+  rejected: '拒否',
+  expired: '期限切れ',
+}
+
+export default function StoreOffersPage() {
+  const [offers, setOffers] = useState<Offer[]>([])
+  const [filter, setFilter] = useState<string>('all')
+  const [sortKey, setSortKey] = useState<'date' | 'created_at'>('date')
+  const [selected, setSelected] = useState<Offer | null>(null)
+
+  useEffect(() => {
+    const load = async () => {
+      const data = await getOffersForStore()
+      setOffers(data)
+    }
+    load()
+  }, [])
+
+  const filtered = offers.filter(o => (filter === 'all' ? true : o.status === filter))
+  const sorted = [...filtered].sort((a, b) => {
+    const aa = a[sortKey] || ''
+    const bb = b[sortKey] || ''
+    return aa < bb ? -1 : aa > bb ? 1 : 0
+  })
+
+  const groups: Record<string, Offer[]> = {
+    pending: [],
+    approved: [],
+    rejected: [],
+    expired: [],
+  }
+  for (const o of sorted) {
+    const key = o.status || 'pending'
+    if (groups[key]) groups[key].push(o)
+  }
+
+  return (
+    <main className="p-6 space-y-6">
+      <h1 className="text-2xl font-bold">オファー一覧</h1>
+
+      <div className="flex gap-4 items-center text-sm">
+        <select
+          value={filter}
+          onChange={e => setFilter(e.target.value)}
+          className="border rounded p-1"
+        >
+          <option value="all">すべて</option>
+          <option value="pending">保留中</option>
+          <option value="approved">承認済み</option>
+          <option value="rejected">拒否</option>
+          <option value="expired">期限切れ</option>
+        </select>
+        <select
+          value={sortKey}
+          onChange={e => setSortKey(e.target.value as 'date' | 'created_at')}
+          className="border rounded p-1"
+        >
+          <option value="date">日付順</option>
+          <option value="created_at">作成順</option>
+        </select>
+      </div>
+
+      {(['pending', 'approved', 'rejected', 'expired'] as const).map(status => (
+        groups[status].length > 0 && (
+          <div key={status} className="space-y-2">
+            <h2 className="font-semibold">{statusLabels[status]}</h2>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>日付</TableHead>
+                  <TableHead>メッセージ</TableHead>
+                  <TableHead>操作</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {groups[status].map(o => (
+                  <TableRow key={o.id}>
+                    <TableCell>{o.date}</TableCell>
+                    <TableCell className="truncate max-w-xs">{o.message}</TableCell>
+                    <TableCell>
+                      <Modal onOpenChange={open => !open && setSelected(null)}>
+                        <ModalTrigger asChild>
+                          <Button size="sm" onClick={() => setSelected(o)}>
+                            詳細を見る
+                          </Button>
+                        </ModalTrigger>
+                        <ModalContent>
+                          <ModalHeader>
+                            <ModalTitle>オファー詳細</ModalTitle>
+                          </ModalHeader>
+                          <p className="text-sm whitespace-pre-line mb-4">{selected?.message}</p>
+                          <ModalFooter>
+                            <Button asChild variant="outline">
+                              <Link href={`/store/offers/${selected?.id}`}>詳細ページへ</Link>
+                            </Button>
+                            <ModalClose asChild>
+                              <Button variant="secondary">閉じる</Button>
+                            </ModalClose>
+                          </ModalFooter>
+                        </ModalContent>
+                      </Modal>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )
+      ))}
+    </main>
+  )
+}

--- a/talentify-next-frontend/components/ui/modal.tsx
+++ b/talentify-next-frontend/components/ui/modal.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import * as React from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { X } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+export const Modal = DialogPrimitive.Root
+export const ModalTrigger = DialogPrimitive.Trigger
+export const ModalClose = DialogPrimitive.Close
+
+export function ModalOverlay({ className, ...props }: DialogPrimitive.DialogOverlayProps) {
+  return (
+    <DialogPrimitive.Overlay
+      className={cn(
+        'fixed inset-0 z-50 bg-black/50 backdrop-blur-sm',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export const ModalPortal = DialogPrimitive.Portal
+
+export const ModalContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <ModalPortal>
+    <ModalOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-1/2 top-1/2 z-50 w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-md bg-white p-6 shadow-md',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-2 top-2 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none">
+        <X className="h-4 w-4" />
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </ModalPortal>
+))
+ModalContent.displayName = DialogPrimitive.Content.displayName
+
+export function ModalHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('mb-4', className)} {...props} />
+}
+
+export function ModalTitle({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+  return <h2 className={cn('text-lg font-semibold', className)} {...props} />
+}
+
+export function ModalFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('mt-4 flex justify-end gap-2', className)} {...props} />
+}

--- a/talentify-next-frontend/components/ui/table.tsx
+++ b/talentify-next-frontend/components/ui/table.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export function Table({ className, ...props }: React.HTMLAttributes<HTMLTableElement>) {
+  return <table className={cn('w-full caption-bottom text-sm', className)} {...props} />
+}
+
+export function TableHeader({ className, ...props }: React.HTMLAttributes<HTMLTableSectionElement>) {
+  return <thead className={cn('[&_tr]:border-b', className)} {...props} />
+}
+
+export function TableBody({ className, ...props }: React.HTMLAttributes<HTMLTableSectionElement>) {
+  return <tbody className={cn('[&_tr:last-child]:border-0', className)} {...props} />
+}
+
+export function TableRow({ className, ...props }: React.HTMLAttributes<HTMLTableRowElement>) {
+  return <tr className={cn('border-b transition-colors hover:bg-muted/50', className)} {...props} />
+}
+
+export function TableHead({ className, ...props }: React.ThHTMLAttributes<HTMLTableCellElement>) {
+  return <th className={cn('h-12 px-2 text-left align-middle font-medium text-muted-foreground', className)} {...props} />
+}
+
+export function TableCell({ className, ...props }: React.TdHTMLAttributes<HTMLTableCellElement>) {
+  return <td className={cn('p-2 align-middle', className)} {...props} />
+}
+
+export function TableCaption({ className, ...props }: React.HTMLAttributes<HTMLTableCaptionElement>) {
+  return <caption className={cn('mt-4 text-sm text-muted-foreground', className)} {...props} />
+}

--- a/talentify-next-frontend/package-lock.json
+++ b/talentify-next-frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
+        "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-slot": "^1.2.3",
         "@supabase/auth-helpers-nextjs": "^0.10.0",
@@ -739,6 +740,42 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.14.tgz",
+      "integrity": "sha512-+CpweKjqpzTmwRwcYECQcNYbI8V9VSQt0SNFKeEBLgfucbsLssU6Ppq7wUdNXEGb573bMjFhVjKVll8rmV6zMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.10",
+        "@radix-ui/react-focus-guards": "1.1.2",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/talentify-next-frontend/package.json
+++ b/talentify-next-frontend/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
+    "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-slot": "^1.2.3",
     "@supabase/auth-helpers-nextjs": "^0.10.0",

--- a/talentify-next-frontend/utils/getOffersForStore.ts
+++ b/talentify-next-frontend/utils/getOffersForStore.ts
@@ -1,0 +1,33 @@
+'use client'
+
+import { createClient } from '@/utils/supabase/client'
+
+const supabase = createClient()
+
+export type Offer = {
+  id: string
+  user_id: string
+  talent_id: string
+  message: string
+  date: string
+  created_at: string | null
+  status: string | null
+}
+
+export async function getOffersForStore() {
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return [] as Offer[]
+
+  const { data, error } = await supabase
+    .from('offers')
+    .select('*')
+    .eq('user_id', user.id)
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    console.error('failed to fetch offers:', error)
+    return [] as Offer[]
+  }
+
+  return (data ?? []) as Offer[]
+}


### PR DESCRIPTION
## Summary
- add Table and Modal components
- add `getOffersForStore` helper for fetching offers
- build store offers page using new components
- install `@radix-ui/react-dialog`

## Testing
- `npm run lint` *(fails: Invalid Options)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6875adef7e908332a2552fc0fa5678c8