### PR TITLE
Add offer modal from schedule slots

### DIFF
--- a/talentify-next-frontend/app/store/schedule/page.tsx
+++ b/talentify-next-frontend/app/store/schedule/page.tsx
@@ -16,6 +16,7 @@ import getDay from 'date-fns/getDay'
 import ja from 'date-fns/locale/ja'
 import { createClient } from '@/utils/supabase/client'
 import 'react-big-calendar/lib/css/react-big-calendar.css'
+import OfferModal from '@/components/modals/OfferModal'
 
 interface OfferEvent extends BigCalendarEvent {
   talentId: string
@@ -36,6 +37,8 @@ export default function StoreSchedulePage() {
   const supabase = createClient()
   const [events, setEvents] = useState<OfferEvent[]>([])
   const [view, setView] = useState<View>(Views.MONTH)
+  const [slot, setSlot] = useState<{ start: Date; end: Date } | null>(null)
+  const [modalOpen, setModalOpen] = useState(false)
 
   useEffect(() => {
     const loadOffers = async () => {
@@ -82,6 +85,11 @@ export default function StoreSchedulePage() {
     router.push(`/talents/${event.talentId}`)
   }
 
+  const handleSelectSlot = ({ start, end }: { start: Date; end: Date }) => {
+    setSlot({ start, end })
+    setModalOpen(true)
+  }
+
   return (
     <main className="p-4">
       <h1 className="text-2xl font-bold mb-4">スケジュール</h1>
@@ -110,6 +118,13 @@ export default function StoreSchedulePage() {
         style={{ height: 600 }}
         eventPropGetter={eventStyleGetter}
         onSelectEvent={handleSelectEvent}
+        selectable
+        onSelectSlot={handleSelectSlot}
+      />
+      <OfferModal
+        open={modalOpen}
+        onOpenChange={setModalOpen}
+        initialDate={slot ? slot.start : null}
       />
     </main>
   )

--- a/talentify-next-frontend/components/modals/OfferModal.tsx
+++ b/talentify-next-frontend/components/modals/OfferModal.tsx
@@ -1,0 +1,163 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import {
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalTitle,
+  ModalFooter,
+  ModalClose,
+} from '@/components/ui/modal'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/button'
+import { createClient } from '@/utils/supabase/client'
+
+interface OfferModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  initialDate: Date | null
+}
+
+type Template = {
+  name: string
+  talentId: string
+  message: string
+}
+
+const TEMPLATE_KEY = 'offer_templates'
+
+export default function OfferModal({ open, onOpenChange, initialDate }: OfferModalProps) {
+  const supabase = createClient()
+  const [talents, setTalents] = useState<{ id: string; stage_name: string | null }[]>([])
+  const [date, setDate] = useState('')
+  const [talentId, setTalentId] = useState('')
+  const [message, setMessage] = useState('')
+  const [templates, setTemplates] = useState<Template[]>([])
+
+  useEffect(() => {
+    if (open) {
+      if (initialDate) setDate(formatDate(initialDate))
+      loadTalents()
+      loadTemplates()
+    }
+  }, [open, initialDate])
+
+  const formatDate = (d: Date) => d.toISOString().slice(0, 10)
+
+  const loadTalents = async () => {
+    const { data, error } = await supabase.from('talents').select('id, stage_name')
+    if (!error && data) setTalents(data)
+  }
+
+  const loadTemplates = () => {
+    try {
+      const t = JSON.parse(localStorage.getItem(TEMPLATE_KEY) || '[]') as Template[]
+      setTemplates(t)
+    } catch {
+      setTemplates([])
+    }
+  }
+
+  const applyTemplate = (index: number) => {
+    const t = templates[index]
+    if (!t) return
+    setTalentId(t.talentId)
+    setMessage(t.message)
+  }
+
+  const saveTemplate = () => {
+    const name = window.prompt('テンプレート名を入力してください')
+    if (!name) return
+    const newTemplates = [...templates, { name, talentId, message }]
+    localStorage.setItem(TEMPLATE_KEY, JSON.stringify(newTemplates))
+    setTemplates(newTemplates)
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) {
+      alert('ログインしてください')
+      return
+    }
+    const { error } = await supabase.from('offers').insert([
+      { user_id: user.id, talent_id: talentId, message, date, status: 'pending' },
+    ])
+    if (error) {
+      alert('送信に失敗しました')
+      return
+    }
+    onOpenChange(false)
+  }
+
+  return (
+    <Modal open={open} onOpenChange={onOpenChange}>
+      <ModalContent>
+        <ModalHeader>
+          <ModalTitle>オファー作成</ModalTitle>
+        </ModalHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium mb-1">日付</label>
+            <Input type="date" value={date} onChange={e => setDate(e.target.value)} />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">演者</label>
+            <select
+              value={talentId}
+              onChange={e => setTalentId(e.target.value)}
+              className="h-9 w-full rounded-md border px-2"
+            >
+              <option value="">選択してください</option>
+              {talents.map(t => (
+                <option key={t.id} value={t.id}>
+                  {t.stage_name || t.id}
+                </option>
+              ))}
+            </select>
+          </div>
+          {templates.length > 0 && (
+            <div>
+              <label className="block text-sm font-medium mb-1">テンプレート</label>
+              <select
+                defaultValue=""
+                onChange={e => applyTemplate(Number(e.target.value))}
+                className="h-9 w-full rounded-md border px-2"
+              >
+                <option value="">選択してください</option>
+                {templates.map((t, i) => (
+                  <option key={i} value={i}>
+                    {t.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+          <div>
+            <label className="block text-sm font-medium mb-1">メッセージ</label>
+            <Textarea
+              value={message}
+              onChange={e => setMessage(e.target.value)}
+              placeholder="出演依頼内容などを入力"
+            />
+          </div>
+          <ModalFooter className="justify-between">
+            <Button type="button" variant="outline" onClick={saveTemplate}>
+              テンプレート保存
+            </Button>
+            <div className="flex gap-2">
+              <ModalClose asChild>
+                <Button type="button" variant="secondary">
+                  キャンセル
+                </Button>
+              </ModalClose>
+              <Button type="submit">送信</Button>
+            </div>
+          </ModalFooter>
+        </form>
+      </ModalContent>
+    </Modal>
+  )
+}


### PR DESCRIPTION
## Summary
- add offer creation modal component
- open modal when clicking empty slot on store schedule
- allow saving/reusing templates in localStorage
- install dependencies and run tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879cc94ca748332858cfa9d684ded81