### PR TITLE
Add notification history pages

### DIFF
--- a/talentify-next-frontend/app/api/offers/[id]/route.ts
+++ b/talentify-next-frontend/app/api/offers/[id]/route.ts
@@ -48,6 +48,66 @@ export async function PUT(
     return NextResponse.json<{ error: string }>({ error: error.message }, { status: 500 })
   }
 
+  const { data: offerRow } = await supabase
+    .from('offers')
+    .select('store_id, talent_id')
+    .eq('id', id)
+    .single()
+
+  if (status === 'accepted' && offerRow?.store_id) {
+    await supabase.from('notifications').insert({
+      user_id: offerRow.store_id,
+      offer_id: id,
+      type: 'offer_accepted',
+      title: 'オファーが承諾されました',
+    })
+  }
+
+  if (fixed_date && offerRow?.talent_id) {
+    await supabase.from('notifications').insert({
+      user_id: offerRow.talent_id,
+      offer_id: id,
+      type: 'schedule_fixed',
+      title: '出演日程が確定しました',
+    })
+  }
+
+  if (contract_url && offerRow?.talent_id) {
+    await supabase.from('notifications').insert({
+      user_id: offerRow.talent_id,
+      offer_id: id,
+      type: 'contract_uploaded',
+      title: '契約書がアップロードされました',
+    })
+  }
+
+  if (agreed === true && offerRow?.store_id) {
+    await supabase.from('notifications').insert({
+      user_id: offerRow.store_id,
+      offer_id: id,
+      type: 'contract_checked',
+      title: 'タレントが契約書を確認しました',
+    })
+  }
+
+  if (invoice_submitted === true && offerRow?.store_id) {
+    await supabase.from('notifications').insert({
+      user_id: offerRow.store_id,
+      offer_id: id,
+      type: 'invoice_submitted',
+      title: '請求書が提出されました',
+    })
+  }
+
+  if (paid === true && offerRow?.talent_id) {
+    await supabase.from('notifications').insert({
+      user_id: offerRow.talent_id,
+      offer_id: id,
+      type: 'payment_completed',
+      title: 'お支払いが完了しました',
+    })
+  }
+
   // Notify performer or store about status change via webhook if configured
   const webhook = process.env.NOTIFICATION_WEBHOOK_URL
   if (webhook) {

--- a/talentify-next-frontend/app/store/dashboard/page.tsx
+++ b/talentify-next-frontend/app/store/dashboard/page.tsx
@@ -74,7 +74,7 @@ export default function StoreDashboard() {
           <div className='sm:col-span-2'>
             <MessageAlertCard count={unread} link='/store/messages' />
           </div>
-        <NotificationListCard className='sm:col-span-2' />
+        <NotificationListCard role='store' className='sm:col-span-2' />
       </div>
       )}
       {toast && (

--- a/talentify-next-frontend/app/store/notifications/page.tsx
+++ b/talentify-next-frontend/app/store/notifications/page.tsx
@@ -5,7 +5,7 @@ import { NotificationItem } from '@/components/ui/notification-item'
 import { getNotifications, markNotificationRead } from '@/utils/getNotifications'
 import type { Notification } from '@/types/ui'
 
-export default function TalentNotificationsPage() {
+export default function StoreNotificationsPage() {
   const [items, setItems] = useState<Notification[]>([])
   const [loading, setLoading] = useState(true)
 
@@ -34,7 +34,7 @@ export default function TalentNotificationsPage() {
             <li key={n.id}>
               <NotificationItem
                 notification={n}
-                href={n.offer_id ? `/talent/offers/${n.offer_id}` : undefined}
+                href={n.offer_id ? `/store/offers/${n.offer_id}` : undefined}
                 onClick={() => handleRead(n.id)}
               />
             </li>

--- a/talentify-next-frontend/app/talent/dashboard/page.tsx
+++ b/talentify-next-frontend/app/talent/dashboard/page.tsx
@@ -53,7 +53,7 @@ export default function TalentDashboard() {
           <ScheduleCard items={schedule} />
           <OfferSummaryCard pending={pending} accepted={schedule.length} link='/talent/offers' />
           <MessageAlertCard count={unread} link='/talent/messages' />
-          <NotificationListCard className='sm:col-span-2 lg:col-span-3' />
+          <NotificationListCard role='talent' className='sm:col-span-2 lg:col-span-3' />
           <div className='sm:col-span-2 lg:col-span-3'>
             <ProfileProgressCard />
           </div>

--- a/talentify-next-frontend/components/Header.tsx
+++ b/talentify-next-frontend/components/Header.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
-import { Menu, Search } from 'lucide-react'
+import { Menu, Search, Bell } from 'lucide-react'
 import Sidebar from './Sidebar'
 import { Sheet, SheetTrigger, SheetContent } from './ui/sheet'
 import { Button } from './ui/button'
@@ -14,6 +14,7 @@ const supabase = createClient()
 export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'store' }) {
   const [userName, setUserName] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(true)
+  const [unread, setUnread] = useState(0)
 
   useEffect(() => {
     const fetchSessionAndProfile = async () => {
@@ -28,6 +29,12 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
 
       const { name } = await getUserRoleInfo(supabase, user.id)
       setUserName(name ?? 'ユーザー')
+      const { count } = await supabase
+        .from('notifications')
+        .select('*', { count: 'exact', head: true })
+        .eq('user_id', user.id)
+        .eq('is_read', false)
+      setUnread(count ?? 0)
       setIsLoading(false)
     }
 
@@ -120,6 +127,16 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
                     <span className="text-base">{userName}</span>
                     <span className="ml-1 text-sm text-muted-foreground align-top">様</span>
                   </span>
+                  {sidebarRole && (
+                    <Link href={`/${sidebarRole}/notifications`} className="relative ml-2">
+                      <Bell className="h-5 w-5" />
+                      {unread > 0 && (
+                        <span className="absolute -top-1 -right-2 rounded-full bg-red-600 text-white text-xs px-1">
+                          {unread}
+                        </span>
+                      )}
+                    </Link>
+                  )}
                 </>
               )}
             </div>

--- a/talentify-next-frontend/components/NotificationListCard.tsx
+++ b/talentify-next-frontend/components/NotificationListCard.tsx
@@ -5,18 +5,19 @@ import { DashboardCard } from '@/components/ui/dashboard-card'
 import { NotificationItem } from '@/components/ui/notification-item'
 import { cn } from '@/lib/utils'
 import type { Notification } from '@/types/ui'
-import { getRecentNotifications } from '@/utils/getRecentNotifications'
+import { getNotifications } from '@/utils/getNotifications'
 
 interface Props {
   title?: string
   className?: string
+  role: 'talent' | 'store'
 }
 
-export default function NotificationListCard({ title = '通知', className }: Props) {
+export default function NotificationListCard({ title = '通知', className, role }: Props) {
   const [items, setItems] = useState<Notification[] | null>(null)
 
   useEffect(() => {
-    getRecentNotifications().then(setItems)
+    getNotifications(5).then(setItems)
   }, [])
 
   return (
@@ -30,7 +31,11 @@ export default function NotificationListCard({ title = '通知', className }: Pr
       {items && items.length > 0 && (
         <div className="space-y-2 max-h-64 overflow-y-auto">
           {items.map((n) => (
-            <NotificationItem key={n.id} notification={n} />
+            <NotificationItem
+              key={n.id}
+              notification={n}
+              href={n.offer_id ? `/${role}/offers/${n.offer_id}` : undefined}
+            />
           ))}
         </div>
       )}

--- a/talentify-next-frontend/components/ui/notification-item.tsx
+++ b/talentify-next-frontend/components/ui/notification-item.tsx
@@ -1,38 +1,61 @@
 import React from 'react'
+import Link from 'next/link'
 import { Badge } from './badge'
 import { cn } from '@/lib/utils'
 import type { Notification } from '@/types/ui'
-import { Bell, Mail, Calendar as CalendarIcon, Info } from 'lucide-react'
+import {
+  Bell,
+  Calendar as CalendarIcon,
+  FileText,
+  CheckCircle,
+  Wallet,
+} from 'lucide-react'
 
 interface NotificationItemProps extends React.HTMLAttributes<HTMLDivElement> {
   notification: Notification
+  href?: string
+  onClick?: () => void
 }
 
 const typeIcon = {
-  message: Mail,
-  offer: Bell,
-  schedule: CalendarIcon,
-  system: Info,
-}
+  offer_accepted: Bell,
+  schedule_fixed: CalendarIcon,
+  contract_uploaded: FileText,
+  contract_checked: CheckCircle,
+  invoice_submitted: FileText,
+  payment_completed: Wallet,
+} as const
 
-export function NotificationItem({ notification, className, ...props }: NotificationItemProps) {
-  const Icon = typeIcon[notification.type]
+export function NotificationItem({ notification, className, href, onClick, ...props }: NotificationItemProps) {
+  const Icon = typeIcon[notification.type] ?? Bell
 
-  return (
+  const content = (
     <div
       className={cn(
         'flex items-start gap-2 rounded-md border p-3 bg-white',
         !notification.is_read && 'font-semibold',
-        className
+        className,
       )}
       {...props}
     >
       <Icon className="h-4 w-4 mt-0.5" />
       <div className="text-sm flex-1">
-        <div>{notification.body}</div>
-        <div className="text-xs text-muted-foreground">{notification.created_at}</div>
+        <div>{notification.title}</div>
+        <div className="text-xs text-muted-foreground">{notification.created_at?.slice(0,10)}</div>
       </div>
-      {!notification.is_read && <Badge className="self-start" variant="destructive">NEW</Badge>}
+      {!notification.is_read && (
+        <Badge className="self-start" variant="destructive">
+          NEW
+        </Badge>
+      )}
     </div>
+  )
+
+  return href ? (
+    <Link href={href} onClick={onClick} className="block">
+      {content}
+    </Link>
+  ) : (
+    content
   )
 }

--- a/talentify-next-frontend/supabase-docs/enums.md
+++ b/talentify-next-frontend/supabase-docs/enums.md
@@ -41,11 +41,12 @@
 - rejected
 
 ### public.notification_type
-- offer_created
-- offer_updated
-- payment_created
+- offer_accepted
+- schedule_fixed
+- contract_uploaded
+- contract_checked
 - invoice_submitted
-- review_received
+- payment_completed
 
 ### public.offer_status
 - pending

--- a/talentify-next-frontend/supabase-docs/schema.md
+++ b/talentify-next-frontend/supabase-docs/schema.md
@@ -54,7 +54,9 @@
 - id: uuid, NOT NULL, DEFAULT gen_random_uuid()
 - user_id: uuid, NOT NULL
 - type: USER-DEFINED, NOT NULL
-- data: jsonb
+- offer_id: uuid
+- title: text
+- body: text
 - is_read: boolean, DEFAULT false
 - created_at: timestamp without time zone, DEFAULT now()
 - read_at: timestamp without time zone

--- a/talentify-next-frontend/types/supabase.ts
+++ b/talentify-next-frontend/types/supabase.ts
@@ -44,6 +44,43 @@ export type Database = {
         }
         Relationships: []
       }
+
+      notifications: {
+        Row: {
+          id: string
+          user_id: string
+          offer_id: string | null
+          type: Enums<'notification_type'>
+          title: string
+          body: string | null
+          is_read: boolean | null
+          created_at: string | null
+          read_at: string | null
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          offer_id?: string | null
+          type: Enums<'notification_type'>
+          title: string
+          body?: string | null
+          is_read?: boolean | null
+          created_at?: string | null
+          read_at?: string | null
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          offer_id?: string | null
+          type?: Enums<'notification_type'>
+          title?: string
+          body?: string | null
+          is_read?: boolean | null
+          created_at?: string | null
+          read_at?: string | null
+        }
+        Relationships: []
+      }
       companies: {
         Row: {
           id: string
@@ -419,11 +456,12 @@ export type Database = {
     Enums: {
       invoice_status: 'draft' | 'submitted' | 'approved' | 'rejected'
       notification_type:
-        | 'offer_created'
-        | 'offer_updated'
-        | 'payment_created'
+        | 'offer_accepted'
+        | 'schedule_fixed'
+        | 'contract_uploaded'
+        | 'contract_checked'
         | 'invoice_submitted'
-        | 'review_received'
+        | 'payment_completed'
       offer_status: 'pending' | 'accepted' | 'rejected' | 'confirmed'
       payment_status: 'pending' | 'paid' | 'cancelled'
       status_type: 'draft' | 'pending' | 'approved' | 'rejected' | 'completed'
@@ -545,11 +583,12 @@ export const Constants = {
     Enums: {
       invoice_status: ['draft', 'submitted', 'approved', 'rejected'],
       notification_type: [
-        'offer_created',
-        'offer_updated',
-        'payment_created',
+        'offer_accepted',
+        'schedule_fixed',
+        'contract_uploaded',
+        'contract_checked',
         'invoice_submitted',
-        'review_received'
+        'payment_completed'
       ],
       offer_status: ['pending', 'accepted', 'rejected', 'confirmed'],
       payment_status: ['pending', 'paid', 'cancelled'],

--- a/talentify-next-frontend/types/ui.ts
+++ b/talentify-next-frontend/types/ui.ts
@@ -1,4 +1,10 @@
-export type NotificationType = 'message' | 'offer' | 'schedule' | 'system'
+export type NotificationType =
+  | 'offer_accepted'
+  | 'schedule_fixed'
+  | 'contract_uploaded'
+  | 'contract_checked'
+  | 'invoice_submitted'
+  | 'payment_completed'
 
 export type TaskType = 'respond_offer' | 'update_profile' | 'check_message'
 
@@ -8,6 +14,7 @@ export interface Notification {
   title: string
   body: string
   created_at: string
+  offer_id?: string | null
   is_read: boolean
 }
 

--- a/talentify-next-frontend/utils/getNotifications.ts
+++ b/talentify-next-frontend/utils/getNotifications.ts
@@ -1,0 +1,36 @@
+'use client'
+
+import { createClient } from '@/utils/supabase/client'
+import type { Database } from '@/types/supabase'
+import type { Notification } from '@/types/ui'
+
+const supabase = createClient()
+
+export type NotificationRow = Database['public']['Tables']['notifications']['Row']
+
+export async function getNotifications(limit?: number): Promise<Notification[]> {
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return []
+
+  let query = supabase
+    .from('notifications')
+    .select('*')
+    .eq('user_id', user.id)
+    .order('created_at', { ascending: false })
+  if (limit) query = query.limit(limit)
+
+  const { data, error } = await query
+
+  if (error) {
+    console.error('failed to fetch notifications:', error)
+    return []
+  }
+  return (data ?? []) as unknown as Notification[]
+}
+
+export async function markNotificationRead(id: string) {
+  await supabase
+    .from('notifications')
+    .update({ is_read: true, read_at: new Date().toISOString() })
+    .eq('id', id)
+}


### PR DESCRIPTION
## Summary
- implement notification fetch helper
- add notification list pages for talent and store
- show unread count in header
- render recent notifications with links
- create notifications on offer updates
- document notification schema and types

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889d3887e14833296b3a2b8ceb19d63