### PR TITLE
Fix offer details loading error handling

### DIFF
--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -38,6 +38,7 @@ export default function TalentOfferDetailPage() {
   const params = useParams<{ id: string }>()
   const supabase = createClient()
   const [offer, setOffer] = useState<Offer | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   const handleStatusChange = async (status: 'accepted' | 'rejected') => {
     if (!offer) return
@@ -55,6 +56,7 @@ export default function TalentOfferDetailPage() {
 
   useEffect(() => {
     const load = async () => {
+      setErrorMessage(null)
       const { data, error } = await supabase
         .from('offers')
         .select(
@@ -74,13 +76,16 @@ export default function TalentOfferDetailPage() {
           store_logo_url: store.avatar_url ?? null,
         })
       } else {
-        console.error("offer fetch error:", error)
+        console.error('offer fetch error:', error)
         setOffer(null)
+        setErrorMessage(error?.message || 'オファー情報を取得できませんでした')
       }
     }
     load()
   }, [params.id, supabase])
 
+  if (errorMessage)
+    return <p className="p-4 text-red-600">{errorMessage}</p>
   if (!offer) return <p className="p-4">Loading...</p>
 
   const deadline = offer.respond_deadline || ''


### PR DESCRIPTION
## Summary
- handle fetch errors in talent offer detail page
- show error message when data retrieval fails

## Testing
- `npm -s --prefix talentify-next-frontend test`


------
https://chatgpt.com/codex/tasks/task_e_6887079510f08332aa20656534b21800