### PR TITLE
Fix offer payload field names

### DIFF
--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -21,7 +21,7 @@ interface Offer {
   start_time?: string | null
   end_time?: string | null
   reward?: number | null
-  notes?: string | null
+  remarks?: string | null
   question_allowed?: boolean | null
   user_id?: string
   store_name?: string | null
@@ -53,7 +53,7 @@ export default function TalentOfferDetailPage() {
       const { data, error } = await supabase
         .from('offers')
         .select(
-          `id, date, message, status, respond_deadline, event_name, start_time, end_time, reward, notes, question_allowed, user_id, stores(store_name,address,avatar_url)`,
+          `id, date, message, status, respond_deadline, event_name, start_time, end_time, reward, remarks, question_allowed, user_id, stores(store_name,address,avatar_url)`,
         )
         .eq('id', params.id)
         .single()
@@ -143,9 +143,9 @@ export default function TalentOfferDetailPage() {
             <div>報酬: {offer.reward.toLocaleString()}円</div>
           )}
           <div className="whitespace-pre-wrap">{offer.message}</div>
-          {offer.notes && (
+          {offer.remarks && (
             <div className="p-2 bg-muted rounded text-sm whitespace-pre-wrap">
-              {offer.notes}
+              {offer.remarks}
             </div>
           )}
         </CardContent>

--- a/talentify-next-frontend/app/talents/[id]/TalentDetailPageClient.tsx
+++ b/talentify-next-frontend/app/talents/[id]/TalentDetailPageClient.tsx
@@ -96,12 +96,12 @@ export default function TalentDetailPageClient({ id, initialTalent }: Props) {
       user_id: user.id,
       talent_id: id,
       message,
-      visit_date1: visitDate1,
-      visit_date2: visitDate2 || null,
-      visit_date3: visitDate3 || null,
+      date: visitDate1,
+      second_date: visitDate2 || null,
+      third_date: visitDate3 || null,
       time_range: timeRange || null,
-      note: note || null,
-      is_agreed: isAgreed,
+      remarks: note || null,
+      agreed: isAgreed,
       status: 'pending'
     }
 


### PR DESCRIPTION
## Summary
- align frontend payload fields with Supabase schema
- update offer detail page type and query field names

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68834371d83c8332ada862b02af8f1b4