### PR TITLE
Fix store update logic and improve validation

### DIFF
--- a/talentify-next-frontend/app/auth/callback/page.tsx
+++ b/talentify-next-frontend/app/auth/callback/page.tsx
@@ -55,11 +55,21 @@ export default function AuthCallbackPage() {
             return
           }
         } else {
-          const { error: insertError } = await supabase
+          const { error: upsertError } = await supabase
             .from('stores')
-            .insert([{ user_id: userId, display_name: '' }])
-          if (insertError) {
-            console.error('profile insert error:', insertError)
+            .upsert(
+              { user_id: userId, display_name: '' },
+              { onConflict: 'user_id' }
+            )
+          if (upsertError) {
+            console.error('profile insert error:', upsertError)
+            alert(`Supabase更新エラー: ${upsertError.message}`)
+            if (
+              upsertError.message.toLowerCase().includes('row level security') ||
+              upsertError.message.toLowerCase().includes('permission')
+            ) {
+              console.warn('RLS policy may prevent inserting/updating stores')
+            }
             return
           }
         }

--- a/talentify-next-frontend/app/store/edit/page.tsx
+++ b/talentify-next-frontend/app/store/edit/page.tsx
@@ -57,6 +57,11 @@ export default function StoreProfileEditPage() {
     return
   }
 
+  if (!profile.display_name.trim()) {
+    alert('店舗名（表示名）は必須です')
+    return
+  }
+
   // ✅ 保存前のログ
   console.log("📝 保存データ（送信前）:", {
     ...profile,
@@ -82,7 +87,13 @@ export default function StoreProfileEditPage() {
       hint: error.hint,
       code: error.code,
     })
-    alert('保存に失敗しました')
+    alert(`保存に失敗しました: ${error.message}`)
+    if (
+      error.message.toLowerCase().includes('row level security') ||
+      error.message.toLowerCase().includes('permission')
+    ) {
+      console.warn('RLS policy may prevent inserting/updating stores')
+    }
   } else {
     // ✅ 成功ログ
     console.log("✅ プロフィール保存成功")

--- a/talentify-next-frontend/app/store/settings/page.tsx
+++ b/talentify-next-frontend/app/store/settings/page.tsx
@@ -56,6 +56,11 @@ export default function StoreSettingsPage() {
     const { data: { user } } = await supabase.auth.getUser()
     if (!user) return
 
+    if (!settings.store_name.trim()) {
+      alert('店舗名は必須です')
+      return
+    }
+
     const storeValues = { user_id: user.id, ...settings } as any
     const { error } = await supabase
       .from('stores')
@@ -63,7 +68,13 @@ export default function StoreSettingsPage() {
 
     if (error) {
       console.error('保存に失敗しました', error)
-      alert('保存に失敗しました')
+      alert(`保存に失敗しました: ${error.message}`)
+      if (
+        error.message.toLowerCase().includes('row level security') ||
+        error.message.toLowerCase().includes('permission')
+      ) {
+        console.warn('RLS policy may prevent inserting/updating stores')
+      }
     } else {
       setToast('更新しました')
       setTimeout(() => setToast(null), 3000)


### PR DESCRIPTION
## Summary
- update auth callback to use `upsert` when creating store profile
- validate required fields and show Supabase error messages for store profile and settings pages
- add RLS warning logs when permission errors occur

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881e1435d04833291b7a34f0d8be062