### PR TITLE
Switch to new Supabase client

### DIFF
--- a/talentify-next-frontend/app/(auth)/layout.tsx
+++ b/talentify-next-frontend/app/(auth)/layout.tsx
@@ -7,7 +7,7 @@ import "../globals.css"
 import Header from "@/components/Header"
 import Footer from "@/components/Footer"
 import { Inter, Noto_Sans_JP } from "next/font/google"
-import { createServerClient } from "@/utils/supabase/server"
+import { createClient } from "@/lib/supabase/server"
 import { SupabaseProvider } from "@/utils/supabase/provider"
 
 const inter = Inter({
@@ -35,7 +35,7 @@ export default async function AuthLayout({
 }: {
   children: React.ReactNode
 }) {
-  const supabase = await createServerClient()
+  const supabase = await createClient()
   const {
     data: { session },
   } = await supabase.auth.getSession()

--- a/talentify-next-frontend/app/talent/dashboard/layout.tsx
+++ b/talentify-next-frontend/app/talent/dashboard/layout.tsx
@@ -5,7 +5,7 @@ import Header from "@/components/Header"
 import Sidebar from "@/components/Sidebar"
 import Footer from "@/components/Footer"
 import { Inter, Noto_Sans_JP } from "next/font/google"
-import { createServerClient } from "@/utils/supabase/server"
+import { createClient } from "@/lib/supabase/server"
 import { SupabaseProvider } from "@/utils/supabase/provider"
 
 const inter = Inter({
@@ -30,7 +30,7 @@ export default async function DashboardLayout({
 }: {
   children: React.ReactNode
 }) {
-  const supabase = await createServerClient()
+  const supabase = await createClient()
   const {
     data: { session },
   } = await supabase.auth.getSession()


### PR DESCRIPTION
## Summary
- use `createClient` helper from the new `lib/supabase` folder
- update dashboard and auth layouts

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6877939eac0483329ea1982e5818ecb7