### PR TITLE
Add Supabase reviews feed

### DIFF
--- a/talentify-next-frontend/app/talent/reviews/page.tsx
+++ b/talentify-next-frontend/app/talent/reviews/page.tsx
@@ -1,47 +1,67 @@
 'use client'
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Star } from "lucide-react"
+import { useEffect, useState } from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Star } from 'lucide-react'
+import { getReviewsForTalent, TalentReview } from '@/utils/getReviewsForTalent'
 
 export default function TalentReviewPage() {
-  // 仮データ（後で Supabase に置き換え）
-  const reviews = [
-    {
-      store: "パチンコMAX渋谷",
-      date: "2025年7月10日",
-      rating: 5,
-      comment: "場の空気を一気に明るくしてくれました！またお願いします！"
-    },
-    {
-      store: "スロットキング新宿",
-      date: "2025年6月22日",
-      rating: 4,
-      comment: "丁寧な対応が好印象でした。次回はもっとSNSでも発信してほしいです。"
+  const [reviews, setReviews] = useState<TalentReview[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const load = async () => {
+      const data = await getReviewsForTalent()
+      setReviews(data)
+      setLoading(false)
     }
-  ]
+    load()
+  }, [])
 
   return (
     <div className="max-w-screen-md mx-auto py-8 space-y-6">
       <h1 className="text-2xl font-bold mb-4">評価・レビュー一覧</h1>
 
-      {reviews.map((review, idx) => (
-        <Card key={idx}>
-          <CardHeader>
-            <CardTitle className="text-base">
-              {review.store}（{review.date}）
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-2 text-sm">
-            <div className="flex items-center gap-1 text-yellow-500">
-              {[...Array(5)].map((_, i) => (
-                <Star key={i} size={16} fill={i < review.rating ? "currentColor" : "none"} />
-              ))}
-              <span className="text-gray-500 ml-2">{review.rating} / 5</span>
-            </div>
-            <p className="text-gray-700">{review.comment}</p>
-          </CardContent>
-        </Card>
-      ))}
+      {loading ? (
+        <p>読み込み中...</p>
+      ) : reviews.length === 0 ? (
+        <p>まだレビューがありません。</p>
+      ) : (
+        reviews.map(review => (
+          <Card key={review.id}>
+            <CardHeader>
+              <CardTitle className="text-base">
+                {review.store_name ?? '店舗不明'}（{review.visit_date ?? '---'}）
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm">
+              <div className="flex items-center gap-1 text-yellow-500">
+                {[...Array(5)].map((_, i) => (
+                  <Star key={i} size={16} fill={i < review.rating ? 'currentColor' : 'none'} />
+                ))}
+                <span className="text-gray-500 ml-2">{review.rating} / 5</span>
+              </div>
+              {review.category_ratings && (
+                <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+                  {Object.entries(review.category_ratings).map(([key, val]) => (
+                    <div key={key} className="flex items-center gap-1 text-yellow-500 text-xs">
+                      <span className="text-gray-600 w-16">
+                        {key === 'time' ? '時間厳守' : key === 'attitude' ? '接客態度' : key === 'fan' ? 'ファンサービス' : key === 'play' ? '遊技姿勢' : key}
+                      </span>
+                      {[...Array(5)].map((_, i) => (
+                        <Star key={i} size={12} fill={i < (val as number) ? 'currentColor' : 'none'} />
+                      ))}
+                    </div>
+                  ))}
+                </div>
+              )}
+              <p className="text-gray-700">
+                {review.comment ? review.comment : 'コメントなし'}
+              </p>
+            </CardContent>
+          </Card>
+        ))
+      )}
     </div>
   )
 }

--- a/talentify-next-frontend/utils/getReviewsForTalent.ts
+++ b/talentify-next-frontend/utils/getReviewsForTalent.ts
@@ -1,0 +1,39 @@
+'use client'
+
+import { createClient } from '@/utils/supabase/client'
+
+const supabase = createClient()
+
+export type TalentReview = {
+  id: string
+  store_name: string | null
+  visit_date: string | null
+  rating: number
+  category_ratings: any | null
+  comment: string | null
+}
+
+export async function getReviewsForTalent() {
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return [] as TalentReview[]
+
+  const { data, error } = await supabase
+    .from('reviews')
+    .select('id, rating, category_ratings, comment, created_at, stores(display_name), offers(date)')
+    .eq('talent_id', user.id)
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    console.error('failed to fetch reviews:', error)
+    return [] as TalentReview[]
+  }
+
+  return (data || []).map(r => ({
+    id: r.id as string,
+    store_name: (r as any).stores?.display_name ?? null,
+    visit_date: (r as any).offers?.date ?? null,
+    rating: r.rating as number,
+    category_ratings: r.category_ratings,
+    comment: r.comment,
+  })) as TalentReview[]
+}


### PR DESCRIPTION
## Summary
- fetch reviews from Supabase for the talent reviews page
- show store name, visit date, rating breakdown and comment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f1f06b31c8332b8dcc5c5cb5dd28b