### PR TITLE
Add notification center to dashboard

### DIFF
--- a/talentify-next-frontend/app/store/dashboard/page.tsx
+++ b/talentify-next-frontend/app/store/dashboard/page.tsx
@@ -4,6 +4,7 @@ import OfferSummaryCard from '@/components/OfferSummaryCard'
 import ScheduleCard, { ScheduleItem } from '@/components/ScheduleCard'
 import MessageAlertCard from '@/components/MessageAlertCard'
 import { EmptyState } from '@/components/ui/empty-state'
+import NotificationListCard from '@/components/NotificationListCard'
 
 export default function StoreDashboard() {
   const offerStats = { pending: 1, accepted: 2 }
@@ -25,6 +26,7 @@ export default function StoreDashboard() {
           <div className='sm:col-span-2'>
             <MessageAlertCard count={unread} link='/store/messages' />
           </div>
+          <NotificationListCard className='sm:col-span-2' />
         </div>
       )}
     </div>

--- a/talentify-next-frontend/app/talent/dashboard/page.tsx
+++ b/talentify-next-frontend/app/talent/dashboard/page.tsx
@@ -4,6 +4,7 @@ import OfferSummaryCard from '@/components/OfferSummaryCard'
 import ScheduleCard, { ScheduleItem } from '@/components/ScheduleCard'
 import MessageAlertCard from '@/components/MessageAlertCard'
 import ProfileProgressCard from '@/components/ProfileProgressCard'
+import NotificationListCard from '@/components/NotificationListCard'
 
 export default function TalentDashboard() {
   const pending = 2
@@ -17,6 +18,7 @@ export default function TalentDashboard() {
       <ScheduleCard items={schedule} />
       <OfferSummaryCard pending={pending} accepted={schedule.length} link='/talent/offers' />
       <MessageAlertCard count={unread} link='/talent/messages' />
+      <NotificationListCard className='sm:col-span-2 lg:col-span-3' />
       <div className='sm:col-span-2 lg:col-span-3'>
         <ProfileProgressCard />
       </div>

--- a/talentify-next-frontend/components/NotificationListCard.tsx
+++ b/talentify-next-frontend/components/NotificationListCard.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { DashboardCard } from '@/components/ui/dashboard-card'
+import { NotificationItem } from '@/components/ui/notification-item'
+import { cn } from '@/lib/utils'
+import type { Notification } from '@/types/ui'
+import { getRecentNotifications } from '@/utils/getRecentNotifications'
+
+interface Props {
+  title?: string
+  className?: string
+}
+
+export default function NotificationListCard({ title = '通知', className }: Props) {
+  const [items, setItems] = useState<Notification[] | null>(null)
+
+  useEffect(() => {
+    getRecentNotifications().then(setItems)
+  }, [])
+
+  return (
+    <DashboardCard title={title} className={cn('space-y-2', className)}>
+      {items === null && (
+        <div className="text-sm text-muted-foreground">読み込み中...</div>
+      )}
+      {items && items.length === 0 && (
+        <div className="text-sm text-muted-foreground">通知はありません</div>
+      )}
+      {items && items.length > 0 && (
+        <div className="space-y-2 max-h-64 overflow-y-auto">
+          {items.map((n) => (
+            <NotificationItem key={n.id} notification={n} />
+          ))}
+        </div>
+      )}
+    </DashboardCard>
+  )
+}

--- a/talentify-next-frontend/utils/getRecentNotifications.ts
+++ b/talentify-next-frontend/utils/getRecentNotifications.ts
@@ -1,0 +1,80 @@
+'use client'
+
+import { createClient } from '@/utils/supabase/client'
+import type { Notification } from '@/types/ui'
+
+/**
+ * Fetch recent notifications related to the current user.
+ * This is a simplified example and does not cover RLS or webhooks.
+ */
+export async function getRecentNotifications(): Promise<Notification[]> {
+  const supabase = createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) return []
+
+  // Unread messages
+  const { data: messages } = await supabase
+    .from('messages')
+    .select('*')
+    .eq('receiver_id', user.id)
+    .eq('is_read', false)
+    .order('created_at', { ascending: false })
+    .limit(5)
+
+  // Pending offers
+  const { data: offers } = await supabase
+    .from('offers')
+    .select('*')
+    .eq('talent_id', user.id)
+    .eq('status', 'pending')
+    .order('created_at', { ascending: false })
+
+  // Schedules for the next 7 days
+  const { data: schedules } = await supabase
+    .from('schedules')
+    .select('*')
+    .eq('user_id', user.id)
+    .gte('date', new Date().toISOString())
+    .lte('date', new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString())
+
+  const notifications: Notification[] = []
+
+  messages?.forEach((m) =>
+    notifications.push({
+      id: m.id,
+      type: 'message',
+      title: '新着メッセージ',
+      body: m.text ?? '',
+      created_at: m.created_at ?? '',
+      is_read: !!m.is_read,
+    }),
+  )
+
+  offers?.forEach((o) =>
+    notifications.push({
+      id: o.id,
+      type: 'offer',
+      title: 'オファー対応待ち',
+      body: `オファーの日程 ${o.date}`,
+      created_at: o.created_at ?? '',
+      is_read: false,
+    }),
+  )
+
+  schedules?.forEach((s) =>
+    notifications.push({
+      id: s.id,
+      type: 'schedule',
+      title: '今週の予定',
+      body: s.description ?? '',
+      created_at: s.date ?? '',
+      is_read: true,
+    }),
+  )
+
+  // Sort by created_at desc
+  return notifications.sort((a, b) => (a.created_at < b.created_at ? 1 : -1))
+}


### PR DESCRIPTION
## Summary
- add `NotificationListCard` component using `NotificationItem`
- fetch recent notifications via new `getRecentNotifications` utility
- show notifications on talent and store dashboards

## Testing
- `npm run lint` *(fails: Invalid Options)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879d077fb588332904bcea6875458f8