### PR TITLE
Fix email verification flow

### DIFF
--- a/talentify-next-frontend/__tests__/getRedirectUrl.test.ts
+++ b/talentify-next-frontend/__tests__/getRedirectUrl.test.ts
@@ -9,26 +9,26 @@ describe('getRedirectUrl', () => {
     process.env = originalEnv
   })
 
-  test('returns localhost path for store in development', () => {
+  test('returns localhost callback path in development', () => {
     const env = { ...process.env } as NodeJS.ProcessEnv
     env.NODE_ENV = 'development'
     process.env = env
-    expect(getRedirectUrl('store')).toBe('http://localhost:3000/store/edit')
+    expect(getRedirectUrl('store')).toBe('http://localhost:3000/auth/callback')
   })
 
-  test('returns NEXT_PUBLIC_SITE_URL for talent in production', () => {
+  test('returns NEXT_PUBLIC_SITE_URL callback in production', () => {
     const env = { ...process.env } as NodeJS.ProcessEnv
     env.NODE_ENV = 'production'
     env.NEXT_PUBLIC_SITE_URL = 'https://example.com'
     process.env = env
-    expect(getRedirectUrl('talent')).toBe('https://example.com/talent/edit')
+    expect(getRedirectUrl('talent')).toBe('https://example.com/auth/callback')
   })
 
-  test('defaults to root for unknown role', () => {
+  test('still returns callback for unknown role', () => {
     const env = { ...process.env } as NodeJS.ProcessEnv
     env.NODE_ENV = 'production'
     env.NEXT_PUBLIC_SITE_URL = 'https://example.com'
     process.env = env
-    expect(getRedirectUrl('unknown')).toBe('https://example.com/')
+    expect(getRedirectUrl('unknown')).toBe('https://example.com/auth/callback')
   })
 })

--- a/talentify-next-frontend/app/auth/callback/page.tsx
+++ b/talentify-next-frontend/app/auth/callback/page.tsx
@@ -11,6 +11,19 @@ export default function AuthCallbackPage() {
 
   useEffect(() => {
     const checkAndRedirect = async () => {
+      // When the user clicks the confirmation link from the email, Supabase
+      // appends an auth `code` to the callback URL. We need to exchange this
+      // code for a session so that `getSession` returns a valid session.
+      const urlParams = new URLSearchParams(window.location.search)
+      const code = urlParams.get('code')
+
+      if (code) {
+        const { error } = await supabase.auth.exchangeCodeForSession(code)
+        if (error) {
+          console.error('Failed to exchange code:', error)
+        }
+      }
+
       const {
         data: { session },
       } = await supabase.auth.getSession()

--- a/talentify-next-frontend/lib/getRedirectUrl.ts
+++ b/talentify-next-frontend/lib/getRedirectUrl.ts
@@ -4,13 +4,9 @@ export function getRedirectUrl(role: string) {
       ? 'http://localhost:3000'
       : process.env.NEXT_PUBLIC_SITE_URL || 'https://talentify-xi.vercel.app'
 
-  if (role === 'store') {
-    return `${baseUrl}/store/edit`
-  } else if (role === 'talent') {
-    return `${baseUrl}/talent/edit`
-  } else if (role === 'company') {
-    return `${baseUrl}/company/edit`
-  } else {
-    return `${baseUrl}/`
-  }
+  // Always redirect to the auth callback so that Supabase session tokens
+  // contained in the confirmation link can be exchanged properly. The
+  // callback page will handle inserting profile rows and redirecting the user
+  // to the appropriate edit page based on their role stored in localStorage.
+  return `${baseUrl}/auth/callback`
 }


### PR DESCRIPTION
## Summary
- ensure redirect after signup goes to `/auth/callback`
- handle auth code in callback page to create the session
- update related tests

## Testing
- `npm test --silent`
- `npx jest --runTestsByPath __tests__/getRedirectUrl.test.ts --colors`


------
https://chatgpt.com/codex/tasks/task_e_6882f8aad86c8332bdbd62ca9356d1cf