### PR TITLE
Fix API base env instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,13 @@ talentify-next-frontend 目に `.env.local` を作成し、下記を記述:
 
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+NEXT_PUBLIC_API_BASE=
 NEXT_PUBLIC_SITE_URL=https://example.com
 NOTIFICATION_WEBHOOK_URL=https://example.com/webhook
+
+`NEXT_PUBLIC_API_BASE` を空にしておくと、フロントエンドと同じオリジンの API ルー
+トを使用します。別ドメインを指定すると認証リクエストが CORS でブロックされる
+ため注意してください。
 
 `NOTIFICATION_WEBHOOK_URL` はオファーのステータス更新後に通知を送るWebフックのURLです。
 

--- a/talentify-next-frontend/.env.example
+++ b/talentify-next-frontend/.env.example
@@ -1,6 +1,6 @@
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 # Base URL for API requests. Leave blank to use the same origin as the frontend.
-NEXT_PUBLIC_API_BASE=http://localhost:3000
+NEXT_PUBLIC_API_BASE=
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 NOTIFICATION_WEBHOOK_URL=https://example.com/webhook

--- a/talentify-next-frontend/.env.local.example
+++ b/talentify-next-frontend/.env.local.example
@@ -1,6 +1,6 @@
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 # Base URL for API requests. Leave blank to use the same origin as the frontend.
-NEXT_PUBLIC_API_BASE=http://localhost:3000
+NEXT_PUBLIC_API_BASE=
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 NOTIFICATION_WEBHOOK_URL=https://example.com/webhook


### PR DESCRIPTION
## Summary
- clarify `NEXT_PUBLIC_API_BASE` handling in README
- update `.env.example` and `.env.local.example` to use same-origin API by default

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688a315c39b08332a925ab39ba45bf6f