### PR TITLE
Add talent search CTA for store users

### DIFF
--- a/talentify-next-frontend/app/store/dashboard/page.tsx
+++ b/talentify-next-frontend/app/store/dashboard/page.tsx
@@ -6,6 +6,10 @@ import MessageAlertCard from '@/components/MessageAlertCard'
 import { EmptyState } from '@/components/ui/empty-state'
 import NotificationListCard from '@/components/NotificationListCard'
 import { CardSkeleton } from '@/components/ui/skeleton'
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import Link from 'next/link'
+import { Search as SearchIcon } from 'lucide-react'
 import { useEffect, useState } from 'react'
 
 export default function StoreDashboard() {
@@ -35,6 +39,21 @@ export default function StoreDashboard() {
         <EmptyState title='まだオファーがありません' actionHref='/talent-search' actionLabel='オファーを送ってみましょう' />
       ) : (
         <div className='grid gap-4 sm:grid-cols-2'>
+          <Card className='sm:col-span-2'>
+            <CardHeader>
+              <CardTitle>次の来店イベントを企画しませんか？</CardTitle>
+            </CardHeader>
+            <CardContent className='text-sm text-muted-foreground'>
+              演者一覧から希望に合ったタレントを探しましょう。
+            </CardContent>
+            <CardFooter>
+              <Button variant='default' size='lg' asChild>
+                <Link href='/store/talents'>
+                  <SearchIcon className='mr-2' /> 演者を探す
+                </Link>
+              </Button>
+            </CardFooter>
+          </Card>
           <ScheduleCard items={schedule} />
           <OfferSummaryCard pending={offerStats.pending} accepted={offerStats.accepted} link='/store/offers' />
           <div className='sm:col-span-2'>
@@ -43,6 +62,14 @@ export default function StoreDashboard() {
           <NotificationListCard className='sm:col-span-2' />
         </div>
       )}
+      <Button
+        asChild
+        className='fixed bottom-4 right-4 md:hidden rounded-full shadow-lg px-4 py-3'
+      >
+        <Link href='/store/talents'>
+          <SearchIcon className='mr-1 w-5 h-5' /> 演者を探す
+        </Link>
+      </Button>
     </div>
   )
 }

--- a/talentify-next-frontend/app/store/talents/page.tsx
+++ b/talentify-next-frontend/app/store/talents/page.tsx
@@ -1,0 +1,5 @@
+import TalentSearchPage from '@/components/talent-search/TalentSearchPage'
+
+export default function StoreTalentSearchPage() {
+  return <TalentSearchPage />
+}

--- a/talentify-next-frontend/components/Header.tsx
+++ b/talentify-next-frontend/components/Header.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
-import { Menu } from 'lucide-react'
+import { Menu, Search } from 'lucide-react'
 import Sidebar from './Sidebar'
 import { Sheet, SheetTrigger, SheetContent } from './ui/sheet'
 import { Button } from './ui/button'
@@ -104,6 +104,14 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
 
             {/* 右メニュー */}
             <div className="flex items-center space-x-2 ml-auto">
+              {sidebarRole === 'store' && (
+                <Link
+                  href="/store/talents"
+                  className="hidden md:inline-flex items-center rounded-full bg-[#daa520] text-white font-normal px-4 py-2 hover:brightness-110 transition"
+                >
+                  <Search className="w-4 h-4 mr-1" /> 演者を探す
+                </Link>
+              )}
               {!isLoggedIn ? (
                 <>
                   <span className="text-black text-sm font-normal mr-2">

--- a/talentify-next-frontend/components/Sidebar.tsx
+++ b/talentify-next-frontend/components/Sidebar.tsx
@@ -14,6 +14,7 @@ import {
   Star,
   Wallet,
   Bell,
+  Search,
   LogOut,
   ChevronLeft,
   ChevronRight,
@@ -30,6 +31,7 @@ const navItems = {
     { href: '/talent/notifications', label: '通知・設定', icon: Bell },
   ],
   store: [
+    { href: '/store/talents', label: '演者を探す', icon: Search },
     { href: '/store/dashboard', label: 'ダッシュボード', icon: LayoutDashboard },
     { href: '/store/offers', label: 'オファー管理', icon: Mail },
     { href: '/store/schedule', label: 'スケジュール', icon: Calendar },


### PR DESCRIPTION
## Summary
- add link to search talents in sidebar
- add hero card and floating button on store dashboard to find talents
- add header button for store users to jump to talent search
- add /store/talents route reusing existing search page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ee4dfdd5c8332aa4625a5986daac0