### PR TITLE
Fix store relation query for talent offer details

### DIFF
--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -60,15 +60,15 @@ export default function TalentOfferDetailPage() {
       const { data, error } = await supabase
         .from('offers')
         .select(
-          `id, date, second_date, third_date, time_range, created_at, message, status, respond_deadline, event_name, start_time, end_time, reward, notes, question_allowed, agreed, user_id, stores(store_name,store_address,avatar_url)`,
+          `id, date, second_date, third_date, time_range, created_at, message, status, respond_deadline, event_name, start_time, end_time, reward, notes, question_allowed, agreed, user_id, store:store_id(store_name,store_address,avatar_url)`,
         )
         .eq('id', params.id)
         .single()
 
       if (!error && data) {
-        const store = (data as any).stores || {}
+        const store = (data as any).store || {}
         const offerData = { ...(data as any) }
-        delete offerData.stores
+        delete offerData.store
         setOffer({
           ...offerData,
           store_name: store.store_name ?? null,

--- a/talentify-next-frontend/utils/getReviewsForTalent.ts
+++ b/talentify-next-frontend/utils/getReviewsForTalent.ts
@@ -19,7 +19,7 @@ export async function getReviewsForTalent() {
 
   const { data, error } = await supabase
     .from('reviews' as any)
-    .select('id, rating, category_ratings, comment, created_at, stores(store_name), offers(date)')
+    .select('id, rating, category_ratings, comment, created_at, store:store_id(store_name), offers(date)')
     .eq('talent_id', user.id)
     .order('created_at', { ascending: false })
 
@@ -30,7 +30,7 @@ export async function getReviewsForTalent() {
 
   return (data || []).map((r: any) => ({
     id: r.id as string,
-    store_name: r.stores?.store_name ?? null,
+    store_name: r.store?.store_name ?? null,
     visit_date: r.offers?.date ?? null,
     rating: r.rating as number,
     category_ratings: r.category_ratings,


### PR DESCRIPTION
## Summary
- disambiguate store relationship when selecting offer details
- update reviews query to use explicit store relation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68870d12c77c8332aa23565a421015eb