### PR TITLE
Redirect query code to dynamic talent edit page

### DIFF
--- a/talentify-next-frontend/app/talent/edit/page.tsx
+++ b/talentify-next-frontend/app/talent/edit/page.tsx
@@ -1,3 +1,4 @@
+import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import EditClient from './EditClient'
 
@@ -14,6 +15,10 @@ export default async function Page({ searchParams }: { searchParams: { code?: st
   }
 
   const code = searchParams.code ?? session.user.id
+
+  if (searchParams.code && searchParams.code !== session.user.id) {
+    redirect(`/talent/edit/${searchParams.code}`)
+  }
 
   if (code) {
     const { data, error } = await supabase


### PR DESCRIPTION
## Summary
- handle `code` query with a redirect to `/talent/edit/[code]`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882ef30305c8332b523f802521de429