### PR TITLE
Refactor auth callback and role checks

### DIFF
--- a/talentify-next-frontend/__tests__/getRedirectUrl.test.ts
+++ b/talentify-next-frontend/__tests__/getRedirectUrl.test.ts
@@ -13,7 +13,9 @@ describe('getRedirectUrl', () => {
     const env = { ...process.env } as NodeJS.ProcessEnv
     env.NODE_ENV = 'development'
     process.env = env
-    expect(getRedirectUrl('store')).toBe('http://localhost:3000/auth/callback')
+    expect(getRedirectUrl('store')).toBe(
+      'http://localhost:3000/auth/callback?role=store'
+    )
   })
 
   test('returns NEXT_PUBLIC_SITE_URL callback in production', () => {
@@ -21,7 +23,9 @@ describe('getRedirectUrl', () => {
     env.NODE_ENV = 'production'
     env.NEXT_PUBLIC_SITE_URL = 'https://example.com'
     process.env = env
-    expect(getRedirectUrl('talent')).toBe('https://example.com/auth/callback')
+    expect(getRedirectUrl('talent')).toBe(
+      'https://example.com/auth/callback?role=talent'
+    )
   })
 
   test('still returns callback for unknown role', () => {
@@ -29,6 +33,8 @@ describe('getRedirectUrl', () => {
     env.NODE_ENV = 'production'
     env.NEXT_PUBLIC_SITE_URL = 'https://example.com'
     process.env = env
-    expect(getRedirectUrl('unknown')).toBe('https://example.com/auth/callback')
+    expect(getRedirectUrl('unknown')).toBe(
+      'https://example.com/auth/callback?role=unknown'
+    )
   })
 })

--- a/talentify-next-frontend/app/auth/callback/page.tsx
+++ b/talentify-next-frontend/app/auth/callback/page.tsx
@@ -1,110 +1,53 @@
-'use client'
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import { getUserRoleInfo, UserRole } from '@/lib/getUserRole'
 
-import { useEffect } from 'react'
-import { useRouter } from 'next/navigation'
-import { createClient } from '@/utils/supabase/client'
-import { getUserRoleInfo } from '@/lib/getUserRole'
+export default async function AuthCallbackPage({
+  searchParams,
+}: {
+  searchParams: { code?: string; role?: string }
+}) {
+  const supabase = await createClient()
 
-export default function AuthCallbackPage() {
-  const router = useRouter()
-  const supabase = createClient()
+  const code = searchParams.code
+  if (code) {
+    const { error } = await supabase.auth.exchangeCodeForSession(code)
+    if (error) console.error('Failed to exchange code:', error)
+  }
 
-  useEffect(() => {
-    const checkAndRedirect = async () => {
-      // When the user clicks the confirmation link from the email, Supabase
-      // appends an auth `code` to the callback URL. We need to exchange this
-      // code for a session so that `getSession` returns a valid session.
-      const urlParams = new URLSearchParams(window.location.search)
-      const code = urlParams.get('code')
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  if (!session) {
+    redirect('/login')
+  }
 
-      if (code) {
-        const { error } = await supabase.auth.exchangeCodeForSession(code)
-        if (error) {
-          console.error('Failed to exchange code:', error)
-        }
-      }
+  const userId = session!.user.id
+  const pendingRole = (searchParams.role as UserRole | undefined) ?? 'store'
 
-      const {
-        data: { session },
-      } = await supabase.auth.getSession()
+  const { role: existingRole } = await getUserRoleInfo(supabase, userId)
+  let role: UserRole | null = existingRole
 
-      if (!session) {
-        router.push('/login')
-        return
-      }
-
-      const userId = session.user.id
-      const role = localStorage.getItem('pending_role') ?? 'store'
-
-      const { role: existingRole } = await getUserRoleInfo(supabase, userId)
-
-      if (!existingRole) {
-        if (role === 'talent') {
-          const { error: insertError } = await supabase
-            .from('talents')
-            .insert([
-              {
-                id: userId,
-                user_id: userId,
-                name: '',
-                is_setup_complete: false,
-              },
-            ])
-          if (insertError) {
-            console.error('profile insert error:', insertError)
-            return
-          }
-        } else if (role === 'company') {
-          const { error: insertError } = await supabase
-            .from('companies')
-            .insert([
-              {
-                user_id: userId,
-                company_name: '',
-                display_name: '',
-              },
-            ])
-          if (insertError) {
-            console.error('profile insert error:', insertError)
-            return
-          }
-        } else {
-          const { error: upsertError } = await supabase
-            .from('stores')
-            .upsert(
-              { user_id: userId, store_name: '' },
-              { onConflict: 'user_id' }
-            )
-          if (upsertError) {
-            console.error('profile insert error:', upsertError)
-            alert(`Supabase更新エラー: ${upsertError.message}`)
-            if (
-              upsertError.message.toLowerCase().includes('row level security') ||
-              upsertError.message.toLowerCase().includes('permission')
-            ) {
-              console.warn('RLS policy may prevent inserting/updating stores')
-            }
-            return
-          }
-        }
-      }
-
-      // ✅ ロールに応じて edit ページへリダイレクト
-      if (role === 'store') {
-        router.push('/store/edit')
-      } else if (role === 'talent') {
-        router.push('/talent/edit')
-      } else if (role === 'company') {
-        router.push('/company/edit')
-      } else {
-        router.push('/') // 万が一不明なロールだった場合
-      }
-
-      localStorage.removeItem('pending_role')
+  if (!existingRole) {
+    role = pendingRole
+    if (role === 'talent') {
+      const { error } = await supabase.from('talents').insert([
+        { id: userId, user_id: userId, name: '', is_setup_complete: false },
+      ])
+      if (error) console.error('profile insert error:', error)
+    } else if (role === 'company') {
+      const { error } = await supabase.from('companies').insert([
+        { user_id: userId, company_name: '', display_name: '' },
+      ])
+      if (error) console.error('profile insert error:', error)
+    } else {
+      const { error } = await supabase
+        .from('stores')
+        .upsert({ user_id: userId, store_name: '' }, { onConflict: 'user_id' })
+      if (error) console.error('profile insert error:', error)
     }
+  }
 
-    checkAndRedirect()
-  }, [router, supabase])
-
-  return <p className="p-4">ログイン処理中です...</p>
+  const target = role ? `/${role}/edit` : '/'
+  redirect(target)
 }

--- a/talentify-next-frontend/components/RegisterForm.tsx
+++ b/talentify-next-frontend/components/RegisterForm.tsx
@@ -65,14 +65,13 @@ export default function RegisterForm() {
 
     if (hasError) return
 
-// 🔽 ロールを保存（AuthCallback で使う）
-  localStorage.setItem('pending_role', role)
-
     try {
       const { data, error: signUpError } = await supabase.auth.signUp({
         email,
         password,
         options: {
+          // The role is passed via query parameter so the callback can
+          // create the appropriate profile on the server.
           emailRedirectTo: getRedirectUrl(role),
         },
       })

--- a/talentify-next-frontend/lib/getRedirectUrl.ts
+++ b/talentify-next-frontend/lib/getRedirectUrl.ts
@@ -5,8 +5,7 @@ export function getRedirectUrl(role: string) {
       : process.env.NEXT_PUBLIC_SITE_URL
 
   // Always redirect to the auth callback so that Supabase session tokens
-  // contained in the confirmation link can be exchanged properly. The
-  // callback page will handle inserting profile rows and redirecting the user
-  // to the appropriate edit page based on their role stored in localStorage.
-  return `${baseUrl}/auth/callback`
+  // contained in the confirmation link can be exchanged properly. Pass the
+  // desired role via query parameters instead of using localStorage.
+  return `${baseUrl}/auth/callback?role=${encodeURIComponent(role)}`
 }

--- a/talentify-next-frontend/lib/getServerUserRole.ts
+++ b/talentify-next-frontend/lib/getServerUserRole.ts
@@ -1,0 +1,14 @@
+import { createClient } from '@/lib/supabase/server'
+import { getUserRoleInfo } from '@/lib/getUserRole'
+
+export async function getServerUserRole() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return { role: null, isSetupComplete: null }
+  }
+  const { role, isSetupComplete } = await getUserRoleInfo(supabase, user.id)
+  return { role, isSetupComplete }
+}

--- a/talentify-next-frontend/lib/getUserRole.ts
+++ b/talentify-next-frontend/lib/getUserRole.ts
@@ -7,11 +7,28 @@ export async function getUserRoleInfo(
   supabase: SupabaseClient<Database>,
   userId: string
 ): Promise<{ role: UserRole | null; name: string | null; isSetupComplete: boolean | null }> {
-  const { data: store } = await supabase
-    .from('stores' as any)
-    .select('store_name, is_setup_complete')
-    .eq('user_id', userId)
-    .maybeSingle()
+  const [
+    { data: store },
+    { data: talent },
+    { data: company },
+  ] = await Promise.all([
+    supabase
+      .from('stores' as any)
+      .select('store_name, is_setup_complete')
+      .eq('user_id', userId)
+      .maybeSingle(),
+    supabase
+      .from('talents' as any)
+      .select('stage_name, is_setup_complete')
+      .eq('id', userId)
+      .maybeSingle(),
+    supabase
+      .from('companies' as any)
+      .select('display_name, is_setup_complete')
+      .eq('user_id', userId)
+      .maybeSingle(),
+  ])
+
   if (store) {
     return {
       role: 'store',
@@ -20,11 +37,6 @@ export async function getUserRoleInfo(
     }
   }
 
-  const { data: talent } = await supabase
-    .from('talents' as any)
-    .select('stage_name, is_setup_complete')
-    .eq('id', userId)
-    .maybeSingle()
   if (talent) {
     return {
       role: 'talent',
@@ -33,11 +45,6 @@ export async function getUserRoleInfo(
     }
   }
 
-  const { data: company } = await supabase
-    .from('companies' as any)
-    .select('display_name, is_setup_complete')
-    .eq('user_id', userId)
-    .maybeSingle()
   if (company) {
     return {
       role: 'company',

--- a/talentify-next-frontend/utils/useRole.ts
+++ b/talentify-next-frontend/utils/useRole.ts
@@ -1,7 +1,6 @@
 'use client'
 import { useEffect, useState } from 'react'
 import { createClient } from '@/utils/supabase/client'
-import { createClient as createServerClient } from '@/lib/supabase/server'
 import { getUserRoleInfo, UserRole } from '@/lib/getUserRole'
 
 const supabase = createClient()
@@ -32,14 +31,3 @@ export function useUserRole() {
   return { role, isSetupComplete, loading }
 }
 
-export async function getServerUserRole() {
-  const supabase = await createServerClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-  if (!user) {
-    return { role: null, isSetupComplete: null }
-  }
-  const { role, isSetupComplete } = await getUserRoleInfo(supabase, user.id)
-  return { role, isSetupComplete }
-}

--- a/talentify-next-frontend/utils/useRole.ts
+++ b/talentify-next-frontend/utils/useRole.ts
@@ -1,6 +1,7 @@
 'use client'
 import { useEffect, useState } from 'react'
 import { createClient } from '@/utils/supabase/client'
+import { createClient as createServerClient } from '@/lib/supabase/server'
 import { getUserRoleInfo, UserRole } from '@/lib/getUserRole'
 
 const supabase = createClient()
@@ -29,4 +30,16 @@ export function useUserRole() {
   }, [])
 
   return { role, isSetupComplete, loading }
+}
+
+export async function getServerUserRole() {
+  const supabase = await createServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return { role: null, isSetupComplete: null }
+  }
+  const { role, isSetupComplete } = await getUserRoleInfo(supabase, user.id)
+  return { role, isSetupComplete }
 }


### PR DESCRIPTION
## Summary
- run role queries in parallel
- expose server-side user role helper
- pass role via query param when redirecting
- handle callback logic server-side
- update tests for new callback URL

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a0554a0ac83329b127a49ca04b160