### PR TITLE
Fix talent insert

### DIFF
--- a/talentify-next-frontend/app/dashboard/page.tsx
+++ b/talentify-next-frontend/app/dashboard/page.tsx
@@ -44,7 +44,7 @@ export default function DashboardRedirectPage() {
       console.log('pendingRole:', pendingRole)
 
       if (pendingRole === 'talent') {
-        const { error } = await supabase.from('talents').insert([{ user_id: userId }])
+        const { error } = await supabase.from('talents').insert([{ user_id: userId, name: '' }])
         if (error) console.error('talent insert error:', error.message)
         router.replace('/talent/edit')
         return


### PR DESCRIPTION
## Summary
- fix the talent insert logic to set a placeholder name

## Testing
- `npm install` in `talentify-next-frontend`
- `npx next lint` *(fails: Invalid Options)*

------
https://chatgpt.com/codex/tasks/task_e_68770bff4c2483329127391ccec1bd55