### PR TITLE
Remove redundant header search button

### DIFF
--- a/talentify-next-frontend/components/Header.tsx
+++ b/talentify-next-frontend/components/Header.tsx
@@ -104,14 +104,6 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
 
             {/* 右メニュー */}
             <div className="flex items-center space-x-2 ml-auto">
-              {sidebarRole === 'store' && (
-                <Link
-                  href="/search"
-                  className="hidden md:inline-flex items-center rounded-full bg-[#daa520] text-white font-normal px-4 py-2 hover:brightness-110 transition"
-                >
-                  <Search className="w-4 h-4 mr-1" /> 演者を探す
-                </Link>
-              )}
               {!isLoggedIn ? (
                 <>
                   <span className="text-black text-sm font-normal mr-2">


### PR DESCRIPTION
## Summary
- delete the "演者を探す" link from the header because it already exists in the sidebar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f0d2abea483328f84a090b0e3188c