### PR TITLE
Update talent detail page with inline offer form

### DIFF
--- a/talentify-next-frontend/components/talent-search/TalentCard.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentCard.tsx
@@ -31,12 +31,9 @@ export default function TalentCard({ talent }: { talent: Talent }) {
         <p className="line-clamp-2">{talent.bio}</p>
         {talent.agency && <p className="text-xs text-gray-500">所属: {talent.agency}</p>}
       </CardContent>
-      <CardFooter className="mt-auto flex gap-2">
-        <Button asChild variant="outline" className="flex-1">
+      <CardFooter className="mt-auto">
+        <Button asChild variant="outline" className="w-full">
           <Link href={`/talents/${talent.id}`}>詳細を見る</Link>
-        </Button>
-        <Button asChild className="flex-1">
-          <Link href={`/talents/${talent.id}/offer`}>オファーする</Link>
         </Button>
       </CardFooter>
     </Card>


### PR DESCRIPTION
## Summary
- remove offer button from talent list cards
- add collapsible offer form to talent detail page

## Testing
- `npm run lint`
- `npm test`
- `npm run build` *(fails: Supabase env vars missing)*

------
https://chatgpt.com/codex/tasks/task_e_687f1812d25083328ec01ae3ff37eb56