### PR TITLE
Enforce initial profile setup

### DIFF
--- a/talentify-next-frontend/app/(auth)/dashboard/page.tsx
+++ b/talentify-next-frontend/app/(auth)/dashboard/page.tsx
@@ -6,14 +6,20 @@ import { useUserRole } from '@/utils/useRole'
 
 export default function DashboardRedirectPage() {
   const router = useRouter()
-  const { role, loading } = useUserRole()
+  const { role, isSetupComplete, loading } = useUserRole()
 
   useEffect(() => {
     if (loading) return
-    if (role === 'store') router.replace('/store/dashboard')
-    else if (role === 'talent') router.replace('/talent/dashboard')
-    else router.replace('/')
-  }, [role, loading, router])
+    if (role === 'store') {
+      router.replace(isSetupComplete ? '/store/dashboard' : '/store/edit')
+    } else if (role === 'talent') {
+      router.replace(isSetupComplete ? '/talent/dashboard' : '/talent/edit')
+    } else if (role === 'company') {
+      router.replace(isSetupComplete ? '/company/dashboard' : '/company/edit')
+    } else {
+      router.replace('/')
+    }
+  }, [role, isSetupComplete, loading, router])
 
   return null
 }

--- a/talentify-next-frontend/app/company/edit/page.tsx
+++ b/talentify-next-frontend/app/company/edit/page.tsx
@@ -65,6 +65,7 @@ export default function CompanyProfileEditPage() {
       description: profile.description || null,
       avatar_url: profile.avatar_url || null,
       user_id: user.id,
+      is_setup_complete: true,
     }
 
     const { error } = await supabase

--- a/talentify-next-frontend/app/page.tsx
+++ b/talentify-next-frontend/app/page.tsx
@@ -18,19 +18,33 @@ export default async function HomePage() {
   if (session) {
     const userId = session.user.id;
     const { data: store } = await sb
-      .from<{ id: string }>('stores')
-      .select('id')
+      .from<{ id: string; is_setup_complete: boolean | null }>('stores')
+      .select('id, is_setup_complete')
       .eq('user_id', userId)
       .maybeSingle();
     const { data: talent } = await sb
-      .from<{ id: string }>('talents')
-      .select('id')
+      .from<{ id: string; is_setup_complete: boolean | null }>('talents')
+      .select('id, is_setup_complete')
+      .eq('user_id', userId)
+      .maybeSingle();
+    const { data: company } = await sb
+      .from<{ id: string; is_setup_complete: boolean | null }>('companies')
+      .select('id, is_setup_complete')
       .eq('user_id', userId)
       .maybeSingle();
 
-    if (store) redirect('/store/dashboard');
-    else if (talent) redirect('/talent/dashboard');
-    else redirect('/dashboard');
+    if (store) {
+      if (!(store as any).is_setup_complete) redirect('/store/edit');
+      else redirect('/store/dashboard');
+    } else if (talent) {
+      if (!(talent as any).is_setup_complete) redirect('/talent/edit');
+      else redirect('/talent/dashboard');
+    } else if (company) {
+      if (!(company as any).is_setup_complete) redirect('/company/edit');
+      else redirect('/company/dashboard');
+    } else {
+      redirect('/dashboard');
+    }
   }
 
   return (

--- a/talentify-next-frontend/app/store/edit/page.tsx
+++ b/talentify-next-frontend/app/store/edit/page.tsx
@@ -73,6 +73,7 @@ export default function StoreProfileEditPage() {
     bio: profile.bio || null,
     avatar_url: profile.avatar_url || null,
     user_id: user.id,
+    is_setup_complete: true,
   }
 
   const { error } = await supabase

--- a/talentify-next-frontend/app/talent/edit/EditClient.tsx
+++ b/talentify-next-frontend/app/talent/edit/EditClient.tsx
@@ -169,6 +169,7 @@ export default function TalentProfileEditPageClient({ code }: { code?: string | 
       social_x: profile.twitter || null,
       social_instagram: profile.instagram || null,
       social_youtube: profile.youtube || null,
+      is_setup_complete: true,
     }
 
     // Debug log before sending

--- a/talentify-next-frontend/lib/getUserRole.ts
+++ b/talentify-next-frontend/lib/getUserRole.ts
@@ -6,33 +6,45 @@ export type UserRole = 'store' | 'talent' | 'company'
 export async function getUserRoleInfo(
   supabase: SupabaseClient<Database>,
   userId: string
-): Promise<{ role: UserRole | null; name: string | null }> {
+): Promise<{ role: UserRole | null; name: string | null; isSetupComplete: boolean | null }> {
   const { data: store } = await supabase
     .from('stores' as any)
-    .select('store_name')
+    .select('store_name, is_setup_complete')
     .eq('user_id', userId)
     .maybeSingle()
   if (store) {
-    return { role: 'store', name: (store as any).store_name ?? '店舗ユーザー' }
+    return {
+      role: 'store',
+      name: (store as any).store_name ?? '店舗ユーザー',
+      isSetupComplete: (store as any).is_setup_complete ?? false,
+    }
   }
 
   const { data: talent } = await supabase
     .from('talents' as any)
-    .select('stage_name')
+    .select('stage_name, is_setup_complete')
     .eq('id', userId)
     .maybeSingle()
   if (talent) {
-    return { role: 'talent', name: (talent as any).stage_name ?? 'タレント' }
+    return {
+      role: 'talent',
+      name: (talent as any).stage_name ?? 'タレント',
+      isSetupComplete: (talent as any).is_setup_complete ?? false,
+    }
   }
 
   const { data: company } = await supabase
     .from('companies' as any)
-    .select('display_name')
+    .select('display_name, is_setup_complete')
     .eq('user_id', userId)
     .maybeSingle()
   if (company) {
-    return { role: 'company', name: (company as any).display_name ?? '会社ユーザー' }
+    return {
+      role: 'company',
+      name: (company as any).display_name ?? '会社ユーザー',
+      isSetupComplete: (company as any).is_setup_complete ?? false,
+    }
   }
 
-  return { role: null, name: null }
+  return { role: null, name: null, isSetupComplete: null }
 }

--- a/talentify-next-frontend/middleware.ts
+++ b/talentify-next-frontend/middleware.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from 'next/server'
 import { createServerClient } from '@supabase/ssr'
 import type { Database } from './types/supabase'
+import { getUserRoleInfo } from './lib/getUserRole'
 
 export async function middleware(req: NextRequest) {
   const res = NextResponse.next()
@@ -31,6 +32,19 @@ export async function middleware(req: NextRequest) {
 
   if (pathname === '/' && !isLoggedIn) {
     return res
+  }
+
+  if (isLoggedIn) {
+    const { role, isSetupComplete } = await getUserRoleInfo(
+      supabase,
+      session!.user.id
+    )
+    const editPath = role ? `/${role}/edit` : null
+    if (role && isSetupComplete === false && !pathname.startsWith(editPath || '')) {
+      const url = req.nextUrl.clone()
+      url.pathname = editPath!
+      return NextResponse.redirect(url)
+    }
   }
 
   if (

--- a/talentify-next-frontend/types/supabase.ts
+++ b/talentify-next-frontend/types/supabase.ts
@@ -20,6 +20,7 @@ export type Database = {
           id: string
           updated_at: string | null
           user_id: string
+          is_setup_complete: boolean | null
         }
         Insert: {
           avatar_url?: string | null
@@ -29,6 +30,7 @@ export type Database = {
           id?: string
           updated_at?: string | null
           user_id: string
+          is_setup_complete?: boolean | null
         }
         Update: {
           avatar_url?: string | null
@@ -38,6 +40,7 @@ export type Database = {
           id?: string
           updated_at?: string | null
           user_id?: string
+          is_setup_complete?: boolean | null
         }
         Relationships: []
       }
@@ -145,6 +148,7 @@ export type Database = {
           rate: number | null
           skills: string[] | null
           social_links: string[] | null
+          is_setup_complete: boolean | null
         }
         Insert: {
           area?: string | null
@@ -180,6 +184,7 @@ export type Database = {
           rate?: number | null
           skills?: string[] | null
           social_links?: string[] | null
+          is_setup_complete?: boolean | null
         }
         Update: {
           area?: string | null
@@ -215,6 +220,7 @@ export type Database = {
           rate?: number | null
           skills?: string[] | null
           social_links?: string[] | null
+          is_setup_complete?: boolean | null
         }
         Relationships: []
       },

--- a/talentify-next-frontend/utils/useRole.ts
+++ b/talentify-next-frontend/utils/useRole.ts
@@ -7,6 +7,7 @@ const supabase = createClient()
 
 export function useUserRole() {
   const [role, setRole] = useState<UserRole | null>(null)
+  const [isSetupComplete, setIsSetupComplete] = useState<boolean | null>(null)
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
@@ -18,13 +19,14 @@ export function useUserRole() {
         setLoading(false)
         return
       }
-      const { role: r } = await getUserRoleInfo(supabase, user.id)
+      const { role: r, isSetupComplete } = await getUserRoleInfo(supabase, user.id)
       setRole(r)
+      setIsSetupComplete(isSetupComplete)
       setLoading(false)
     }
 
     fetchRole()
   }, [])
 
-  return { role, loading }
+  return { role, isSetupComplete, loading }
 }


### PR DESCRIPTION
## Summary
- require profile completion before allowing dashboard access
- track setup completion in middleware using Supabase
- mark setup complete when saving profile edits
- surface setup status via utilities and dashboard redirect logic
- add schema types for `is_setup_complete`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882e5c0b5888332bee3938d050516a5