### PR TITLE
Switch to @supabase/ssr

### DIFF
--- a/talentify-next-frontend/app/layout.tsx
+++ b/talentify-next-frontend/app/layout.tsx
@@ -33,7 +33,7 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode
 }) {
-  const supabase = createServerClient()
+  const supabase = await createServerClient()
   const {
     data: { session },
   } = await supabase.auth.getSession()

--- a/talentify-next-frontend/app/talent/dashboard/layout.tsx
+++ b/talentify-next-frontend/app/talent/dashboard/layout.tsx
@@ -30,7 +30,7 @@ export default async function DashboardLayout({
 }: {
   children: React.ReactNode
 }) {
-  const supabase = createServerClient()
+  const supabase = await createServerClient()
   const {
     data: { session },
   } = await supabase.auth.getSession()

--- a/talentify-next-frontend/app/talent/offers/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/page.tsx
@@ -4,7 +4,6 @@ export const dynamic = 'force-dynamic'
 
 import { useEffect, useState } from 'react'
 import { createClient } from '@/utils/supabase/client'
-import { useUser } from '@supabase/auth-helpers-react'
 
 type Offer = {
   id: string
@@ -15,11 +14,13 @@ type Offer = {
 
 export default function TalentOffersPage() {
   const supabase = createClient()
-  const user = useUser()
   const [offers, setOffers] = useState<Offer[]>([])
 
   useEffect(() => {
     const fetchOffers = async () => {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
       if (!user) return
 
       const { data, error } = await supabase
@@ -35,7 +36,7 @@ export default function TalentOffersPage() {
     }
 
     fetchOffers()
-  }, [user])
+  }, [supabase])
 
   return (
     <div className="p-6 space-y-4">

--- a/talentify-next-frontend/package-lock.json
+++ b/talentify-next-frontend/package-lock.json
@@ -15,8 +15,6 @@
         "@radix-ui/react-progress": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-switch": "^1.2.5",
-        "@supabase/auth-helpers-nextjs": "^0.10.0",
-        "@supabase/auth-helpers-react": "^0.5.0",
         "@supabase/ssr": "^0.6.1",
         "@supabase/supabase-js": "^2.50.3",
         "class-variance-authority": "^0.7.1",
@@ -1372,43 +1370,6 @@
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@supabase/auth-helpers-nextjs": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-nextjs/-/auth-helpers-nextjs-0.10.0.tgz",
-      "integrity": "sha512-2dfOGsM4yZt0oS4TPiE7bD4vf7EVz7NRz/IJrV6vLg0GP7sMUx8wndv2euLGq4BjN9lUCpu6DG/uCC8j+ylwPg==",
-      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/auth-helpers-shared": "0.7.0",
-        "set-cookie-parser": "^2.6.0"
-      },
-      "peerDependencies": {
-        "@supabase/supabase-js": "^2.39.8"
-      }
-    },
-    "node_modules/@supabase/auth-helpers-react": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-react/-/auth-helpers-react-0.5.0.tgz",
-      "integrity": "sha512-5QSaV2CGuhDhd7RlQCoviVEAYsP7XnrFMReOcBazDvVmqSIyjKcDwhLhWvnrxMOq5qjOaA44MHo7wXqDiF0puQ==",
-      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
-      "license": "MIT",
-      "peerDependencies": {
-        "@supabase/supabase-js": "^2.39.8"
-      }
-    },
-    "node_modules/@supabase/auth-helpers-shared": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-shared/-/auth-helpers-shared-0.7.0.tgz",
-      "integrity": "sha512-FBFf2ei2R7QC+B/5wWkthMha8Ca2bWHAndN+syfuEUUfufv4mLcAgBCcgNg5nJR8L0gZfyuaxgubtOc9aW3Cpg==",
-      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
-      "license": "MIT",
-      "dependencies": {
-        "jose": "^4.14.4"
-      },
-      "peerDependencies": {
-        "@supabase/supabase-js": "^2.39.8"
-      }
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.70.0",
@@ -5126,15 +5087,6 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
-    "node_modules/jose": {
-      "version": "4.15.9",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
-      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6727,12 +6679,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
-      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
-      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/talentify-next-frontend/package.json
+++ b/talentify-next-frontend/package.json
@@ -16,8 +16,6 @@
     "@radix-ui/react-progress": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-switch": "^1.2.5",
-    "@supabase/auth-helpers-nextjs": "^0.10.0",
-    "@supabase/auth-helpers-react": "^0.5.0",
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.50.3",
     "class-variance-authority": "^0.7.1",

--- a/talentify-next-frontend/utils/supabase/client.ts
+++ b/talentify-next-frontend/utils/supabase/client.ts
@@ -3,6 +3,10 @@
 
 export const dynamic = 'force-dynamic'
 
-import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
+import { createBrowserClient } from '@supabase/ssr'
 
-export const createClient = () => createClientComponentClient()
+export const createClient = () =>
+  createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  )

--- a/talentify-next-frontend/utils/supabase/provider.tsx
+++ b/talentify-next-frontend/utils/supabase/provider.tsx
@@ -1,9 +1,8 @@
 // utils/supabase/provider.tsx
 'use client'
 
-import { SessionContextProvider } from '@supabase/auth-helpers-react'
 import { createBrowserClient } from '@supabase/ssr'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 
 export function SupabaseProvider({
   children,
@@ -19,9 +18,11 @@ export function SupabaseProvider({
     )
   )
 
-  return (
-    <SessionContextProvider supabaseClient={supabase} initialSession={session}>
-      {children}
-    </SessionContextProvider>
-  )
+  useEffect(() => {
+    if (session) {
+      supabase.auth.setSession(session)
+    }
+  }, [session, supabase])
+
+  return <>{children}</>
 }

--- a/talentify-next-frontend/utils/supabase/server.ts
+++ b/talentify-next-frontend/utils/supabase/server.ts
@@ -1,8 +1,27 @@
 export const dynamic = 'force-dynamic' // ← 追加
 
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs"
-import { cookies } from "next/headers"
+import { createServerClient as createSupabaseServerClient, type CookieOptions } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+import { Database } from '@/types/supabase'
 
-export const createServerClient = () => {
-  return createServerComponentClient({ cookies })
+export async function createServerClient() {
+  const cookieStore = await cookies()
+
+  return createSupabaseServerClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name: string) {
+          return cookieStore.get(name)?.value
+        },
+        set(name: string, value: string, options: CookieOptions) {
+          cookieStore.set({ name, value, ...options })
+        },
+        remove(name: string, options: CookieOptions) {
+          cookieStore.set({ name, value: '', ...options })
+        },
+      },
+    },
+  )
 }


### PR DESCRIPTION
## Summary
- rely solely on `@supabase/ssr`
- remove `auth-helpers` packages
- update Supabase helpers and provider
- refactor auth usage on talent pages

## Testing
- `npm run lint` *(fails: Invalid Options)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687781f004f8833296500f7a8d5ac575