### PR TITLE
Add shared UI components for dashboard

### DIFF
--- a/docs/dashboard-sections.md
+++ b/docs/dashboard-sections.md
@@ -1,0 +1,41 @@
+# Dashboard Sections Overview
+
+This document lists the planned dashboard sections for each role and notes which UI pieces can be shared between Store users and Talent users.
+
+## Common Components
+
+- **DashboardCard** – reusable card container with title, description, icon and CTA.
+- **NotificationItem** – single notification display used inside lists.
+- **EmptyState** – simple empty state with illustration, description and action button.
+
+## Store Dashboard
+
+Sections displayed:
+
+1. **Offer Stats** – summary of offers received recently.
+2. **Next Event** – upcoming confirmed schedule.
+3. **Unread Messages** – badge showing unread message count.
+
+These can all be presented using `DashboardCard` with specific content.
+
+## Talent Dashboard
+
+Sections displayed:
+
+1. **Pending Offers** – list of received offers awaiting response.
+2. **This Week's Schedule** – upcoming schedule items.
+3. **Notifications** – list of notifications using `NotificationItem`.
+4. **Profile Progress** – progress bar for profile completion.
+5. **Reviews Summary** – recent review statistics.
+6. **Payment Status** – latest payment details.
+
+## Shared vs. Role‑Specific Parts
+
+- **Shared**
+  - `DashboardCard`, `NotificationItem`, `EmptyState` components
+  - Basic layout structure for cards and lists
+- **Role Specific**
+  - Data fetching logic within pages
+  - Certain card variations (e.g. `StoreDashboardCard`, `TalentTaskCard`) that extend `DashboardCard`
+
+The goal is to keep styling and props compatible so each role can reuse these UI pieces while supplying role‑specific data and actions.

--- a/talentify-next-frontend/components/ui/dashboard-card.tsx
+++ b/talentify-next-frontend/components/ui/dashboard-card.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import Link from 'next/link'
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from './card'
+import { Button } from './button'
+import { cn } from '@/lib/utils'
+
+export interface DashboardCardProps extends React.HTMLAttributes<HTMLDivElement> {
+  title: string
+  description?: string
+  icon?: React.ReactNode
+  ctaHref?: string
+  ctaLabel?: string
+}
+
+export function DashboardCard({
+  title,
+  description,
+  icon,
+  ctaHref,
+  ctaLabel,
+  className,
+  children,
+  ...props
+}: DashboardCardProps) {
+  const content = (
+    <Card className={cn('flex flex-col gap-2', className)} {...props}>
+      <CardHeader className="flex items-center gap-2">
+        {icon}
+        <CardTitle className="text-base font-semibold">{title}</CardTitle>
+      </CardHeader>
+      {description && <CardContent className="text-sm text-muted-foreground">{description}</CardContent>}
+      {children && <CardContent>{children}</CardContent>}
+      {ctaHref && ctaLabel && (
+        <CardFooter>
+          <Link href={ctaHref} className="ml-auto">
+            <Button size="sm">{ctaLabel}</Button>
+          </Link>
+        </CardFooter>
+      )}
+    </Card>
+  )
+
+  return content
+}

--- a/talentify-next-frontend/components/ui/empty-state.tsx
+++ b/talentify-next-frontend/components/ui/empty-state.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import Link from 'next/link'
+import { Button } from './button'
+import { cn } from '@/lib/utils'
+
+export interface EmptyStateProps extends React.HTMLAttributes<HTMLDivElement> {
+  illustration?: React.ReactNode
+  title: string
+  description?: string
+  actionHref?: string
+  actionLabel?: string
+}
+
+export function EmptyState({
+  illustration,
+  title,
+  description,
+  actionHref,
+  actionLabel,
+  className,
+  ...props
+}: EmptyStateProps) {
+  return (
+    <div className={cn('text-center space-y-4 py-10', className)} {...props}>
+      {illustration && <div className="flex justify-center">{illustration}</div>}
+      <h3 className="text-lg font-semibold">{title}</h3>
+      {description && <p className="text-sm text-muted-foreground">{description}</p>}
+      {actionHref && actionLabel && (
+        <Link href={actionHref}>
+          <Button>{actionLabel}</Button>
+        </Link>
+      )}
+    </div>
+  )
+}

--- a/talentify-next-frontend/components/ui/notification-item.tsx
+++ b/talentify-next-frontend/components/ui/notification-item.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { Badge } from './badge'
+import { cn } from '@/lib/utils'
+import type { Notification } from '@/types/ui'
+import { Bell, Mail, Calendar as CalendarIcon, Info } from 'lucide-react'
+
+interface NotificationItemProps extends React.HTMLAttributes<HTMLDivElement> {
+  notification: Notification
+}
+
+const typeIcon = {
+  message: Mail,
+  offer: Bell,
+  schedule: CalendarIcon,
+  system: Info,
+}
+
+export function NotificationItem({ notification, className, ...props }: NotificationItemProps) {
+  const Icon = typeIcon[notification.type]
+
+  return (
+    <div
+      className={cn(
+        'flex items-start gap-2 rounded-md border p-3 bg-white',
+        !notification.is_read && 'font-semibold',
+        className
+      )}
+      {...props}
+    >
+      <Icon className="h-4 w-4 mt-0.5" />
+      <div className="text-sm flex-1">
+        <div>{notification.body}</div>
+        <div className="text-xs text-muted-foreground">{notification.created_at}</div>
+      </div>
+      {!notification.is_read && <Badge className="self-start" variant="destructive">NEW</Badge>}
+    </div>
+  )
+}

--- a/talentify-next-frontend/types/ui.ts
+++ b/talentify-next-frontend/types/ui.ts
@@ -1,0 +1,20 @@
+export type NotificationType = 'message' | 'offer' | 'schedule' | 'system'
+
+export type TaskType = 'respond_offer' | 'update_profile' | 'check_message'
+
+export interface Notification {
+  id: string
+  type: NotificationType
+  title: string
+  body: string
+  created_at: string
+  is_read: boolean
+}
+
+export interface Task {
+  id: string
+  type: TaskType
+  title: string
+  due_date?: string
+  completed: boolean
+}


### PR DESCRIPTION
## Summary
- add `DashboardCard`, `NotificationItem`, and `EmptyState` components
- add UI related TypeScript types
- document planned dashboard sections for each role

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6879c5945c6c83328cf650db4e8a09a3