### PR TITLE
Fix redirect URL fallback

### DIFF
--- a/talentify-next-frontend/__tests__/getRedirectUrl.test.ts
+++ b/talentify-next-frontend/__tests__/getRedirectUrl.test.ts
@@ -28,6 +28,16 @@ describe('getRedirectUrl', () => {
     )
   })
 
+  test('falls back to default domain when NEXT_PUBLIC_SITE_URL is not set in production', () => {
+    const env = { ...process.env } as NodeJS.ProcessEnv
+    env.NODE_ENV = 'production'
+    delete env.NEXT_PUBLIC_SITE_URL
+    process.env = env
+    expect(getRedirectUrl('store')).toBe(
+      'https://talentify-xi.vercel.app/auth/callback?role=store'
+    )
+  })
+
   test('still returns callback for unknown role', () => {
     const env = { ...process.env } as NodeJS.ProcessEnv
     env.NODE_ENV = 'production'

--- a/talentify-next-frontend/lib/getRedirectUrl.ts
+++ b/talentify-next-frontend/lib/getRedirectUrl.ts
@@ -2,7 +2,7 @@ export function getRedirectUrl(role: string) {
   const baseUrl =
     process.env.NODE_ENV === 'development'
       ? 'http://localhost:3000'
-      : process.env.NEXT_PUBLIC_SITE_URL ?? process.env.NEXT_PUBLIC_VERCEL_URL ?? ''
+      : process.env.NEXT_PUBLIC_SITE_URL || 'https://talentify-xi.vercel.app'
 
   // Always redirect to the auth callback so that Supabase session tokens
   // contained in the confirmation link can be exchanged properly. Pass the


### PR DESCRIPTION
## Summary
- restore fallback URL in `getRedirectUrl`
- test default URL fallback when `NEXT_PUBLIC_SITE_URL` is unset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a1c42edc48332aff26a3dc1540162