### PR TITLE
Fix middleware redirect loop for edit pages

### DIFF
--- a/talentify-next-frontend/middleware.ts
+++ b/talentify-next-frontend/middleware.ts
@@ -40,6 +40,11 @@ export async function middleware(req: NextRequest) {
       session!.user.id
     )
     const editPath = role ? `/${role}/edit` : null
+
+    if (editPath && pathname.startsWith(editPath)) {
+      return res
+    }
+
     if (role && isSetupComplete === false && !pathname.startsWith(editPath || '')) {
       const url = req.nextUrl.clone()
       url.pathname = editPath!


### PR DESCRIPTION
## Summary
- avoid middleware loop by allowing role edit pages to pass through

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882f4fbbfc88332b9405902b60dcd71