### PR TITLE
Remove email field from talent insert

### DIFF
--- a/talentify-next-frontend/app/api/talents/route.ts
+++ b/talentify-next-frontend/app/api/talents/route.ts
@@ -26,7 +26,6 @@ export async function POST(req: Request) {
 
   const {
     name,
-    email,
     profile,
     sns_links,
     area,
@@ -43,7 +42,6 @@ export async function POST(req: Request) {
     .insert([
       {
         name,
-        email,
         profile,
         sns_links,
         area,

--- a/talentify-next-frontend/app/auth/callback/page.tsx
+++ b/talentify-next-frontend/app/auth/callback/page.tsx
@@ -46,7 +46,6 @@ export default function AuthCallbackPage() {
               {
                 id: userId,
                 user_id: userId,
-                email: session.user.email ?? '',
                 name: '',
                 is_setup_complete: false,
               },

--- a/talentify-next-frontend/app/talent/edit/EditClient.tsx
+++ b/talentify-next-frontend/app/talent/edit/EditClient.tsx
@@ -150,7 +150,6 @@ export default function TalentProfileEditPageClient({ code }: { code?: string | 
 
     const updateData = {
       id: user.id,
-      email: user.email ?? '',
       name: profile.name,
       stage_name: profile.stage_name,
       profile: profile.description || null,

--- a/talentify-next-frontend/types/supabase.ts
+++ b/talentify-next-frontend/types/supabase.ts
@@ -133,7 +133,6 @@ export type Database = {
           birthplace: string | null
           height_cm: number | null
           agency_name: string | null
-          email: string
           experience_years: number | null
           social_x: string | null
           social_instagram: string | null
@@ -169,7 +168,6 @@ export type Database = {
           birthplace?: string | null
           height_cm?: number | null
           agency_name?: string | null
-          email: string
           experience_years?: number | null
           social_x?: string | null
           social_instagram?: string | null
@@ -205,7 +203,6 @@ export type Database = {
           birthplace?: string | null
           height_cm?: number | null
           agency_name?: string | null
-          email?: string
           experience_years?: number | null
           social_x?: string | null
           social_instagram?: string | null


### PR DESCRIPTION
## Summary
- fix talent signup flow by removing nonexistent `email` column from talent insertions
- update API route and profile editor accordingly
- sync Supabase types with current schema

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68830aefb848833286af66d0a1a2f293