### PR TITLE
Fix login redirect after authentication

### DIFF
--- a/talentify-next-frontend/app/login/page.tsx
+++ b/talentify-next-frontend/app/login/page.tsx
@@ -1,12 +1,13 @@
 'use client'
 
 import { useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { createClient } from '@/utils/supabase/client'
 import { getUserRoleInfo } from '@/lib/getUserRole'
 
 export default function LoginPage() {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const supabase = createClient()
 
   const [email, setEmail] = useState('')
@@ -35,7 +36,7 @@ export default function LoginPage() {
       // TODO: explicit role selection page can be implemented here
     }
 
-    router.push('/dashboard')
+    router.replace(searchParams.get('redirectedFrom') ?? '/dashboard')
   }
 
   return (


### PR DESCRIPTION
## Summary
- redirect users after login by checking `redirectedFrom`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688a240db1748332923385902f5dd368