### PR TITLE
Align talent SNS fields with Supabase schema

### DIFF
--- a/supabase/migrations/0005_add_sns_links.sql
+++ b/supabase/migrations/0005_add_sns_links.sql
@@ -1,0 +1,4 @@
+ALTER TABLE public.talents
+ADD COLUMN IF NOT EXISTS instagram text,
+ADD COLUMN IF NOT EXISTS x text,
+ADD COLUMN IF NOT EXISTS youtube text;

--- a/talentify-next-frontend/app/api/talents/[id]/route.ts
+++ b/talentify-next-frontend/app/api/talents/[id]/route.ts
@@ -14,7 +14,7 @@ export async function GET(
     return NextResponse.json({ error: 'id is required' }, { status: 400 })
   }
 
-  const fields = 'id,user_id,stage_name,birthdate,gender,residence,birthplace,height_cm,agency_name,agency_url,avatar_url,photos,area,bio_hobby,bio_certifications,notes,media_appearance,profile,social_x,social_instagram,social_youtube' as const
+  const fields = 'id,user_id,stage_name,birthdate,gender,residence,birthplace,height_cm,agency_name,agency_url,avatar_url,photos,area,bio_hobby,bio_certifications,notes,media_appearance,profile,x,instagram,youtube' as const
 
   const { data, error } = await supabase
     .from('talents')
@@ -52,9 +52,9 @@ export async function GET(
     notes: data.notes,
     profile: data.profile,
     media_appearance: data.media_appearance,
-    twitter: data.social_x,
-    instagram: data.social_instagram,
-    youtube: data.social_youtube,
+    twitter: data.x,
+    instagram: data.instagram,
+    youtube: data.youtube,
   }
 
   return NextResponse.json(result, { status: 200 })

--- a/talentify-next-frontend/app/talent/edit/EditClient.tsx
+++ b/talentify-next-frontend/app/talent/edit/EditClient.tsx
@@ -53,7 +53,7 @@ export default function TalentProfileEditPageClient({ code }: { code?: string | 
       }
       setUserId(user.id)
 
-      const fields = 'name,stage_name,description:profile,residence,area,genre,availability,min_hours,transportation,rate,notes,achievements:media_appearance,video_url,avatar_url,photos,twitter:social_x,instagram:social_instagram,youtube:social_youtube' as const
+      const fields = 'name,stage_name,description:profile,residence,area,genre,availability,min_hours,transportation,rate,notes,achievements:media_appearance,video_url,avatar_url,photos,twitter:x,instagram,youtube' as const
 
       const { data, error } = await supabase
         .from('talents' as any)
@@ -149,25 +149,24 @@ export default function TalentProfileEditPageClient({ code }: { code?: string | 
     }
 
     const updateData = {
-      id: user.id,
       name: profile.name,
       stage_name: profile.stage_name,
-      profile: profile.description || null,
-      residence: profile.residence || null,
-      area: profile.area.length > 0 ? profile.area : null,
-      genre: profile.genre || null,
-      availability: profile.availability || null,
-      min_hours: profile.min_hours || null,
-      transportation: profile.transportation || null,
-      rate: profile.rate !== '' ? Number(profile.rate) : null,
-      notes: profile.notes || null,
-      media_appearance: profile.achievements || null,
-      video_url: profile.video_url || null,
-      avatar_url: profile.avatar_url || null,
-      photos: profile.photos.length > 0 ? profile.photos : null,
-      social_x: profile.twitter || null,
-      social_instagram: profile.instagram || null,
-      social_youtube: profile.youtube || null,
+      ...(profile.description && { profile: profile.description }),
+      ...(profile.residence && { residence: profile.residence }),
+      ...(profile.area.length > 0 && { area: profile.area }),
+      ...(profile.genre && { genre: profile.genre }),
+      ...(profile.availability && { availability: profile.availability }),
+      ...(profile.min_hours && { min_hours: profile.min_hours }),
+      ...(profile.transportation && { transportation: profile.transportation }),
+      ...(profile.rate !== '' && { rate: Number(profile.rate) }),
+      ...(profile.notes && { notes: profile.notes }),
+      ...(profile.achievements && { media_appearance: profile.achievements }),
+      ...(profile.video_url && { video_url: profile.video_url }),
+      ...(profile.avatar_url && { avatar_url: profile.avatar_url }),
+      ...(profile.photos.length > 0 && { photos: profile.photos }),
+      ...(profile.twitter && { x: profile.twitter }),
+      ...(profile.instagram && { instagram: profile.instagram }),
+      ...(profile.youtube && { youtube: profile.youtube }),
       is_setup_complete: true,
     }
 

--- a/talentify-next-frontend/app/talents/[id]/page.tsx
+++ b/talentify-next-frontend/app/talents/[id]/page.tsx
@@ -15,7 +15,7 @@ export default async function Page({ params }: PageProps) {
   const { data, error } = await supabase
     .from('talents')
     .select(
-      'id,user_id,stage_name,birthdate,gender,residence,birthplace,height_cm,agency_name,agency_url,avatar_url,photos,bio_hobby,bio_certifications,notes,media_appearance,profile,social_x,social_instagram,social_youtube'
+      'id,user_id,stage_name,birthdate,gender,residence,birthplace,height_cm,agency_name,agency_url,avatar_url,photos,bio_hobby,bio_certifications,notes,media_appearance,profile,x,instagram,youtube'
     )
     .eq('id', params.id)
     .maybeSingle<any>()
@@ -42,9 +42,9 @@ export default async function Page({ params }: PageProps) {
     notes: data.notes,
     profile: data.profile,
     media_appearance: data.media_appearance,
-    twitter: data.social_x,
-    instagram: data.social_instagram,
-    youtube: data.social_youtube,
+    twitter: data.x,
+    instagram: data.instagram,
+    youtube: data.youtube,
   }
 
   return <TalentDetailPageClient id={params.id} initialTalent={talent} />

--- a/talentify-next-frontend/types/supabase.ts
+++ b/talentify-next-frontend/types/supabase.ts
@@ -134,9 +134,9 @@ export type Database = {
           height_cm: number | null
           agency_name: string | null
           experience_years: number | null
-          social_x: string | null
-          social_instagram: string | null
-          social_youtube: string | null
+          x: string | null
+          instagram: string | null
+          youtube: string | null
           social_tiktok: string | null
           photos: string[] | null
           media_appearance: string | null
@@ -169,9 +169,9 @@ export type Database = {
           height_cm?: number | null
           agency_name?: string | null
           experience_years?: number | null
-          social_x?: string | null
-          social_instagram?: string | null
-          social_youtube?: string | null
+          x?: string | null
+          instagram?: string | null
+          youtube?: string | null
           social_tiktok?: string | null
           photos?: string[] | null
           media_appearance?: string | null
@@ -204,9 +204,9 @@ export type Database = {
           height_cm?: number | null
           agency_name?: string | null
           experience_years?: number | null
-          social_x?: string | null
-          social_instagram?: string | null
-          social_youtube?: string | null
+          x?: string | null
+          instagram?: string | null
+          youtube?: string | null
           social_tiktok?: string | null
           photos?: string[] | null
           media_appearance?: string | null


### PR DESCRIPTION
## Summary
- fix `/talent/edit` profile update to match Supabase columns
- fetch new SNS fields when reading profiles
- update API route for new SNS column names
- regenerate Supabase types
- add migration to create `instagram`, `x` and `youtube` columns

## Testing
- `npm test --prefix talentify-next-frontend`

------
https://chatgpt.com/codex/tasks/task_e_688313928f1883328d7ae7775c3623e0