### PR TITLE
Fix talent edit 404 and add dynamic route

### DIFF
--- a/talentify-next-frontend/app/talent/edit/[code]/page.tsx
+++ b/talentify-next-frontend/app/talent/edit/[code]/page.tsx
@@ -1,0 +1,27 @@
+import { createClient } from '@/lib/supabase/server'
+import EditClient from '../EditClient'
+
+export const dynamic = 'force-dynamic'
+
+export default async function Page({ params }: { params: { code: string } }) {
+  const supabase = await createClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+
+  if (!session) {
+    return <main className="p-4">ログインしてください</main>
+  }
+
+  const { data, error } = await supabase
+    .from('talents')
+    .select('*')
+    .eq('id', params.code)
+    .maybeSingle()
+
+  if (error || !data) {
+    return <main className="p-4">このプロフィールは存在しません</main>
+  }
+
+  return <EditClient code={params.code} />
+}

--- a/talentify-next-frontend/app/talent/edit/page.tsx
+++ b/talentify-next-frontend/app/talent/edit/page.tsx
@@ -1,4 +1,3 @@
-import { notFound } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import EditClient from './EditClient'
 
@@ -6,9 +5,16 @@ export const dynamic = 'force-dynamic'
 
 export default async function Page({ searchParams }: { searchParams: { code?: string } }) {
   const supabase = await createClient()
-  const code = searchParams.code || null
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
 
-  // If code provided, fetch that talent; otherwise fetch logged-in user
+  if (!session) {
+    return <main className="p-4">ログインしてください</main>
+  }
+
+  const code = searchParams.code ?? session.user.id
+
   if (code) {
     const { data, error } = await supabase
       .from('talents')
@@ -17,7 +23,7 @@ export default async function Page({ searchParams }: { searchParams: { code?: st
       .maybeSingle()
 
     if (error || !data) {
-      notFound()
+      return <main className="p-4">このプロフィールは存在しません</main>
     }
   }
 


### PR DESCRIPTION
## Summary
- update `/talent/edit` page to show login and not found messages
- add dynamic `/talent/edit/[code]` route for editing a specific talent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882d696775c83328424984ee2d4c80f