### PR TITLE
Fix talent dashboard message link and update docs

### DIFF
--- a/talentify-next-frontend/app/talent/dashboard/page.tsx
+++ b/talentify-next-frontend/app/talent/dashboard/page.tsx
@@ -52,7 +52,7 @@ export default function TalentDashboard() {
         <>
           <ScheduleCard items={schedule} />
           <OfferSummaryCard pending={pending} accepted={schedule.length} link='/talent/offers' />
-          <MessageAlertCard count={unread} link='/talent/messages' />
+          <MessageAlertCard count={unread} link='/messages' />
           <NotificationListCard className='sm:col-span-2 lg:col-span-3' />
           <div className='sm:col-span-2 lg:col-span-3'>
             <ProfileProgressCard />

--- a/talentify-next-frontend/app/talent/notifications/page.tsx
+++ b/talentify-next-frontend/app/talent/notifications/page.tsx
@@ -20,7 +20,7 @@ export default function TalentNotificationsPage() {
   }
 
   const linkFor = (n: NotificationRow) => {
-    if (n.type === 'message') return '/talent/messages'
+    if (n.type === 'message') return '/messages'
     return n.offer_id ? `/talent/offers/${n.offer_id}` : '#'
   }
 

--- a/talentify-next-frontend/supabase-docs/enums.md
+++ b/talentify-next-frontend/supabase-docs/enums.md
@@ -73,6 +73,7 @@
 - rejected
 - completed
 - offer_created
+- confirmed
 
 ### public.visit_status
 - scheduled


### PR DESCRIPTION
## Summary
- fix talent dashboard messages link
- update link in talent notifications
- document new `confirmed` status in status_type enum

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889eb3f98f88332b3be30768dc119d8