### PR TITLE
Refine sidebar and header UI

### DIFF
--- a/talentify-next-frontend/components/Header.tsx
+++ b/talentify-next-frontend/components/Header.tsx
@@ -152,11 +152,13 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
                 </>
               ) : (
                 <>
-                  <Link href="/dashboard" className="hover:underline">ダッシュボード</Link>
-                  <Link href="/contact" className="hover:underline">お問い合わせ</Link>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                      <span className="cursor-pointer font-semibold">{userName} ▼</span>
+                      <span className="cursor-pointer flex items-baseline font-semibold">
+                        <span className="text-base">{userName}</span>
+                        <span className="ml-1 text-sm text-muted-foreground align-top">様</span>
+                        <span className="ml-1">▼</span>
+                      </span>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent>
                       <DropdownMenuItem>
@@ -207,8 +209,6 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
             </>
           ) : (
             <>
-              <Link href="/dashboard" className="block">ダッシュボード</Link>
-              <Link href="/contact" className="block">お問い合わせ</Link>
               <Link href={profileEditPath} className="block">プロフィール</Link>
               <button onClick={handleLogout} className="block text-left w-full">ログアウト</button>
             </>

--- a/talentify-next-frontend/components/Sidebar.tsx
+++ b/talentify-next-frontend/components/Sidebar.tsx
@@ -60,8 +60,10 @@ export default function Sidebar({
           <Link href={href} key={href}>
             <div
               className={cn(
-                'group flex items-center gap-3 rounded-2xl px-4 py-2 text-sm font-semibold transition-colors hover:bg-muted',
-                pathname === href ? 'bg-muted text-primary shadow-md' : 'text-muted-foreground',
+                'group flex items-center gap-3 rounded-2xl px-4 py-2 text-sm transition-colors hover:bg-muted',
+                pathname === href
+                  ? 'bg-muted text-primary font-medium shadow-md'
+                  : 'text-muted-foreground font-normal',
                 collapsed && 'justify-center px-3'
               )}
             >


### PR DESCRIPTION
## Summary
- tone down sidebar typography
- drop dashboard and contact links from the header once logged in
- show username with small `様` suffix

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6879e72deed4833281f61b2fb008e76a