### PR TITLE
Implement notification history pages and header badge

### DIFF
--- a/talentify-next-frontend/app/store/notifications/page.tsx
+++ b/talentify-next-frontend/app/store/notifications/page.tsx
@@ -6,7 +6,7 @@ import { createClient } from '@/utils/supabase/client'
 import { NotificationItem } from '@/components/ui/notification-item'
 import type { Notification } from '@/types/ui'
 
-export default function TalentNotificationsPage() {
+export default function StoreNotificationsPage() {
   const supabase = createClient()
   const [items, setItems] = useState<Notification[]>([])
   const [loading, setLoading] = useState(true)
@@ -38,7 +38,7 @@ export default function TalentNotificationsPage() {
 
   const linkFor = (n: Notification) => {
     if (n.type === 'message') return '/messages'
-    if (n.offer_id) return `/talent/offers/${n.offer_id}`
+    if (n.offer_id) return `/store/offers/${n.offer_id}`
     return undefined
   }
 

--- a/talentify-next-frontend/components/Header.tsx
+++ b/talentify-next-frontend/components/Header.tsx
@@ -7,12 +7,14 @@ import Sidebar from './Sidebar'
 import { Sheet, SheetTrigger, SheetContent } from './ui/sheet'
 import { Button } from './ui/button'
 import { createClient } from '@/utils/supabase/client'
-import { getUserRoleInfo } from '@/lib/getUserRole'
+import { getUserRoleInfo, type UserRole } from '@/lib/getUserRole'
+import NotificationBell from './NotificationBell'
 
 const supabase = createClient()
 
 export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'store' }) {
   const [userName, setUserName] = useState<string | null>(null)
+  const [role, setRole] = useState<UserRole | null>(null)
   const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
@@ -26,7 +28,8 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
         return
       }
 
-      const { name } = await getUserRoleInfo(supabase, user.id)
+      const { name, role } = await getUserRoleInfo(supabase, user.id)
+      setRole(role)
       setUserName(name ?? 'ユーザー')
       setIsLoading(false)
     }
@@ -38,6 +41,7 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
       if (session?.user) fetchSessionAndProfile()
       else {
         setUserName(null)
+        setRole(null)
         setIsLoading(false)
       }
     })
@@ -116,7 +120,8 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
                 </>
               ) : (
                 <>
-                  <span className="flex items-baseline font-semibold">
+                  <NotificationBell role={role ?? 'talent'} />
+                  <span className="flex items-baseline font-semibold ml-2">
                     <span className="text-base">{userName}</span>
                     <span className="ml-1 text-sm text-muted-foreground align-top">様</span>
                   </span>

--- a/talentify-next-frontend/components/NotificationBell.tsx
+++ b/talentify-next-frontend/components/NotificationBell.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { Bell } from 'lucide-react'
+import { createClient } from '@/utils/supabase/client'
+
+export default function NotificationBell({ role }: { role: 'talent' | 'store' }) {
+  const supabase = createClient()
+  const [count, setCount] = useState(0)
+
+  useEffect(() => {
+    let userId: string | null = null
+    const fetchCount = async () => {
+      const { data: { user } } = await supabase.auth.getUser()
+      userId = user?.id || null
+      if (!userId) return
+      const { count } = await supabase
+        .from('notifications')
+        .select('*', { count: 'exact', head: true })
+        .eq('user_id', userId)
+        .eq('is_read', false)
+      setCount(count ?? 0)
+    }
+
+    fetchCount()
+
+    const channel = supabase
+      .channel('public:notifications')
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'notifications' },
+        payload => {
+          if (!userId) return
+          if (payload.new.user_id === userId || payload.old?.user_id === userId) {
+            fetchCount()
+          }
+        }
+      )
+    channel.subscribe()
+    return () => {
+      supabase.removeChannel(channel)
+    }
+  }, [])
+
+  return (
+    <Link href={`/${role}/notifications`} className="relative">
+      <Bell className="w-5 h-5" />
+      {count > 0 && (
+        <span className="absolute -top-1 -right-2 rounded-full bg-red-600 text-white text-xs px-1">
+          {count}
+        </span>
+      )}
+    </Link>
+  )
+}

--- a/talentify-next-frontend/components/Sidebar.tsx
+++ b/talentify-next-frontend/components/Sidebar.tsx
@@ -48,6 +48,7 @@ const navItems = {
     { href: "/store/schedule", label: "スケジュール", icon: Calendar },
     { href: "/store/reviews", label: "レビュー管理", icon: Star },
     { href: "/store/messages", label: "メッセージ", icon: Bell },
+    { href: "/store/notifications", label: "通知", icon: Bell },
     { href: "/store/invoices", label: "請求一覧", icon: Wallet },
     { href: "/store/edit", label: "店舗情報", icon: User },
     { href: "/store/settings", label: "設定", icon: Star },

--- a/talentify-next-frontend/components/ui/notification-item.tsx
+++ b/talentify-next-frontend/components/ui/notification-item.tsx
@@ -11,12 +11,18 @@ interface NotificationItemProps extends React.HTMLAttributes<HTMLDivElement> {
 const typeIcon = {
   message: Mail,
   offer: Bell,
+  offer_accepted: Bell,
+  schedule_fixed: CalendarIcon,
+  contract_uploaded: Info,
+  contract_checked: Info,
+  invoice_submitted: Info,
+  payment_completed: Info,
   schedule: CalendarIcon,
   system: Info,
-}
+} as const
 
 export function NotificationItem({ notification, className, ...props }: NotificationItemProps) {
-  const Icon = typeIcon[notification.type]
+  const Icon = typeIcon[notification.type as keyof typeof typeIcon] ?? Bell
 
   return (
     <div
@@ -29,7 +35,10 @@ export function NotificationItem({ notification, className, ...props }: Notifica
     >
       <Icon className="h-4 w-4 mt-0.5" />
       <div className="text-sm flex-1">
-        <div>{notification.body}</div>
+        <div>{notification.title}</div>
+        {notification.body && (
+          <div className="text-xs text-muted-foreground whitespace-pre-wrap">{notification.body}</div>
+        )}
         <div className="text-xs text-muted-foreground">{notification.created_at}</div>
       </div>
       {!notification.is_read && <Badge className="self-start" variant="destructive">NEW</Badge>}

--- a/talentify-next-frontend/types/ui.ts
+++ b/talentify-next-frontend/types/ui.ts
@@ -1,9 +1,20 @@
-export type NotificationType = 'message' | 'offer' | 'schedule' | 'system'
+export type NotificationType =
+  | 'message'
+  | 'offer'
+  | 'offer_accepted'
+  | 'schedule_fixed'
+  | 'contract_uploaded'
+  | 'contract_checked'
+  | 'invoice_submitted'
+  | 'payment_completed'
+  | 'schedule'
+  | 'system'
 
 export type TaskType = 'respond_offer' | 'update_profile' | 'check_message'
 
 export interface Notification {
   id: string
+  offer_id?: string
   type: NotificationType
   title: string
   body: string


### PR DESCRIPTION
## Summary
- add notification bell with realtime unread count
- display bell and username in header
- support store notifications in sidebar
- update Notification types and item component
- implement talent and store notification list pages

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6889dbfc26f0833290b89100b95e93f4