### PR TITLE
Allow talents to update offer status and contract

### DIFF
--- a/talentify-next-frontend/supabase-docs/rls.md
+++ b/talentify-next-frontend/supabase-docs/rls.md
@@ -25,7 +25,7 @@
 - ストアはオファーを登録可能 (`INSERT`): CHECK `(auth.uid() = store_id)`
 - ストアは自分のオファーを削除可能 (`DELETE`): USING `(auth.uid() = store_id)`
 - ストアまたはタレントは自分のオファーを閲覧可能 (`SELECT`): USING `((auth.uid() = store_id) OR (auth.uid() = talent_id))`
-- ストアは自分のオファーを更新可能 (`UPDATE`): USING `(auth.uid() = store_id)`
+- ストアとタレントが自分のオファーを更新可能 (`UPDATE`): USING `((auth.uid() = store_id) OR (auth.uid() = talent_id))`
 
 ### payments
 - 認証済みユーザーは読み書き可能 (`*`): USING `true`, CHECK `true`


### PR DESCRIPTION
## Summary
- allow both store and talent users to update offers with role-based field validation
- document RLS policy to permit talent updates

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688b1f89d430833297cdf3ebf2a4373d