### PR TITLE
Add status_type enum JSON

### DIFF
--- a/talentify-next-frontend/supabase-docs/enums/status_type.json
+++ b/talentify-next-frontend/supabase-docs/enums/status_type.json
@@ -1,0 +1,13 @@
+{
+  "schema": "public",
+  "name": "status_type",
+  "values": [
+    "draft",
+    "pending",
+    "approved",
+    "rejected",
+    "completed",
+    "offer_created",
+    "confirmed"
+  ]
+}


### PR DESCRIPTION
## Summary
- document status_type values in JSON under supabase-docs/enums

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889f0c0efd883328cfcde2184997f8c