### PR TITLE
Fix talent detail API and client error handling

### DIFF
--- a/talentify-next-frontend/app/api/talents/[id]/route.ts
+++ b/talentify-next-frontend/app/api/talents/[id]/route.ts
@@ -9,6 +9,11 @@ export async function GET(
 
   const { id } = params
 
+  if (!id) {
+    console.error('GET /api/talents/[id] called without id')
+    return NextResponse.json({ error: 'id is required' }, { status: 400 })
+  }
+
   const { data, error } = await supabase
     .from('talents')
     .select(
@@ -22,7 +27,16 @@ export async function GET(
     .maybeSingle()
 
   if (error) {
+    console.error('Supabase fetch error:', {
+      message: error.message,
+      details: error.details,
+      hint: error.hint,
+    })
     return NextResponse.json<{ error: string }>({ error: error.message }, { status: 500 })
+  }
+
+  if (!data) {
+    return NextResponse.json({ error: 'Talent not found' }, { status: 404 })
   }
 
   return NextResponse.json(data, { status: 200 })

--- a/talentify-next-frontend/app/talent/edit/page.tsx
+++ b/talentify-next-frontend/app/talent/edit/page.tsx
@@ -148,16 +148,19 @@ export default function TalentProfileEditPage() {
       availability: profile.availability || '',
       min_hours: profile.min_hours || '',
       transportation: profile.transportation || '',
-      rate: profile.rate ? Number(profile.rate) : null,
+      rate: profile.rate !== '' ? Number(profile.rate) : null,
       notes: profile.notes || '',
       achievements: profile.achievements || '',
       video_url: profile.video_url || '',
       avatar_url: profile.avatar_url || '',
-      photos: profile.photos,
+      photos: profile.photos.length > 0 ? profile.photos : null,
       twitter: profile.twitter || '',
       instagram: profile.instagram || '',
       youtube: profile.youtube || ''
     }
+
+    // Debug log before sending
+    console.log('📝 updateData:', updateData)
 
     const { data: existing } = await supabase
       .from('talents')

--- a/talentify-next-frontend/app/talents/[id]/TalentDetailPageClient.tsx
+++ b/talentify-next-frontend/app/talents/[id]/TalentDetailPageClient.tsx
@@ -58,9 +58,14 @@ export default function TalentDetailPageClient({ id }: Props) {
       if (res.ok) {
         const data = await res.json()
         setTalent(data)
+      } else {
+        const text = await res.text()
+        console.error('Failed to fetch talent:', text)
       }
 
-      const { data: { user } } = await supabase.auth.getUser()
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
       if (user) setUserId(user.id)
     }
 
@@ -161,11 +166,11 @@ export default function TalentDetailPageClient({ id }: Props) {
         </CardContent>
       </Card>
 
-      {talent.photos && talent.photos.length > 0 && (
+      {Array.isArray(talent.photos) && talent.photos.length > 0 && (
         <Card>
           <CardContent>
             <div className="flex overflow-x-auto gap-3 pb-2">
-              {talent.photos.map((p, i) => (
+              {(talent.photos ?? []).map((p, i) => (
                 <div
                   key={i}
                   className="flex-none w-40 h-40 rounded-lg overflow-hidden bg-gray-100"


### PR DESCRIPTION
## Summary
- handle missing id and no data in `/api/talents/[id]`
- log errors and respond with 404 when talent not found
- guard against empty photos array when saving talent profile
- output debug log for talent profile update
- log fetch failures and validate photos array on talent detail page

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68803da6f0b48332ac38f6bfb02dae40