### PR TITLE
Add notification history pages

### DIFF
--- a/talentify-next-frontend/app/store/notifications/page.tsx
+++ b/talentify-next-frontend/app/store/notifications/page.tsx
@@ -6,7 +6,7 @@ import { NotificationItem } from '@/components/ui/notification-item'
 import type { NotificationRow } from '@/utils/getNotifications'
 import { fetchNotifications, markAsRead } from '@/utils/getNotifications'
 
-export default function TalentNotificationsPage() {
+export default function StoreNotificationsPage() {
   const [items, setItems] = useState<NotificationRow[]>([])
 
   useEffect(() => {
@@ -21,7 +21,7 @@ export default function TalentNotificationsPage() {
   }
 
   const getLink = (n: NotificationRow) =>
-    n.type === 'message' ? '/talent/messages' : `/talent/offers/${n.offer_id}`
+    n.type === 'message' ? '/store/messages' : `/store/offers/${n.offer_id}`
 
   return (
     <div className="max-w-screen-md mx-auto py-8 space-y-4">

--- a/talentify-next-frontend/components/Header.tsx
+++ b/talentify-next-frontend/components/Header.tsx
@@ -8,6 +8,7 @@ import { Sheet, SheetTrigger, SheetContent } from './ui/sheet'
 import { Button } from './ui/button'
 import { createClient } from '@/utils/supabase/client'
 import { getUserRoleInfo } from '@/lib/getUserRole'
+import NotificationBellIcon from './NotificationBellIcon'
 
 const supabase = createClient()
 
@@ -116,6 +117,7 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
                 </>
               ) : (
                 <>
+                  <NotificationBellIcon />
                   <span className="flex items-baseline font-semibold">
                     <span className="text-base">{userName}</span>
                     <span className="ml-1 text-sm text-muted-foreground align-top">様</span>

--- a/talentify-next-frontend/components/NotificationBellIcon.tsx
+++ b/talentify-next-frontend/components/NotificationBellIcon.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { Bell } from 'lucide-react'
+import { createClient } from '@/utils/supabase/client'
+import { getUserRoleInfo } from '@/lib/getUserRole'
+
+const supabase = createClient()
+
+export default function NotificationBellIcon() {
+  const [count, setCount] = useState(0)
+  const [role, setRole] = useState<'talent' | 'store' | null>(null)
+
+  useEffect(() => {
+    const load = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession()
+      const user = session?.user
+      if (!user) return
+      const info = await getUserRoleInfo(supabase, user.id)
+      setRole(info.role as any)
+      const { count } = await supabase
+        .from('notifications')
+        .select('id', { count: 'exact', head: true })
+        .eq('user_id', user.id)
+        .eq('is_read', false)
+      setCount(count || 0)
+    }
+    load()
+  }, [])
+
+  if (!role) return null
+
+  const href = role === 'store' ? '/store/notifications' : '/talent/notifications'
+
+  return (
+    <Link href={href} className="relative">
+      <Bell className="h-5 w-5" />
+      {count > 0 && (
+        <span className="absolute -top-1 -right-2 rounded-full bg-red-500 text-white text-xs px-1">
+          {count}
+        </span>
+      )}
+    </Link>
+  )
+}

--- a/talentify-next-frontend/components/NotificationListCard.tsx
+++ b/talentify-next-frontend/components/NotificationListCard.tsx
@@ -30,7 +30,11 @@ export default function NotificationListCard({ title = '通知', className }: Pr
       {items && items.length > 0 && (
         <div className="space-y-2 max-h-64 overflow-y-auto">
           {items.map((n) => (
-            <NotificationItem key={n.id} notification={n} />
+            <NotificationItem
+              key={n.id}
+              notification={n}
+              href="/"
+            />
           ))}
         </div>
       )}

--- a/talentify-next-frontend/components/Sidebar.tsx
+++ b/talentify-next-frontend/components/Sidebar.tsx
@@ -48,6 +48,7 @@ const navItems = {
     { href: "/store/schedule", label: "スケジュール", icon: Calendar },
     { href: "/store/reviews", label: "レビュー管理", icon: Star },
     { href: "/store/messages", label: "メッセージ", icon: Bell },
+    { href: "/store/notifications", label: "通知", icon: Bell },
     { href: "/store/invoices", label: "請求一覧", icon: Wallet },
     { href: "/store/edit", label: "店舗情報", icon: User },
     { href: "/store/settings", label: "設定", icon: Star },

--- a/talentify-next-frontend/components/ui/notification-item.tsx
+++ b/talentify-next-frontend/components/ui/notification-item.tsx
@@ -1,25 +1,55 @@
 import React from 'react'
+import Link from 'next/link'
 import { Badge } from './badge'
 import { cn } from '@/lib/utils'
 import type { Notification } from '@/types/ui'
-import { Bell, Mail, Calendar as CalendarIcon, Info } from 'lucide-react'
+import {
+  Bell,
+  Mail,
+  Calendar as CalendarIcon,
+  Info,
+  FileText,
+  CheckCircle,
+} from 'lucide-react'
 
-interface NotificationItemProps extends React.HTMLAttributes<HTMLDivElement> {
+interface NotificationItemProps
+  extends React.HTMLAttributes<HTMLAnchorElement> {
   notification: Notification
+  href: string
+  onRead?: () => void | Promise<void>
 }
 
-const typeIcon = {
+const typeIcon: Record<Notification['type'], React.ComponentType<{
+  className?: string
+}>> = {
+  offer_accepted: Bell,
+  schedule_fixed: CalendarIcon,
+  contract_uploaded: FileText,
+  contract_checked: CheckCircle,
+  invoice_submitted: Mail,
+  payment_completed: Bell,
   message: Mail,
-  offer: Bell,
-  schedule: CalendarIcon,
-  system: Info,
 }
 
-export function NotificationItem({ notification, className, ...props }: NotificationItemProps) {
+export function NotificationItem({
+  notification,
+  href,
+  onRead,
+  className,
+  ...props
+}: NotificationItemProps) {
   const Icon = typeIcon[notification.type]
 
+  const formatted = notification.created_at?.slice(0, 10)
+
+  const handleClick = async () => {
+    if (!notification.is_read && onRead) await onRead()
+  }
+
   return (
-    <div
+    <Link
+      href={href}
+      onClick={handleClick}
       className={cn(
         'flex items-start gap-2 rounded-md border p-3 bg-white',
         !notification.is_read && 'font-semibold',
@@ -29,10 +59,13 @@ export function NotificationItem({ notification, className, ...props }: Notifica
     >
       <Icon className="h-4 w-4 mt-0.5" />
       <div className="text-sm flex-1">
-        <div>{notification.body}</div>
-        <div className="text-xs text-muted-foreground">{notification.created_at}</div>
+        <div>[{notification.title}]（{formatted}）</div>
       </div>
-      {!notification.is_read && <Badge className="self-start" variant="destructive">NEW</Badge>}
-    </div>
+      {!notification.is_read && (
+        <Badge className="self-start" variant="destructive">
+          NEW
+        </Badge>
+      )}
+    </Link>
   )
 }

--- a/talentify-next-frontend/supabase-docs/enums.md
+++ b/talentify-next-frontend/supabase-docs/enums.md
@@ -41,11 +41,13 @@
 - rejected
 
 ### public.notification_type
-- offer_created
-- offer_updated
-- payment_created
+- offer_accepted
+- schedule_fixed
+- contract_uploaded
+- contract_checked
 - invoice_submitted
-- review_received
+- payment_completed
+- message
 
 ### public.offer_status
 - pending

--- a/talentify-next-frontend/supabase-docs/schema.md
+++ b/talentify-next-frontend/supabase-docs/schema.md
@@ -53,11 +53,13 @@
 ### notifications
 - id: uuid, NOT NULL, DEFAULT gen_random_uuid()
 - user_id: uuid, NOT NULL
-- type: USER-DEFINED, NOT NULL
-- data: jsonb
+ - offer_id: uuid
+ - type: USER-DEFINED, NOT NULL
+ - title: text, NOT NULL
+ - body: text
 - is_read: boolean, DEFAULT false
-- created_at: timestamp without time zone, DEFAULT now()
-- read_at: timestamp without time zone
+ - created_at: timestamp with time zone, DEFAULT now()
+ - read_at: timestamp with time zone
 
 ### offers
 - id: uuid, NOT NULL, DEFAULT gen_random_uuid()

--- a/talentify-next-frontend/types/supabase.ts
+++ b/talentify-next-frontend/types/supabase.ts
@@ -331,6 +331,43 @@ export type Database = {
         }
         Relationships: []
       }
+      ,
+      notifications: {
+        Row: {
+          id: string
+          user_id: string
+          offer_id: string | null
+          type: Enums<'notification_type'>
+          title: string
+          body: string | null
+          is_read: boolean | null
+          created_at: string | null
+          read_at: string | null
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          offer_id?: string | null
+          type: Enums<'notification_type'>
+          title: string
+          body?: string | null
+          is_read?: boolean | null
+          created_at?: string | null
+          read_at?: string | null
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          offer_id?: string | null
+          type?: Enums<'notification_type'>
+          title?: string
+          body?: string | null
+          is_read?: boolean | null
+          created_at?: string | null
+          read_at?: string | null
+        }
+        Relationships: []
+      }
       offers: {
         Row: {
           id: string
@@ -419,11 +456,13 @@ export type Database = {
     Enums: {
       invoice_status: 'draft' | 'submitted' | 'approved' | 'rejected'
       notification_type:
-        | 'offer_created'
-        | 'offer_updated'
-        | 'payment_created'
+        | 'offer_accepted'
+        | 'schedule_fixed'
+        | 'contract_uploaded'
+        | 'contract_checked'
         | 'invoice_submitted'
-        | 'review_received'
+        | 'payment_completed'
+        | 'message'
       offer_status: 'pending' | 'accepted' | 'rejected' | 'confirmed'
       payment_status: 'pending' | 'paid' | 'cancelled'
       status_type: 'draft' | 'pending' | 'approved' | 'rejected' | 'completed'
@@ -545,11 +584,13 @@ export const Constants = {
     Enums: {
       invoice_status: ['draft', 'submitted', 'approved', 'rejected'],
       notification_type: [
-        'offer_created',
-        'offer_updated',
-        'payment_created',
+        'offer_accepted',
+        'schedule_fixed',
+        'contract_uploaded',
+        'contract_checked',
         'invoice_submitted',
-        'review_received'
+        'payment_completed',
+        'message'
       ],
       offer_status: ['pending', 'accepted', 'rejected', 'confirmed'],
       payment_status: ['pending', 'paid', 'cancelled'],

--- a/talentify-next-frontend/types/ui.ts
+++ b/talentify-next-frontend/types/ui.ts
@@ -1,9 +1,17 @@
-export type NotificationType = 'message' | 'offer' | 'schedule' | 'system'
+export type NotificationType =
+  | 'offer_accepted'
+  | 'schedule_fixed'
+  | 'contract_uploaded'
+  | 'contract_checked'
+  | 'invoice_submitted'
+  | 'payment_completed'
+  | 'message'
 
 export type TaskType = 'respond_offer' | 'update_profile' | 'check_message'
 
 export interface Notification {
   id: string
+  offer_id?: string | null
   type: NotificationType
   title: string
   body: string

--- a/talentify-next-frontend/utils/getNotifications.ts
+++ b/talentify-next-frontend/utils/getNotifications.ts
@@ -1,0 +1,29 @@
+'use client'
+
+import { createClient } from '@/utils/supabase/client'
+import type { Database } from '@/types/supabase'
+
+const supabase = createClient()
+
+export type NotificationRow = Database['public']['Tables']['notifications']['Row']
+
+export async function fetchNotifications(): Promise<NotificationRow[]> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return []
+
+  const { data } = await supabase
+    .from('notifications')
+    .select('*')
+    .eq('user_id', user.id)
+    .order('created_at', { ascending: false })
+  return (data ?? []) as NotificationRow[]
+}
+
+export async function markAsRead(id: string) {
+  await supabase
+    .from('notifications')
+    .update({ is_read: true, read_at: new Date().toISOString() })
+    .eq('id', id)
+}


### PR DESCRIPTION
## Summary
- implement notifications table type and enum
- document notifications schema and enum
- add NotificationBellIcon with unread badge
- fetch notifications and mark as read
- implement notifications pages for talent and store
- update sidebar links

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889d88480bc83329dd2d48d30108817