### PR TITLE
Improve store profile save UX

### DIFF
--- a/talentify-next-frontend/app/store/dashboard/page.tsx
+++ b/talentify-next-frontend/app/store/dashboard/page.tsx
@@ -11,6 +11,7 @@ import { Button } from '@/components/ui/button'
 import Link from 'next/link'
 import { Search as SearchIcon } from 'lucide-react'
 import { useEffect, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
 
 export default function StoreDashboard() {
   const offerStats = { pending: 1, accepted: 2 }
@@ -19,12 +20,22 @@ export default function StoreDashboard() {
   ]
   const unread = 3
   const [loading, setLoading] = useState(true)
+  const [toast, setToast] = useState<string | null>(null)
+  const searchParams = useSearchParams()
 
   const hasData = offerStats.pending + offerStats.accepted > 0
 
   useEffect(() => {
     setTimeout(() => setLoading(false), 500)
   }, [])
+
+  useEffect(() => {
+    if (searchParams.get('saved') === '1') {
+      setToast('保存しました')
+      const timer = setTimeout(() => setToast(null), 3000)
+      return () => clearTimeout(timer)
+    }
+  }, [searchParams])
 
   return (
     <div className='space-y-4'>
@@ -63,7 +74,12 @@ export default function StoreDashboard() {
           <div className='sm:col-span-2'>
             <MessageAlertCard count={unread} link='/store/messages' />
           </div>
-          <NotificationListCard className='sm:col-span-2' />
+        <NotificationListCard className='sm:col-span-2' />
+      </div>
+      )}
+      {toast && (
+        <div className='fixed top-4 right-4 bg-green-600 text-white px-4 py-2 rounded shadow'>
+          {toast}
         </div>
       )}
     </div>

--- a/talentify-next-frontend/app/store/edit/complete/page.tsx
+++ b/talentify-next-frontend/app/store/edit/complete/page.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+
+export default function StoreEditComplete() {
+  return (
+    <div className="flex flex-col items-center justify-center h-full p-6 space-y-6">
+      <h1 className="text-2xl font-bold">登録が完了しました！</h1>
+      <Link href="/dashboard">
+        <Button>ダッシュボードへ進む</Button>
+      </Link>
+    </div>
+  )
+}

--- a/talentify-next-frontend/app/store/edit/page.tsx
+++ b/talentify-next-frontend/app/store/edit/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
 import { createClient } from '@/utils/supabase/client'
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
@@ -9,7 +10,9 @@ import { Button } from "@/components/ui/button"
 const supabase = createClient()
 
 export default function StoreProfileEditPage() {
+  const router = useRouter()
   const [loading, setLoading] = useState(true)
+  const [isNew, setIsNew] = useState(false)
   const [profile, setProfile] = useState({
     store_name: '',
     bio: '',
@@ -28,16 +31,25 @@ export default function StoreProfileEditPage() {
         .from('stores')
         .select('store_name, bio, avatar_url')
         .eq('user_id', user.id)
-        .single()
+        .maybeSingle()
 
-      if (!error && data) {
-        setProfile(data)
-      } else {
+      if (error) {
         console.error("プロフィール読み込みエラー:", {
           message: error?.message,
           details: error?.details,
           hint: error?.hint,
         })
+      }
+
+      if (data) {
+        setProfile({
+          store_name: data.store_name ?? '',
+          bio: data.bio ?? '',
+          avatar_url: data.avatar_url ?? '',
+        })
+        setIsNew(false)
+      } else {
+        setIsNew(true)
       }
       setLoading(false)
     }
@@ -97,7 +109,11 @@ export default function StoreProfileEditPage() {
   } else {
     // ✅ 成功ログ
     console.log("✅ プロフィール保存成功")
-    alert('保存しました')
+    if (isNew) {
+      router.push('/store/edit/complete')
+    } else {
+      router.push('/dashboard?saved=1')
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- redirect store profile save based on creation state
- show dashboard toast after edit save
- add simple completion page after first store profile save

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882ead7419c83328ca8de78f3397b18