### PR TITLE
Implement offer confirmation notification and schedule display

### DIFF
--- a/supabase/migrations/0009_notify_on_offer_confirmed.sql
+++ b/supabase/migrations/0009_notify_on_offer_confirmed.sql
@@ -1,0 +1,39 @@
+-- Notify talent and create schedule when offer status becomes confirmed
+
+-- Ensure columns exist
+ALTER TABLE public.offers ADD COLUMN IF NOT EXISTS fixed_date date;
+ALTER TABLE public.offers ADD COLUMN IF NOT EXISTS time_range text;
+
+-- Function to handle status change
+CREATE OR REPLACE FUNCTION public.handle_offer_confirmed()
+RETURNS trigger AS $$
+BEGIN
+  IF NEW.status = 'confirmed' AND NEW.fixed_date IS NOT NULL THEN
+    -- Insert schedule entry for the talent
+    INSERT INTO public.schedules (user_id, date, description, related_offer_id, role)
+    VALUES (
+      NEW.talent_id,
+      NEW.fixed_date,
+      (SELECT store_name FROM public.stores WHERE id = NEW.store_id),
+      NEW.id,
+      'offer_confirmed'
+    );
+
+    -- Insert notification
+    INSERT INTO public.notifications (user_id, type, data)
+    VALUES (
+      NEW.talent_id,
+      'offer_updated',
+      jsonb_build_object('offer_id', NEW.id, 'fixed_date', NEW.fixed_date)
+    );
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_offer_confirmed ON public.offers;
+CREATE TRIGGER trigger_offer_confirmed
+AFTER UPDATE OF status ON public.offers
+FOR EACH ROW
+WHEN (NEW.status = 'confirmed' AND (OLD.status IS DISTINCT FROM NEW.status))
+EXECUTE FUNCTION public.handle_offer_confirmed();

--- a/talentify-next-frontend/app/talent/schedule/page.tsx
+++ b/talentify-next-frontend/app/talent/schedule/page.tsx
@@ -1,50 +1,85 @@
 'use client'
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { createClient } from '@/utils/supabase/client'
 
-const mockSchedules = [
-  { date: '2025-07-18', status: 'available' },
-  { date: '2025-07-22', status: 'booked', store: 'グリーンホール渋谷' },
-  { date: '2025-07-24', status: 'available' },
-  { date: '2025-07-28', status: 'booked', store: 'キコーナ川崎' },
-]
+interface Item {
+  id: string
+  fixed_date: string
+  time_range?: string | null
+  store_name?: string | null
+}
 
 export default function SchedulePage() {
-  return (
-    <div className="max-w-screen-md mx-auto py-8 space-y-6">
-      <h1 className="text-2xl font-bold mb-4">スケジュール管理</h1>
+  const supabase = createClient()
+  const [items, setItems] = useState<Item[]>([])
+  const [loading, setLoading] = useState(true)
 
-      <Card>
-        <CardHeader>
-          <CardTitle>今月のスケジュール</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4 text-sm">
-          {mockSchedules.map((item, i) => (
-            <div
-              key={i}
-              className="flex justify-between items-center border rounded px-4 py-2"
-            >
-              <div>
-                <p className="font-medium">{item.date}</p>
-                {item.status === 'booked' ? (
-                  <p className="text-xs text-gray-500">
-                    来店予定: {item.store}
-                  </p>
-                ) : (
-                  <p className="text-xs text-green-600">空きあり</p>
-                )}
+  useEffect(() => {
+    const load = async () => {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+      if (!user) return setLoading(false)
+
+      const { data, error } = await supabase
+        .from('offers')
+        .select('id,fixed_date,time_range,store:store_id(store_name)')
+        .eq('talent_id', user.id)
+        .eq('status', 'confirmed')
+        .not('fixed_date', 'is', null)
+        .order('fixed_date', { ascending: true })
+
+      if (!error && data) {
+        const mapped = (data as any[]).map((o) => ({
+          id: o.id,
+          fixed_date: o.fixed_date,
+          time_range: o.time_range,
+          store_name: o.store?.store_name ?? '',
+        }))
+        setItems(mapped)
+      }
+      setLoading(false)
+    }
+    load()
+  }, [supabase])
+
+  return (
+    <div className='max-w-screen-md mx-auto py-8 space-y-6'>
+      <h1 className='text-2xl font-bold mb-4'>スケジュール管理</h1>
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <div className='space-y-2'>
+          {items.length === 0 ? (
+            <p className='text-sm text-muted-foreground'>確定した予定はありません</p>
+          ) : (
+            items.map((item) => (
+              <div
+                key={item.id}
+                className='border rounded p-3 text-sm flex justify-between'
+              >
+                <div>
+                  <div className='font-medium'>{item.fixed_date}</div>
+                  {item.time_range && (
+                    <div className='text-xs text-muted-foreground'>{item.time_range}</div>
+                  )}
+                  {item.store_name && (
+                    <div className='text-xs text-muted-foreground'>{item.store_name}</div>
+                  )}
+                </div>
+                <Link
+                  href={`/talent/offers/${item.id}`}
+                  className='text-blue-600 text-xs self-center'
+                >
+                  詳細
+                </Link>
               </div>
-              {item.status === 'available' ? (
-                <Badge variant="outline">募集中</Badge>
-              ) : (
-                <Badge variant="default">予定あり</Badge>
-              )}
-            </div>
-          ))}
-        </CardContent>
-      </Card>
+            ))
+          )}
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add database trigger and function to create notifications and schedules when an offer is confirmed
- surface notifications from the `notifications` table on the dashboard
- show confirmed offer schedules on talent schedule page

## Testing
- `npm install`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68899c0b709c8332a6345110d2e150a2