### PR TITLE
Move Supabase provider

### DIFF
--- a/talentify-next-frontend/app/(auth)/layout.tsx
+++ b/talentify-next-frontend/app/(auth)/layout.tsx
@@ -8,7 +8,7 @@ import Header from "@/components/Header"
 import Footer from "@/components/Footer"
 import { Inter, Noto_Sans_JP } from "next/font/google"
 import { createClient } from "@/lib/supabase/server"
-import { SupabaseProvider } from "@/utils/supabase/provider"
+import { SupabaseProvider } from "@/lib/supabase/provider"
 
 const inter = Inter({
   subsets: ["latin"],

--- a/talentify-next-frontend/app/talent/dashboard/layout.tsx
+++ b/talentify-next-frontend/app/talent/dashboard/layout.tsx
@@ -6,7 +6,7 @@ import Sidebar from "@/components/Sidebar"
 import Footer from "@/components/Footer"
 import { Inter, Noto_Sans_JP } from "next/font/google"
 import { createClient } from "@/lib/supabase/server"
-import { SupabaseProvider } from "@/utils/supabase/provider"
+import { SupabaseProvider } from "@/lib/supabase/provider"
 
 const inter = Inter({
   subsets: ["latin"],

--- a/talentify-next-frontend/lib/supabase/provider.tsx
+++ b/talentify-next-frontend/lib/supabase/provider.tsx
@@ -1,4 +1,4 @@
-// utils/supabase/provider.tsx
+// lib/supabase/provider.tsx
 'use client'
 
 import { createBrowserClient } from '@supabase/ssr'


### PR DESCRIPTION
## Summary
- relocate Supabase provider into `lib/supabase`
- update layouts to point at new provider location

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877984b73b883329fe7ecdf9e451dfe