### PR TITLE
Fix fallback icon for unknown notification type

### DIFF
--- a/talentify-next-frontend/components/ui/notification-item.tsx
+++ b/talentify-next-frontend/components/ui/notification-item.tsx
@@ -16,7 +16,7 @@ const typeIcon = {
 }
 
 export function NotificationItem({ notification, className, ...props }: NotificationItemProps) {
-  const Icon = typeIcon[notification.type]
+  const Icon = typeIcon[notification.type] || Info
 
   return (
     <div


### PR DESCRIPTION
## Summary
- avoid React crash when encountering an unknown notification type
- show `Info` icon when the notification type isn't in the map

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b1ba6631c833299b162fe6da4fded