### PR TITLE
Fix talent detail layout spacing

### DIFF
--- a/talentify-next-frontend/app/talents/[id]/TalentDetailPageClient.tsx
+++ b/talentify-next-frontend/app/talents/[id]/TalentDetailPageClient.tsx
@@ -105,7 +105,7 @@ export default function TalentDetailPageClient({ id, initialTalent }: Props) {
   }
 
   return (
-    <main className="max-w-3xl mx-auto p-4 space-y-6">
+    <main className="max-w-3xl mx-auto p-4 space-y-6 mt-16 scroll-mt-16">
       <Card>
         <CardContent className="flex flex-col sm:flex-row gap-4 items-start">
           <div className="w-full sm:w-48 h-48 rounded-lg overflow-hidden bg-gray-100 flex-shrink-0">

--- a/talentify-next-frontend/app/talents/layout.tsx
+++ b/talentify-next-frontend/app/talents/layout.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import Header from '@/components/Header'
+import Sidebar from '@/components/Sidebar'
+import { createClient } from '@/lib/supabase/server'
+import { SupabaseProvider } from '@/lib/supabase/provider'
+
+export const metadata = {
+  title: 'Talentify | 演者',
+}
+
+export default async function TalentsLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const supabase = await createClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+
+  return (
+    <html lang="ja">
+      <body className="font-sans antialiased bg-white text-black">
+        <SupabaseProvider session={session}>
+          <Header sidebarRole="store" />
+          <div className="flex h-[calc(100vh-64px)] pt-16">
+            <aside className="hidden md:block">
+              <Sidebar role="store" collapsible />
+            </aside>
+            <main className="flex-1 overflow-y-auto p-6">{children}</main>
+          </div>
+        </SupabaseProvider>
+      </body>
+    </html>
+  )
+}


### PR DESCRIPTION
## Summary
- add top spacing for talent detail page to avoid header overlap
- apply sidebar layout to talents pages for consistency

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6883356e10b48332b58b115950524ebe