### PR TITLE
Fix offer button link

### DIFF
--- a/talentify-next-frontend/components/talent-search/TalentCard.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentCard.tsx
@@ -35,7 +35,9 @@ export default function TalentCard({ talent }: { talent: Talent }) {
         <Button asChild variant="outline" className="flex-1">
           <Link href={`/talents/${talent.id}`}>詳細を見る</Link>
         </Button>
-        <Button className="flex-1">オファーする</Button>
+        <Button asChild className="flex-1">
+          <Link href={`/talents/${talent.id}/offer`}>オファーする</Link>
+        </Button>
       </CardFooter>
     </Card>
   )


### PR DESCRIPTION
## Summary
- connect the `オファーする` button in `TalentCard` to the existing offer page

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f046cb39483328c756b51aefa7433