### PR TITLE
Align offer payload with DB schema

### DIFF
--- a/supabase/migrations/0006_add_offer_request_fields.sql
+++ b/supabase/migrations/0006_add_offer_request_fields.sql
@@ -1,0 +1,6 @@
+ALTER TABLE public.offers
+  ADD COLUMN IF NOT EXISTS second_date date,
+  ADD COLUMN IF NOT EXISTS third_date date,
+  ADD COLUMN IF NOT EXISTS time_range text,
+  ADD COLUMN IF NOT EXISTS remarks text,
+  ADD COLUMN IF NOT EXISTS agreed boolean;

--- a/talentify-next-frontend/app/talents/[id]/TalentDetailPageClient.tsx
+++ b/talentify-next-frontend/app/talents/[id]/TalentDetailPageClient.tsx
@@ -92,11 +92,22 @@ export default function TalentDetailPageClient({ id, initialTalent }: Props) {
     }
 
     const message = `第1希望:${date1}\n第2希望:${date2}\n第3希望:${date3}\n希望時間帯:${timeSlot}\n備考:${remarks}`
+    const payload = {
+      user_id: user.id,
+      talent_id: id,
+      message,
+      date: date1,
+      second_date: date2 || null,
+      third_date: date3 || null,
+      time_range: timeSlot || null,
+      remarks: remarks || null,
+      agreed: agree,
+      status: 'pending'
+    }
 
-    const { error } = await supabase.from('offers').insert([
-      { user_id: user.id, talent_id: id, message, date: date1, status: 'pending' }
-    ])
+    const { error } = await supabase.from('offers').insert([payload])
     if (error) {
+      console.log('offer insert error', { payload, error })
       alert('送信に失敗しました')
       return
     }

--- a/talentify-next-frontend/types/supabase.ts
+++ b/talentify-next-frontend/types/supabase.ts
@@ -338,6 +338,11 @@ export type Database = {
           talent_id: string
           message: string
           date: string
+          second_date: string | null
+          third_date: string | null
+          time_range: string | null
+          remarks: string | null
+          agreed: boolean | null
           created_at: string | null
           status: string | null
         }
@@ -347,6 +352,11 @@ export type Database = {
           talent_id: string
           message: string
           date: string
+          second_date?: string | null
+          third_date?: string | null
+          time_range?: string | null
+          remarks?: string | null
+          agreed?: boolean | null
           created_at?: string | null
           status?: string | null
         }
@@ -356,6 +366,11 @@ export type Database = {
           talent_id?: string
           message?: string
           date?: string
+          second_date?: string | null
+          third_date?: string | null
+          time_range?: string | null
+          remarks?: string | null
+          agreed?: boolean | null
           created_at?: string | null
           status?: string | null
         }


### PR DESCRIPTION
## Summary
- extend `offers` table with additional optional fields for detailed requests
- update generated Supabase types
- log offer payload for debugging

## Testing
- `npm test --prefix talentify-next-frontend`

------
https://chatgpt.com/codex/tasks/task_e_688337663f808332b2586f3b11b2a691