### PR TITLE
Fix supabase type inference

### DIFF
--- a/talentify-next-frontend/app/page.tsx
+++ b/talentify-next-frontend/app/page.tsx
@@ -17,12 +17,12 @@ export default async function HomePage() {
       .from('stores')
       .select('id')
       .eq('user_id', userId)
-      .maybeSingle();
+      .maybeSingle<{ id: string }>();
     const { data: talent } = await supabase
       .from('talents')
       .select('id')
       .eq('user_id', userId)
-      .maybeSingle();
+      .maybeSingle<{ id: string }>();
 
     if (store) redirect('/store/dashboard');
     else if (talent) redirect('/talent/dashboard');


### PR DESCRIPTION
## Summary
- add generics to supabase `maybeSingle` calls in home page

## Testing
- `npm ci`
- `npx tsc --noEmit` *(fails: Type instantiation is excessively deep)*

------
https://chatgpt.com/codex/tasks/task_e_6879ffee7700833294be230a0b6d5e57