### PR TITLE
Consolidate Supabase server client

### DIFF
--- a/talentify-next-frontend/app/layout.tsx
+++ b/talentify-next-frontend/app/layout.tsx
@@ -5,7 +5,7 @@ import "./globals.css"
 import Header from "../components/Header"
 import Footer from "../components/Footer"
 import { Inter, Noto_Sans_JP } from "next/font/google"
-import { createServerClient } from "@/utils/supabase/server"
+import { createClient } from "@/lib/supabase/server"
 import { SupabaseProvider } from "@/utils/supabase/provider"
 
 const inter = Inter({
@@ -33,7 +33,7 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode
 }) {
-  const supabase = createServerClient()
+  const supabase = await createClient()
   const {
     data: { session },
   } = await supabase.auth.getSession()

--- a/talentify-next-frontend/app/talent/dashboard/layout.tsx
+++ b/talentify-next-frontend/app/talent/dashboard/layout.tsx
@@ -5,7 +5,7 @@ import Header from "@/components/Header"
 import Sidebar from "@/components/Sidebar"
 import Footer from "@/components/Footer"
 import { Inter, Noto_Sans_JP } from "next/font/google"
-import { createServerClient } from "@/utils/supabase/server"
+import { createClient } from "@/lib/supabase/server"
 import { SupabaseProvider } from "@/utils/supabase/provider"
 
 const inter = Inter({
@@ -30,7 +30,7 @@ export default async function DashboardLayout({
 }: {
   children: React.ReactNode
 }) {
-  const supabase = createServerClient()
+  const supabase = await createClient()
   const {
     data: { session },
   } = await supabase.auth.getSession()

--- a/talentify-next-frontend/utils/supabase/server.ts
+++ b/talentify-next-frontend/utils/supabase/server.ts
@@ -1,8 +1,0 @@
-export const dynamic = 'force-dynamic' // ← 追加
-
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs"
-import { cookies } from "next/headers"
-
-export const createServerClient = () => {
-  return createServerComponentClient({ cookies })
-}


### PR DESCRIPTION
## Summary
- remove duplicate `utils/supabase/server.ts`
- use the `lib/supabase/server` client everywhere

## Testing
- `npm run lint` *(fails: Invalid Options)*

------
https://chatgpt.com/codex/tasks/task_e_687781e772888332b0560923662770be