### PR TITLE
Add offer confirmation flow

### DIFF
--- a/supabase/migrations/0008_add_fixed_date.sql
+++ b/supabase/migrations/0008_add_fixed_date.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.offers ADD COLUMN IF NOT EXISTS fixed_date date;
+ALTER TYPE public.offer_status ADD VALUE IF NOT EXISTS 'confirmed';

--- a/talentify-next-frontend/app/api/offers/[id]/route.ts
+++ b/talentify-next-frontend/app/api/offers/[id]/route.ts
@@ -7,11 +7,15 @@ export async function PUT(
 ) {
   const supabase = await createClient()
   const { id } = params
-  const { status } = await req.json()
+  const { status, fixed_date } = await req.json()
+
+  const updates: Record<string, any> = {}
+  if (status) updates.status = status
+  if (fixed_date) updates.fixed_date = fixed_date
 
   const { error } = await supabase
     .from('offers')
-    .update({ status })
+    .update(updates)
     .eq('id', id)
 
   if (error) {

--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams } from 'next/navigation'
+import { createClient } from '@/utils/supabase/client'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { format, parseISO } from 'date-fns'
+import Link from 'next/link'
+
+interface Offer {
+  id: string
+  date: string
+  second_date?: string | null
+  third_date?: string | null
+  fixed_date?: string | null
+  message: string
+  status: string | null
+  created_at?: string | null
+  talent_stage_name?: string | null
+}
+
+export default function StoreOfferDetailPage() {
+  const params = useParams<{ id: string }>()
+  const supabase = createClient()
+  const [offer, setOffer] = useState<Offer | null>(null)
+  const [toast, setToast] = useState<string | null>(null)
+
+  useEffect(() => {
+    const load = async () => {
+      const { data, error } = await supabase
+        .from('offers')
+        .select('id,date,second_date,third_date,fixed_date,message,status,created_at,talents(stage_name)')
+        .eq('id', params.id)
+        .single()
+
+      if (!error && data) {
+        const talent = (data as any).talents || {}
+        const o = { ...(data as any), talent_stage_name: talent.stage_name }
+        delete o.talents
+        setOffer(o as Offer)
+      }
+    }
+    load()
+  }, [params.id, supabase])
+
+  const confirmDate = async (d: string) => {
+    if (!offer) return
+    const res = await fetch(`/api/offers/${offer.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'confirmed', fixed_date: d })
+    })
+    if (res.ok) {
+      setOffer({ ...offer, status: 'confirmed', fixed_date: d })
+      setToast('スケジュールを確定しました')
+      setTimeout(() => setToast(null), 3000)
+    } else {
+      setToast('更新に失敗しました')
+      setTimeout(() => setToast(null), 3000)
+    }
+  }
+
+  if (!offer) return <p className='p-4'>Loading...</p>
+
+  const dateItems = [
+    { label: '候補日1', value: offer.date },
+    { label: '候補日2', value: offer.second_date },
+    { label: '候補日3', value: offer.third_date }
+  ]
+
+  return (
+    <div className='max-w-screen-md mx-auto p-6 space-y-4'>
+      <Link href='/store/offers' className='text-sm underline'>← オファー一覧へ戻る</Link>
+      <h1 className='text-xl font-bold'>オファー詳細</h1>
+      <div className='space-y-2 text-sm'>
+        {offer.talent_stage_name && <div>演者: {offer.talent_stage_name}</div>}
+        {offer.created_at && <div>作成日: {offer.created_at.slice(0,10)}</div>}
+        <div className='whitespace-pre-wrap'>{offer.message}</div>
+      </div>
+      <div className='space-y-2'>
+        {dateItems.map((item, i) => (
+          item.value ? (
+            <div key={i} className='flex items-center gap-2'>
+              <span>{item.label}: {format(parseISO(item.value), 'yyyy-MM-dd')}</span>
+              {offer.fixed_date === item.value && <Badge>確定日</Badge>}
+              {!offer.fixed_date && offer.status === 'accepted' && (
+                <Button size='sm' onClick={() => confirmDate(item.value!)}>
+                  この日で確定
+                </Button>
+              )}
+            </div>
+          ) : null
+        ))}
+      </div>
+      {offer.fixed_date && (
+        <div className='text-green-600'>確定日: {format(parseISO(offer.fixed_date), 'yyyy-MM-dd')}</div>
+      )}
+      {toast && (
+        <div className='fixed top-4 right-4 bg-green-600 text-white px-4 py-2 rounded shadow'>
+          {toast}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/talentify-next-frontend/app/store/offers/page.tsx
+++ b/talentify-next-frontend/app/store/offers/page.tsx
@@ -19,7 +19,8 @@ import {
 
 const statusLabels: Record<string, string> = {
   pending: '保留中',
-  approved: '承認済み',
+  accepted: '承諾済み',
+  confirmed: '確定済',
   rejected: '拒否',
   expired: '期限切れ',
 }
@@ -49,7 +50,8 @@ export default function StoreOffersPage() {
 
   const groups: Record<string, Offer[]> = {
     pending: [],
-    approved: [],
+    accepted: [],
+    confirmed: [],
     rejected: [],
     expired: [],
   }
@@ -70,7 +72,8 @@ export default function StoreOffersPage() {
         >
           <option value="all">すべて</option>
           <option value="pending">保留中</option>
-          <option value="approved">承認済み</option>
+          <option value="accepted">承諾済み</option>
+          <option value="confirmed">確定済</option>
           <option value="rejected">拒否</option>
           <option value="expired">期限切れ</option>
         </select>
@@ -88,7 +91,7 @@ export default function StoreOffersPage() {
       ) : offers.length === 0 ? (
         <EmptyState title='まだオファーがありません' actionHref='/talent-search' actionLabel='オファーを送ってみましょう' />
       ) : (
-        (['pending', 'approved', 'rejected', 'expired'] as const).map(status => (
+        (['pending', 'accepted', 'confirmed', 'rejected', 'expired'] as const).map(status => (
           groups[status].length > 0 && (
             <div key={status} className="space-y-2">
               <h2 className="font-semibold">{statusLabels[status]}</h2>

--- a/talentify-next-frontend/app/store/schedule/page.tsx
+++ b/talentify-next-frontend/app/store/schedule/page.tsx
@@ -51,7 +51,7 @@ export default function StoreSchedulePage() {
         .from('offers')
         .select('id, talent_id, date, status, talents(stage_name)')
         .eq('user_id', user.id)
-        .eq('status', 'accepted')
+        .in('status', ['accepted', 'confirmed'])
 
       if (error) {
         console.error('Failed to fetch offers', error)

--- a/talentify-next-frontend/supabase-docs/enums.md
+++ b/talentify-next-frontend/supabase-docs/enums.md
@@ -51,6 +51,7 @@
 - pending
 - accepted
 - rejected
+- confirmed
 
 ### auth.one_time_token_type
 - confirmation_token

--- a/talentify-next-frontend/supabase-docs/schema.md
+++ b/talentify-next-frontend/supabase-docs/schema.md
@@ -81,6 +81,7 @@
 - second_date: date
 - third_date: date
 - time_range: text
+- fixed_date: date
 
 ### payments
 - id: uuid, NOT NULL, DEFAULT gen_random_uuid()

--- a/talentify-next-frontend/types/supabase.ts
+++ b/talentify-next-frontend/types/supabase.ts
@@ -342,6 +342,7 @@ export type Database = {
           second_date: string | null
           third_date: string | null
           time_range: string | null
+          fixed_date: string | null
           notes: string | null
           agreed: boolean | null
           created_at: string | null
@@ -357,6 +358,7 @@ export type Database = {
           second_date?: string | null
           third_date?: string | null
           time_range?: string | null
+          fixed_date?: string | null
           notes?: string | null
           agreed?: boolean | null
           created_at?: string | null
@@ -372,6 +374,7 @@ export type Database = {
           second_date?: string | null
           third_date?: string | null
           time_range?: string | null
+          fixed_date?: string | null
           notes?: string | null
           agreed?: boolean | null
           created_at?: string | null
@@ -394,7 +397,7 @@ export type Database = {
         | 'payment_created'
         | 'invoice_submitted'
         | 'review_received'
-      offer_status: 'pending' | 'accepted' | 'rejected'
+      offer_status: 'pending' | 'accepted' | 'rejected' | 'confirmed'
       payment_status: 'pending' | 'paid' | 'cancelled'
       status_type: 'draft' | 'pending' | 'approved' | 'rejected' | 'completed'
       visit_status: 'scheduled' | 'confirmed' | 'visited'
@@ -521,7 +524,7 @@ export const Constants = {
         'invoice_submitted',
         'review_received'
       ],
-      offer_status: ['pending', 'accepted', 'rejected'],
+      offer_status: ['pending', 'accepted', 'rejected', 'confirmed'],
       payment_status: ['pending', 'paid', 'cancelled'],
       status_type: ['draft', 'pending', 'approved', 'rejected', 'completed'],
       visit_status: ['scheduled', 'confirmed', 'visited']

--- a/talentify-next-frontend/utils/getOffersForStore.ts
+++ b/talentify-next-frontend/utils/getOffersForStore.ts
@@ -12,6 +12,7 @@ export type Offer = {
   message: string
   created_at: string | null
   status: string | null
+  fixed_date?: string | null
 }
 
 export async function getOffersForStore() {

--- a/talentify-next-frontend/utils/getRecentNotifications.ts
+++ b/talentify-next-frontend/utils/getRecentNotifications.ts
@@ -23,13 +23,28 @@ export async function getRecentNotifications(): Promise<Notification[]> {
     .order('created_at', { ascending: false })
     .limit(5)
 
-  // Pending offers
+  // Pending offers for talents
   const { data: offers } = await supabase
     .from('offers' as any)
     .select('*')
     .eq('talent_id', user.id)
     .eq('status', 'pending')
     .order('created_at', { ascending: false })
+
+  // Check if current user is a store
+  const { data: store } = await supabase
+    .from('stores')
+    .select('id')
+    .eq('user_id', user.id)
+    .single()
+
+  const { data: accepted } = store
+    ? await supabase
+        .from('offers')
+        .select('id, created_at, talents(stage_name), date')
+        .eq('store_id', store.id)
+        .eq('status', 'accepted')
+    : { data: null }
 
   // Schedules for the next 7 days
   const { data: schedules } = await supabase
@@ -58,6 +73,17 @@ export async function getRecentNotifications(): Promise<Notification[]> {
       type: 'offer',
       title: 'オファー対応待ち',
       body: `オファーの日程 ${(o as any).date}`,
+      created_at: (o as any).created_at ?? '',
+      is_read: false,
+    }),
+  )
+
+  accepted?.forEach((o) =>
+    notifications.push({
+      id: (o as any).id,
+      type: 'offer',
+      title: 'オファー承諾通知',
+      body: `🎉 ${(o as any).talents?.stage_name ?? ''} さんがオファーを承諾しました`,
       created_at: (o as any).created_at ?? '',
       is_read: false,
     }),


### PR DESCRIPTION
## Summary
- allow stores to confirm accepted offers
- notify store when talent accepts an offer
- track confirmed date using `fixed_date`
- extend Supabase docs and types
- update schedule and offer listing pages

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6889993a64b88332901750c861fbc16d