### PR TITLE
Fix cookie comment and remove await

### DIFF
--- a/talentify-next-frontend/lib/supabase/server.ts
+++ b/talentify-next-frontend/lib/supabase/server.ts
@@ -10,8 +10,8 @@ import { Database } from '@/types/supabase'
  * 認証クッキー付きSupabaseクライアントを取得する関数
  */
 export async function createClient() {
-  // Next.jsのcookies()はasyncなのでawaitが必要
-  const cookieStore = await cookies()
+  // Next.jsのcookies()は同期関数なのでawaitは不要
+  const cookieStore = cookies()
 
   return createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,      // Supabase URL（環境変数）


### PR DESCRIPTION
## Summary
- clarify that `cookies()` is synchronous
- remove unnecessary `await` when obtaining the cookie store

## Testing
- `npm run lint` *(fails: Invalid Options)*

------
https://chatgpt.com/codex/tasks/task_e_687781f77c1c8332be43a2210ac4325e