### PR TITLE
Apply sidebar layout to search section

### DIFF
--- a/talentify-next-frontend/app/search/layout.tsx
+++ b/talentify-next-frontend/app/search/layout.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import Header from '@/components/Header'
+import Sidebar from '@/components/Sidebar'
+import { createClient } from '@/lib/supabase/server'
+import { SupabaseProvider } from '@/lib/supabase/provider'
+
+export const metadata = {
+  title: 'Talentify | 演者検索',
+}
+
+export default async function SearchLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const supabase = await createClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+
+  return (
+    <html lang="ja">
+      <body className="font-sans antialiased bg-white text-black">
+        <SupabaseProvider session={session}>
+          <Header sidebarRole="store" />
+          <div className="flex h-[calc(100vh-64px)] pt-16">
+            <aside className="hidden md:block">
+              <Sidebar role="store" collapsible />
+            </aside>
+            <main className="flex-1 overflow-y-auto p-6">{children}</main>
+          </div>
+        </SupabaseProvider>
+      </body>
+    </html>
+  )
+}


### PR DESCRIPTION
## Summary
- add `app/search/layout.tsx` to use store sidebar navigation on search pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f021d16148332a977b633fe950164