### PR TITLE
Set app to force dynamic rendering

### DIFF
--- a/talentify-next-frontend/app/api/csrf-token/route.ts
+++ b/talentify-next-frontend/app/api/csrf-token/route.ts
@@ -1,5 +1,4 @@
 export const runtime = 'nodejs'
-export const dynamic = 'force-dynamic'
 
 import { cookies } from 'next/headers'
 import { randomBytes } from 'crypto'

--- a/talentify-next-frontend/app/api/logout/route.ts
+++ b/talentify-next-frontend/app/api/logout/route.ts
@@ -1,4 +1,3 @@
-export const dynamic = 'force-dynamic'
 import { createClient } from '@/lib/supabase/server'
 
 

--- a/talentify-next-frontend/app/api/messages/route.ts
+++ b/talentify-next-frontend/app/api/messages/route.ts
@@ -1,4 +1,3 @@
-export const dynamic = 'force-dynamic'
 import { createClient } from '@/lib/supabase/server'
 import { NextRequest, NextResponse } from 'next/server'
 

--- a/talentify-next-frontend/app/api/offers/[id]/route.ts
+++ b/talentify-next-frontend/app/api/offers/[id]/route.ts
@@ -1,4 +1,3 @@
-export const dynamic = 'force-dynamic'
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 

--- a/talentify-next-frontend/app/api/password-reset/[token]/route.ts
+++ b/talentify-next-frontend/app/api/password-reset/[token]/route.ts
@@ -1,4 +1,3 @@
-export const dynamic = 'force-dynamic'
 import { createClient } from '@/lib/supabase/server'
 import { NextRequest, NextResponse } from 'next/server'
 

--- a/talentify-next-frontend/app/api/password-reset/route.ts
+++ b/talentify-next-frontend/app/api/password-reset/route.ts
@@ -1,4 +1,3 @@
-export const dynamic = 'force-dynamic'
 import { createClient } from '@/lib/supabase/server'
 import { NextRequest, NextResponse } from 'next/server'
 

--- a/talentify-next-frontend/app/api/payments/route.ts
+++ b/talentify-next-frontend/app/api/payments/route.ts
@@ -1,4 +1,3 @@
-export const dynamic = 'force-dynamic'
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 

--- a/talentify-next-frontend/app/api/profiles/route.ts
+++ b/talentify-next-frontend/app/api/profiles/route.ts
@@ -1,4 +1,3 @@
-export const dynamic = 'force-dynamic'
 import { NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 

--- a/talentify-next-frontend/app/api/schedule/route.ts
+++ b/talentify-next-frontend/app/api/schedule/route.ts
@@ -1,4 +1,3 @@
-export const dynamic = 'force-dynamic'
 import { createClient } from '@/lib/supabase/server'
 import { NextRequest } from 'next/server'
 

--- a/talentify-next-frontend/app/api/talents/[id]/route.ts
+++ b/talentify-next-frontend/app/api/talents/[id]/route.ts
@@ -1,4 +1,3 @@
-export const dynamic = 'force-dynamic'
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 

--- a/talentify-next-frontend/app/api/talents/route.ts
+++ b/talentify-next-frontend/app/api/talents/route.ts
@@ -1,4 +1,3 @@
-export const dynamic = 'force-dynamic'
 import { createClient } from '@/lib/supabase/server'
 
 export async function GET() {

--- a/talentify-next-frontend/app/api/users/route.ts
+++ b/talentify-next-frontend/app/api/users/route.ts
@@ -1,4 +1,3 @@
-export const dynamic = 'force-dynamic'
 import { createClient } from '@/lib/supabase/server'
 
 export async function GET() {

--- a/talentify-next-frontend/app/auth/callback/page.tsx
+++ b/talentify-next-frontend/app/auth/callback/page.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-export const dynamic = 'force-dynamic'
 import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { createClient } from '@/utils/supabase/client'

--- a/talentify-next-frontend/app/layout.tsx
+++ b/talentify-next-frontend/app/layout.tsx
@@ -1,5 +1,7 @@
 // app/layout.tsx
 
+export const dynamic = 'force-dynamic'
+
 import React from "react"
 import "./globals.css"
 import Header from "../components/Header"

--- a/talentify-next-frontend/app/login/page.tsx
+++ b/talentify-next-frontend/app/login/page.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-export const dynamic = 'force-dynamic'
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { createClient } from '@/utils/supabase/client'

--- a/talentify-next-frontend/app/messages/page.js
+++ b/talentify-next-frontend/app/messages/page.js
@@ -1,5 +1,4 @@
 'use client'
-export const dynamic = 'force-dynamic'
 import { useState, useEffect, useRef, useMemo } from 'react'
 import Image from 'next/image'
 import { createClient } from '@/utils/supabase/client'

--- a/talentify-next-frontend/app/profile/page.tsx
+++ b/talentify-next-frontend/app/profile/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-export const dynamic = 'force-dynamic'
 
 import { useEffect, useState } from 'react';
 import { createClient } from '@/utils/supabase/client';

--- a/talentify-next-frontend/app/store/dashboard/page.tsx
+++ b/talentify-next-frontend/app/store/dashboard/page.tsx
@@ -1,7 +1,6 @@
 // /app/store/dashboard/page.tsx
 "use client"
 
-export const dynamic = 'force-dynamic'
 
 import { useEffect, useState } from "react"
 import { createClient } from "@/utils/supabase/client"

--- a/talentify-next-frontend/app/store/edit/page.tsx
+++ b/talentify-next-frontend/app/store/edit/page.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-export const dynamic = 'force-dynamic'
 import { useEffect, useState } from 'react'
 import { createClient } from '@/utils/supabase/client'
 import { Input } from "@/components/ui/input"

--- a/talentify-next-frontend/app/store/messages/page.tsx
+++ b/talentify-next-frontend/app/store/messages/page.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-export const dynamic = 'force-dynamic'
 import { useState, useEffect, useRef, useMemo } from 'react'
 import Image from 'next/image'
 import { createClient } from '@/utils/supabase/client'

--- a/talentify-next-frontend/app/store/schedule/page.tsx
+++ b/talentify-next-frontend/app/store/schedule/page.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-export const dynamic = 'force-dynamic'
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import {

--- a/talentify-next-frontend/app/store/settings/page.tsx
+++ b/talentify-next-frontend/app/store/settings/page.tsx
@@ -1,5 +1,4 @@
 'use client'
-export const dynamic = 'force-dynamic'
 
 import { useEffect, useState } from 'react'
 import { createClient } from '@/utils/supabase/client'

--- a/talentify-next-frontend/app/talent/edit/page.tsx
+++ b/talentify-next-frontend/app/talent/edit/page.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-export const dynamic = 'force-dynamic'
 
 import { useEffect, useState } from 'react'
 import { createClient } from '@/utils/supabase/client'

--- a/talentify-next-frontend/app/talent/offers/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/page.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-export const dynamic = 'force-dynamic'
 
 import { useEffect, useState } from 'react'
 import { createClient } from '@/utils/supabase/client'

--- a/talentify-next-frontend/app/talents/[id]/TalentDetailPageClient.tsx
+++ b/talentify-next-frontend/app/talents/[id]/TalentDetailPageClient.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-export const dynamic = 'force-dynamic'
 
 import { useEffect, useState } from 'react'
 import Link from 'next/link'

--- a/talentify-next-frontend/app/talents/[id]/offer/page.tsx
+++ b/talentify-next-frontend/app/talents/[id]/offer/page.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-export const dynamic = 'force-dynamic'
 
 import { useState } from 'react'
 import { useParams } from 'next/navigation'


### PR DESCRIPTION
## Summary
- enable dynamic server rendering globally in app layout
- remove redundant dynamic settings from child pages and API routes

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687781e9e3f08332bb8842b7cb225a97