### PR TITLE
Fix login API CORS handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,7 @@ NEXT_PUBLIC_API_BASE=
 NEXT_PUBLIC_SITE_URL=https://example.com
 NOTIFICATION_WEBHOOK_URL=https://example.com/webhook
 
-`NEXT_PUBLIC_API_BASE` を空にしておくと、フロントエンドと同じオリジンの API ルー
-トを使用します。別ドメインを指定すると認証リクエストが CORS でブロックされる
-ため注意してください。
+`NEXT_PUBLIC_API_BASE` を空にしておくと、フロントエンドと同じオリジンの API ルートを使用します。別ドメインを指定すると認証リクエストが CORS でブロックされるため注意してください。特に本番環境ではこの値を設定せず、フロントと API を同一ドメインでホスティングする構成を推奨します。
 
 `NOTIFICATION_WEBHOOK_URL` はオファーのステータス更新後に通知を送るWebフックのURLです。
 

--- a/talentify-next-frontend/app/login/page.tsx
+++ b/talentify-next-frontend/app/login/page.tsx
@@ -46,6 +46,9 @@ export default function LoginPage() {
       const csrfRes = await fetch(`${API_BASE}/api/csrf-token`, {
         credentials: 'include',
       })
+      if (!csrfRes.ok) {
+        throw new Error('csrf')
+      }
       const { csrfToken } = await csrfRes.json()
       const res = await fetch(`${API_BASE}/api/login`, {
         method: 'POST',
@@ -62,7 +65,11 @@ export default function LoginPage() {
       }
       router.replace(searchParams.get('redirectedFrom') ?? '/dashboard')
     } catch (err) {
-      setError('ログインに失敗しました')
+      const message =
+        err instanceof Error && err.message === 'csrf'
+          ? 'CSRFトークンの取得に失敗しました。CORS またはセッションエラーの可能性があります'
+          : 'ログインに失敗しました'
+      setError(message)
     }
   }
 


### PR DESCRIPTION
## Summary
- document that NEXT_PUBLIC_API_BASE should remain empty in production
- handle CSRF token fetch failure in login form and show error

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a342e03548332a59a89d8c35df2c1