### PR TITLE
Fix ambiguous store relation in offer detail page

### DIFF
--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -60,7 +60,7 @@ export default function TalentOfferDetailPage() {
       const { data, error } = await supabase
         .from('offers')
         .select(
-          `id, date, second_date, third_date, time_range, created_at, message, status, respond_deadline, event_name, start_time, end_time, reward, notes, question_allowed, agreed, user_id, store:store_id(store_name,store_address,avatar_url)`,
+          `id, date, second_date, third_date, time_range, created_at, message, status, respond_deadline, event_name, start_time, end_time, reward, notes, question_allowed, agreed, user_id, store:store_id!fk_offer_store_id_fkey(store_name,store_address,avatar_url)`,
         )
         .eq('id', params.id)
         .single()


### PR DESCRIPTION
## Summary
- specify `fk_offer_store_id_fkey` relation when selecting store details for an offer

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68872f874af083328615f5a190c3802e