### PR TITLE
Improve Supabase server client and dynamic settings

### DIFF
--- a/talentify-next-frontend/app/(auth)/layout.tsx
+++ b/talentify-next-frontend/app/(auth)/layout.tsx
@@ -1,6 +1,6 @@
 // app/(auth)/layout.tsx
 
-export const dynamic = "force-dynamic";
+export const dynamic = "auto";
 
 import React from "react";
 import "../globals.css";

--- a/talentify-next-frontend/app/page.tsx
+++ b/talentify-next-frontend/app/page.tsx
@@ -1,4 +1,4 @@
-export const dynamic = 'force-dynamic'
+export const dynamic = 'auto'
 
 import Link from 'next/link';
 import { redirect } from 'next/navigation';

--- a/talentify-next-frontend/app/talent/edit/[code]/page.tsx
+++ b/talentify-next-frontend/app/talent/edit/[code]/page.tsx
@@ -1,7 +1,7 @@
 import { createClient } from '@/lib/supabase/server'
 import EditClient from '../EditClient'
 
-export const dynamic = 'force-dynamic'
+export const dynamic = 'auto'
 
 export default async function Page({ params }: { params: { code: string } }) {
   const supabase = await createClient()

--- a/talentify-next-frontend/app/talent/edit/page.tsx
+++ b/talentify-next-frontend/app/talent/edit/page.tsx
@@ -2,7 +2,7 @@ import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import EditClient from './EditClient'
 
-export const dynamic = 'force-dynamic'
+export const dynamic = 'auto'
 
 export default async function Page({ searchParams }: { searchParams: { code?: string } }) {
   const supabase = await createClient()

--- a/talentify-next-frontend/app/talents/[id]/page.tsx
+++ b/talentify-next-frontend/app/talents/[id]/page.tsx
@@ -2,7 +2,7 @@ import TalentDetailPageClient from './TalentDetailPageClient'
 import { createClient } from '@/lib/supabase/server'
 import { notFound } from 'next/navigation'
 
-export const dynamic = 'force-dynamic'
+export const dynamic = 'auto'
 
 type PageProps = {
   params: {

--- a/talentify-next-frontend/lib/getRedirectUrl.ts
+++ b/talentify-next-frontend/lib/getRedirectUrl.ts
@@ -2,7 +2,7 @@ export function getRedirectUrl(role: string) {
   const baseUrl =
     process.env.NODE_ENV === 'development'
       ? 'http://localhost:3000'
-      : process.env.NEXT_PUBLIC_SITE_URL || 'https://talentify-xi.vercel.app'
+      : process.env.NEXT_PUBLIC_SITE_URL
 
   // Always redirect to the auth callback so that Supabase session tokens
   // contained in the confirmation link can be exchanged properly. The

--- a/talentify-next-frontend/lib/supabase/server.ts
+++ b/talentify-next-frontend/lib/supabase/server.ts
@@ -2,10 +2,11 @@ export const runtime = 'nodejs'
 
 import { createServerClient, type CookieOptions } from '@supabase/ssr'
 import { cookies } from 'next/headers'
+import { cache } from 'react'
 import type { Database } from '@/types/supabase'
 
-export async function createClient() {
-  const cookieStore = await cookies()
+export const createClient = cache(async () => {
+  const cookieStore = cookies()
   return createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
@@ -23,6 +24,6 @@ export async function createClient() {
       },
     }
   )
-}
+})
 
 export type { Database }


### PR DESCRIPTION
## Summary
- cache Supabase server client to avoid repeated cookie reads
- switch most pages from `force-dynamic` to `auto`
- make redirect URL production host configurable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a010b67688332863ace4934a86c54