### PR TITLE
Implement payment completion workflow

### DIFF
--- a/supabase/migrations/0011_add_paid_fields_to_offers.sql
+++ b/supabase/migrations/0011_add_paid_fields_to_offers.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.offers
+  ADD COLUMN IF NOT EXISTS paid boolean DEFAULT false,
+  ADD COLUMN IF NOT EXISTS paid_at timestamp with time zone;

--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -28,6 +28,8 @@ interface Offer {
   bank_account_number?: string | null
   bank_account_holder?: string | null
   invoice_submitted?: boolean | null
+  paid?: boolean | null
+  paid_at?: string | null
 }
 
 export default function StoreOfferDetailPage() {
@@ -41,7 +43,7 @@ export default function StoreOfferDetailPage() {
     const load = async () => {
       const { data, error } = await supabase
         .from('offers')
-        .select('id,date,second_date,third_date,fixed_date,contract_url,agreed,message,status,created_at,invoice_date,invoice_amount,bank_name,bank_branch,bank_account_number,bank_account_holder,invoice_submitted,talents(stage_name)')
+        .select('id,date,second_date,third_date,fixed_date,contract_url,agreed,message,status,created_at,invoice_date,invoice_amount,bank_name,bank_branch,bank_account_number,bank_account_holder,invoice_submitted,paid,paid_at,talents(stage_name)')
         .eq('id', params.id)
         .single()
 
@@ -121,6 +123,23 @@ export default function StoreOfferDetailPage() {
     doc.save(`invoice-${offer.id}.pdf`)
   }
 
+  const registerPayment = async () => {
+    if (!offer) return
+    const res = await fetch(`/api/offers/${offer.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ paid: true }),
+    })
+    if (res.ok) {
+      const now = new Date().toISOString()
+      setOffer({ ...offer, paid: true, paid_at: now })
+      setToast('支払い完了を登録しました')
+    } else {
+      setToast('更新に失敗しました')
+    }
+    setTimeout(() => setToast(null), 3000)
+  }
+
   if (!offer) return <p className='p-4'>Loading...</p>
 
   const dateItems = [
@@ -171,7 +190,14 @@ export default function StoreOfferDetailPage() {
             振込先: {offer.bank_name} {offer.bank_branch} {offer.bank_account_number}{' '}
             {offer.bank_account_holder}
           </div>
-          <Button size='sm' onClick={downloadInvoice}>請求書をダウンロードする</Button>
+          <div className='flex gap-2'>
+            <Button size='sm' onClick={downloadInvoice}>請求書をダウンロードする</Button>
+            {offer.paid ? (
+              <Badge className='self-center'>支払い済</Badge>
+            ) : (
+              <Button size='sm' onClick={registerPayment}>支払い完了を登録する</Button>
+            )}
+          </div>
         </div>
       ) : (
         <div className='text-sm'>まだ請求書が提出されていません</div>

--- a/talentify-next-frontend/app/store/offers/page.tsx
+++ b/talentify-next-frontend/app/store/offers/page.tsx
@@ -100,6 +100,7 @@ export default function StoreOffersPage() {
                   <TableRow>
                     <TableHead>作成日</TableHead>
                     <TableHead>メッセージ</TableHead>
+                    <TableHead>支払い状況</TableHead>
                     <TableHead>操作</TableHead>
                   </TableRow>
                 </TableHeader>
@@ -108,6 +109,7 @@ export default function StoreOffersPage() {
                     <TableRow key={o.id}>
                       <TableCell>{o.created_at?.slice(0, 10)}</TableCell>
                       <TableCell className="truncate max-w-xs">{o.message}</TableCell>
+                      <TableCell>{o.paid ? '済' : '未'}</TableCell>
                       <TableCell>
                         <Modal onOpenChange={open => !open && setSelected(null)}>
                           <ModalTrigger asChild>

--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -41,6 +41,8 @@ interface Offer {
   bank_account_number?: string | null
   bank_account_holder?: string | null
   invoice_submitted?: boolean | null
+  paid?: boolean | null
+  paid_at?: string | null
 }
 
 export default function TalentOfferDetailPage() {
@@ -130,8 +132,8 @@ export default function TalentOfferDetailPage() {
       const { data, error } = await supabase
         .from('offers')
         .select(
-  `id, date, second_date, third_date, time_range, created_at, message, status, contract_url, respond_deadline, event_name, start_time, end_time, reward, notes, question_allowed, agreed, invoice_date, invoice_amount, bank_name, bank_branch, bank_account_number, bank_account_holder, invoice_submitted, user_id, store:store_id(store_name,store_address,avatar_url)`
-)
+  `id, date, second_date, third_date, time_range, created_at, message, status, contract_url, respond_deadline, event_name, start_time, end_time, reward, notes, question_allowed, agreed, invoice_date, invoice_amount, bank_name, bank_branch, bank_account_number, bank_account_holder, invoice_submitted, paid, paid_at, user_id, store:store_id(store_name,store_address,avatar_url)`
+ )
         .eq('id', params.id)
         .single()
 
@@ -208,6 +210,14 @@ export default function TalentOfferDetailPage() {
           )}
         </CardContent>
       </Card>
+
+      {offer.paid ? (
+        <div className='text-green-600 text-sm'>
+          ✅ お支払いが完了しました（{offer.paid_at?.slice(0,10)}）
+        </div>
+      ) : offer.invoice_submitted ? (
+        <div className='text-yellow-600 text-sm'>請求済みですが未入金です</div>
+      ) : null}
 
       {offer.invoice_submitted ? (
         <Card>

--- a/talentify-next-frontend/supabase-docs/schema.md
+++ b/talentify-next-frontend/supabase-docs/schema.md
@@ -82,6 +82,8 @@
 - third_date: date
 - time_range: text
 - fixed_date: date
+- paid: boolean, DEFAULT false
+- paid_at: timestamp with time zone
 
 ### payments
 - id: uuid, NOT NULL, DEFAULT gen_random_uuid()

--- a/talentify-next-frontend/types/supabase.ts
+++ b/talentify-next-frontend/types/supabase.ts
@@ -354,6 +354,8 @@ export type Database = {
           bank_account_number: string | null
           bank_account_holder: string | null
           invoice_submitted: boolean | null
+          paid: boolean | null
+          paid_at: string | null
           created_at: string | null
           status: string | null
         }
@@ -379,6 +381,8 @@ export type Database = {
           bank_account_number?: string | null
           bank_account_holder?: string | null
           invoice_submitted?: boolean | null
+          paid?: boolean | null
+          paid_at?: string | null
           created_at?: string | null
           status?: string | null
         }
@@ -404,6 +408,8 @@ export type Database = {
           bank_account_number?: string | null
           bank_account_holder?: string | null
           invoice_submitted?: boolean | null
+          paid?: boolean | null
+          paid_at?: string | null
           created_at?: string | null
           status?: string | null
         }

--- a/talentify-next-frontend/utils/getOffersForStore.ts
+++ b/talentify-next-frontend/utils/getOffersForStore.ts
@@ -13,6 +13,8 @@ export type Offer = {
   created_at: string | null
   status: string | null
   fixed_date?: string | null
+  paid?: boolean | null
+  paid_at?: string | null
 }
 
 export async function getOffersForStore() {

--- a/talentify-next-frontend/utils/getRecentNotifications.ts
+++ b/talentify-next-frontend/utils/getRecentNotifications.ts
@@ -63,6 +63,12 @@ export async function getRecentNotifications(): Promise<Notification[]> {
     .not('fixed_date', 'is', null)
     .gte('fixed_date', new Date().toISOString())
 
+  const { data: paymentNotifs } = await supabase
+    .from('notifications')
+    .select('id, data, created_at, is_read')
+    .eq('user_id', user.id)
+    .eq('type', 'payment_created')
+
   const notifications: Notification[] = []
 
   messages?.forEach((m) =>
@@ -117,6 +123,17 @@ export async function getRecentNotifications(): Promise<Notification[]> {
       body: `[${(c as any).stores?.store_name ?? ''}] ${(c as any).fixed_date} ${(c as any).time_range ?? ''}`.trim(),
       created_at: (c as any).fixed_date ?? '',
       is_read: false,
+    }),
+  )
+
+  paymentNotifs?.forEach((p) =>
+    notifications.push({
+      id: (p as any).id,
+      type: 'system',
+      title: '支払い完了',
+      body: `お支払いが完了しました。金額: ¥${(p as any).data?.amount ?? ''}`,
+      created_at: (p as any).created_at ?? '',
+      is_read: (p as any).is_read ?? false,
     }),
   )
 


### PR DESCRIPTION
## Summary
- track payment status on offers table
- allow store to mark payment done and notify talent
- show payment state on store/talent views and offer list
- surface payment notifications
- update Supabase schema and types

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6889b313df848332ad761532704150a7