### PR TITLE
Add health check endpoint with tests

### DIFF
--- a/talentify-next-frontend/__tests__/healthz.test.ts
+++ b/talentify-next-frontend/__tests__/healthz.test.ts
@@ -1,0 +1,10 @@
+import { GET } from '../app/api/healthz/route'
+
+describe('healthz endpoint', () => {
+  test('returns service status with version', async () => {
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data).toEqual({ status: 'ok', version: '0.1.0' })
+  })
+})

--- a/talentify-next-frontend/app/api/healthz/route.ts
+++ b/talentify-next-frontend/app/api/healthz/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server'
+import packageJson from '../../../package.json'
+
+export async function GET() {
+  return NextResponse.json({ status: 'ok', version: packageJson.version })
+}


### PR DESCRIPTION
## Summary
- add `/api/healthz` endpoint returning status and version
- test the new endpoint

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688adb97351c83328b116cc3614b9543