### PR TITLE
Align notes column with Supabase

### DIFF
--- a/supabase/migrations/0007_rename_remarks_to_notes.sql
+++ b/supabase/migrations/0007_rename_remarks_to_notes.sql
@@ -1,0 +1,12 @@
+ALTER TABLE public.offers ADD COLUMN IF NOT EXISTS notes text;
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='offers' AND column_name='remarks'
+  ) THEN
+    UPDATE public.offers SET notes = remarks WHERE notes IS NULL;
+    ALTER TABLE public.offers DROP COLUMN remarks;
+  END IF;
+END;
+$$;

--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -21,7 +21,7 @@ interface Offer {
   start_time?: string | null
   end_time?: string | null
   reward?: number | null
-  remarks?: string | null
+  notes?: string | null
   question_allowed?: boolean | null
   user_id?: string
   store_name?: string | null
@@ -53,7 +53,7 @@ export default function TalentOfferDetailPage() {
       const { data, error } = await supabase
         .from('offers')
         .select(
-          `id, date, message, status, respond_deadline, event_name, start_time, end_time, reward, remarks, question_allowed, user_id, stores(store_name,address,avatar_url)`,
+          `id, date, message, status, respond_deadline, event_name, start_time, end_time, reward, notes, question_allowed, user_id, stores(store_name,address,avatar_url)`,
         )
         .eq('id', params.id)
         .single()
@@ -143,9 +143,9 @@ export default function TalentOfferDetailPage() {
             <div>報酬: {offer.reward.toLocaleString()}円</div>
           )}
           <div className="whitespace-pre-wrap">{offer.message}</div>
-          {offer.remarks && (
+          {offer.notes && (
             <div className="p-2 bg-muted rounded text-sm whitespace-pre-wrap">
-              {offer.remarks}
+              {offer.notes}
             </div>
           )}
         </CardContent>

--- a/talentify-next-frontend/app/talents/[id]/TalentDetailPageClient.tsx
+++ b/talentify-next-frontend/app/talents/[id]/TalentDetailPageClient.tsx
@@ -100,7 +100,7 @@ export default function TalentDetailPageClient({ id, initialTalent }: Props) {
       second_date: visitDate2 || null,
       third_date: visitDate3 || null,
       time_range: timeRange || null,
-      remarks: note || null,
+      notes: note || null,
       agreed: isAgreed,
       status: 'pending'
     }

--- a/talentify-next-frontend/types/supabase.ts
+++ b/talentify-next-frontend/types/supabase.ts
@@ -341,7 +341,7 @@ export type Database = {
           second_date: string | null
           third_date: string | null
           time_range: string | null
-          remarks: string | null
+          notes: string | null
           agreed: boolean | null
           created_at: string | null
           status: string | null
@@ -355,7 +355,7 @@ export type Database = {
           second_date?: string | null
           third_date?: string | null
           time_range?: string | null
-          remarks?: string | null
+          notes?: string | null
           agreed?: boolean | null
           created_at?: string | null
           status?: string | null
@@ -369,7 +369,7 @@ export type Database = {
           second_date?: string | null
           third_date?: string | null
           time_range?: string | null
-          remarks?: string | null
+          notes?: string | null
           agreed?: boolean | null
           created_at?: string | null
           status?: string | null


### PR DESCRIPTION
## Summary
- rename offers.remarks to notes in frontend
- add migration to rename column in DB
- update Supabase type definitions

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6886dbbe27c88332a233033a45623909