### PR TITLE
Refactor offers to single visit date

### DIFF
--- a/docs/dashboard-sections.md
+++ b/docs/dashboard-sections.md
@@ -13,7 +13,7 @@ This document lists the planned dashboard sections for each role and notes which
 Sections displayed:
 
 1. **Offer Stats** – summary of offers received recently.
-2. **Next Event** – upcoming confirmed schedule.
+2. **Next Event** – upcoming accepted schedule.
 3. **Unread Messages** – badge showing unread message count.
 
 These can all be presented using `DashboardCard` with specific content.

--- a/talentify-next-frontend/app/api/offers/[id]/route.ts
+++ b/talentify-next-frontend/app/api/offers/[id]/route.ts
@@ -28,7 +28,7 @@ export async function PUT(
 
   let allowedFields: string[] = []
   if (user.id === offer.store_id) {
-    allowedFields = ['status', 'fixed_date', 'contract_url', 'paid', 'paid_at']
+    allowedFields = ['status', 'contract_url', 'paid', 'paid_at']
   } else if (user.id === offer.talent_id) {
     allowedFields = [
       'status',

--- a/talentify-next-frontend/app/company/offers/page.tsx
+++ b/talentify-next-frontend/app/company/offers/page.tsx
@@ -14,8 +14,8 @@ export default function CompanyOffersPage() {
 
   const [status, setStatus] = useState('all')
   const [keyword, setKeyword] = useState('')
-  const [fixedFrom, setFixedFrom] = useState('')
-  const [fixedTo, setFixedTo] = useState('')
+  const [visitFrom, setVisitFrom] = useState('')
+  const [visitTo, setVisitTo] = useState('')
   const [invoiceFrom, setInvoiceFrom] = useState('')
   const [invoiceTo, setInvoiceTo] = useState('')
   const [paidFrom, setPaidFrom] = useState('')
@@ -36,8 +36,8 @@ export default function CompanyOffersPage() {
       const sn = o.store_name?.toLowerCase() ?? ''
       if (!tn.includes(kw) && !sn.includes(kw)) return false
     }
-    if (fixedFrom && (!o.fixed_date || o.fixed_date < fixedFrom)) return false
-    if (fixedTo && (!o.fixed_date || o.fixed_date > fixedTo)) return false
+    if (visitFrom && (!o.visit_date || o.visit_date < visitFrom)) return false
+    if (visitTo && (!o.visit_date || o.visit_date > visitTo)) return false
     if (invoiceFrom && (!o.invoice_date || o.invoice_date < invoiceFrom)) return false
     if (invoiceTo && (!o.invoice_date || o.invoice_date > invoiceTo)) return false
     if (paidFrom && (!o.paid_at || o.paid_at < paidFrom)) return false
@@ -46,11 +46,11 @@ export default function CompanyOffersPage() {
   })
 
   const downloadCsv = () => {
-    const headers = ['タレント名','店舗名','確定日','報酬金額','請求日','支払日','契約確認済み','備考']
+    const headers = ['タレント名','店舗名','来店日','報酬金額','請求日','支払日','契約確認済み','備考']
     const rows = filtered.map(o => [
       o.talent_name ?? '',
       o.store_name ?? '',
-      o.fixed_date ?? '',
+      o.visit_date ?? '',
       String(o.invoice_amount ?? o.reward ?? ''),
       o.invoice_date ?? '',
       o.paid_at ?? '',
@@ -71,7 +71,6 @@ export default function CompanyOffersPage() {
   const statusLabels: Record<string, string> = {
     pending: '保留中',
     accepted: '承諾済み',
-    confirmed: '確定済',
     rejected: '拒否',
     expired: '期限切れ',
   }
@@ -86,7 +85,6 @@ export default function CompanyOffersPage() {
             <option value='all'>すべて</option>
             <option value='pending'>保留中</option>
             <option value='accepted'>承諾済み</option>
-            <option value='confirmed'>確定済</option>
             <option value='rejected'>拒否</option>
             <option value='expired'>期限切れ</option>
           </select>
@@ -96,12 +94,12 @@ export default function CompanyOffersPage() {
           <input type='text' value={keyword} onChange={e=>setKeyword(e.target.value)} className='border rounded p-1'/>
         </div>
         <div>
-          <label className='block'>確定日From</label>
-          <input type='date' value={fixedFrom} onChange={e=>setFixedFrom(e.target.value)} className='border rounded p-1'/>
+          <label className='block'>来店日From</label>
+          <input type='date' value={visitFrom} onChange={e=>setVisitFrom(e.target.value)} className='border rounded p-1'/>
         </div>
         <div>
-          <label className='block'>確定日To</label>
-          <input type='date' value={fixedTo} onChange={e=>setFixedTo(e.target.value)} className='border rounded p-1'/>
+          <label className='block'>来店日To</label>
+          <input type='date' value={visitTo} onChange={e=>setVisitTo(e.target.value)} className='border rounded p-1'/>
         </div>
         <div>
           <label className='block'>請求日From</label>
@@ -136,7 +134,7 @@ export default function CompanyOffersPage() {
               <TableHead>タレント名</TableHead>
               <TableHead>店舗名</TableHead>
               <TableHead>ステータス</TableHead>
-              <TableHead>確定日</TableHead>
+              <TableHead>来店日</TableHead>
               <TableHead>報酬金額</TableHead>
               <TableHead>契約確認</TableHead>
               <TableHead>請求済</TableHead>
@@ -151,7 +149,7 @@ export default function CompanyOffersPage() {
                 <TableCell>{o.talent_name}</TableCell>
                 <TableCell>{o.store_name}</TableCell>
                 <TableCell>{statusLabels[o.status ?? 'pending']}</TableCell>
-                <TableCell>{o.fixed_date ?? ''}</TableCell>
+                <TableCell>{o.visit_date ?? ''}</TableCell>
                 <TableCell>¥{(o.invoice_amount ?? o.reward ?? 0).toLocaleString()}</TableCell>
                 <TableCell>
                   {o.agreed ? <Badge>確認済</Badge> : <Badge variant='destructive'>未確認</Badge>}

--- a/talentify-next-frontend/app/store/offers/page.tsx
+++ b/talentify-next-frontend/app/store/offers/page.tsx
@@ -20,7 +20,6 @@ import {
 const statusLabels: Record<string, string> = {
   pending: '保留中',
   accepted: '承諾済み',
-  confirmed: '確定済',
   rejected: '拒否',
   expired: '期限切れ',
 }
@@ -51,7 +50,6 @@ export default function StoreOffersPage() {
   const groups: Record<string, Offer[]> = {
     pending: [],
     accepted: [],
-    confirmed: [],
     rejected: [],
     expired: [],
   }
@@ -73,7 +71,6 @@ export default function StoreOffersPage() {
           <option value="all">すべて</option>
           <option value="pending">保留中</option>
           <option value="accepted">承諾済み</option>
-          <option value="confirmed">確定済</option>
           <option value="rejected">拒否</option>
           <option value="expired">期限切れ</option>
         </select>
@@ -91,7 +88,7 @@ export default function StoreOffersPage() {
       ) : offers.length === 0 ? (
         <EmptyState title='まだオファーがありません' actionHref='/talent-search' actionLabel='オファーを送ってみましょう' />
       ) : (
-        (['pending', 'accepted', 'confirmed', 'rejected', 'expired'] as const).map(status => (
+        (['pending', 'accepted', 'rejected', 'expired'] as const).map(status => (
           groups[status].length > 0 && (
             <div key={status} className="space-y-2">
               <h2 className="font-semibold">{statusLabels[status]}</h2>

--- a/talentify-next-frontend/app/store/reviews/page.tsx
+++ b/talentify-next-frontend/app/store/reviews/page.tsx
@@ -39,7 +39,7 @@ export default function StoreReviewsPage() {
           <TableBody>
             {offers.map(o => (
               <TableRow key={o.id}>
-                <TableCell>{o.date}</TableCell>
+                <TableCell>{o.visit_date}</TableCell>
                 <TableCell>{o.talent_name || o.talent_id}</TableCell>
                 <TableCell>
                   {o.reviewed ? (

--- a/talentify-next-frontend/app/store/schedule/page.tsx
+++ b/talentify-next-frontend/app/store/schedule/page.tsx
@@ -49,9 +49,9 @@ export default function StoreSchedulePage() {
 
       const { data, error } = await supabase
         .from('offers')
-        .select('id, talent_id, date, status, talents(stage_name)')
+        .select('id, talent_id, visit_date, status, talents(stage_name)')
         .eq('user_id', user.id)
-        .in('status', ['accepted', 'confirmed'])
+        .eq('status', 'accepted')
 
       if (error) {
         console.error('Failed to fetch offers', error)
@@ -60,8 +60,8 @@ export default function StoreSchedulePage() {
 
       const mapped = (data || []).map((o: any) => ({
         title: o.talents?.stage_name || '出演',
-        start: new Date(o.date),
-        end: new Date(o.date),
+        start: new Date(o.visit_date),
+        end: new Date(o.visit_date),
         talentId: o.talent_id,
         offerId: o.id,
       })) as OfferEvent[]

--- a/talentify-next-frontend/app/talent/dashboard/page.tsx
+++ b/talentify-next-frontend/app/talent/dashboard/page.tsx
@@ -21,7 +21,7 @@ export default function TalentDashboard() {
   useEffect(() => {
     getTalentSchedule().then((data) => {
       const items: ScheduleItem[] = data.map((d) => ({
-        date: d.fixed_date,
+        date: d.visit_date,
         performer: d.store_name ?? '',
         status: 'confirmed',
         href: `/talent/offers/${d.id}`,

--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -15,9 +15,7 @@ import { addNotification } from '@/utils/notifications'
 
 interface Offer {
   id: string
-  date: string
-  second_date?: string | null
-  third_date?: string | null
+  visit_date: string
   time_range?: string | null
   created_at?: string | null
   message: string
@@ -157,7 +155,7 @@ export default function TalentOfferDetailPage() {
       const { data, error } = await supabase
         .from('offers')
         .select(
-  `id, date, second_date, third_date, time_range, created_at, message, status, contract_url, respond_deadline, event_name, start_time, end_time, reward, notes, question_allowed, agreed, invoice_date, invoice_amount, bank_name, bank_branch, bank_account_number, bank_account_holder, invoice_submitted, paid, paid_at, user_id, store:store_id(store_name,store_address,avatar_url)`
+  `id, visit_date, time_range, created_at, message, status, contract_url, respond_deadline, event_name, start_time, end_time, reward, notes, question_allowed, agreed, invoice_date, invoice_amount, bank_name, bank_branch, bank_account_number, bank_account_holder, invoice_submitted, paid, paid_at, user_id, store:store_id(store_name,store_address,avatar_url)`
 )
         .eq('id', params.id)
         .single()
@@ -255,7 +253,7 @@ export default function TalentOfferDetailPage() {
             <div className='text-green-600 text-sm'>✅ お支払いが完了しました（{format(parseISO(offer.paid_at || ''), 'yyyy年M月d日', { locale: ja })}）</div>
           )}
         </>
-      ) : offer.status === 'confirmed' && offer.agreed ? (
+      ) : offer.status === 'accepted' && offer.agreed ? (
         <Card>
           <CardHeader>
             <CardTitle>請求書作成</CardTitle>
@@ -320,13 +318,7 @@ export default function TalentOfferDetailPage() {
             </div>
           )}
           {offer.event_name && <div>イベント名: {offer.event_name}</div>}
-          <div>候補日1: {format(parseISO(offer.date), 'yyyy-MM-dd')}</div>
-          {offer.second_date && (
-            <div>候補日2: {format(parseISO(offer.second_date), 'yyyy-MM-dd')}</div>
-          )}
-          {offer.third_date && (
-            <div>候補日3: {format(parseISO(offer.third_date), 'yyyy-MM-dd')}</div>
-          )}
+          <div>訪問日: {format(parseISO(offer.visit_date), 'yyyy-MM-dd')}</div>
           {timeRange && <div>時間帯: {timeRange}</div>}
           {typeof offer.reward === 'number' && (
             <div>報酬: {offer.reward.toLocaleString()}円</div>
@@ -370,12 +362,6 @@ export default function TalentOfferDetailPage() {
             見送る
           </Button>
           <Button onClick={() => handleStatusChange('accepted')}>承諾する</Button>
-        </div>
-      )}
-
-      {offer.status === 'accepted' && (
-        <div className="fixed bottom-0 left-0 right-0 bg-white border-t p-4 text-center text-sm">
-          確定待ちです
         </div>
       )}
 

--- a/talentify-next-frontend/app/talent/offers/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/page.tsx
@@ -12,7 +12,7 @@ import { format, isBefore, parseISO, addDays } from 'date-fns'
 
 type Offer = {
   id: string
-  date: string
+  visit_date: string
   message: string
   status: string | null
   respond_deadline: string | null
@@ -36,7 +36,7 @@ export default function TalentOffersPage() {
 
       const { data, error } = await supabase
         .from('offers' as any)
-        .select('id, date, message, status, respond_deadline, paid, paid_at')
+        .select('id, visit_date, message, status, respond_deadline, paid, paid_at')
         .eq('talent_id', user.id) // ログイン中タレント宛のみに限定
 
       if (error) {
@@ -68,7 +68,7 @@ export default function TalentOffersPage() {
           {offers.map(offer => {
             const deadline =
               offer.respond_deadline ||
-              format(addDays(parseISO(offer.date), 3), 'yyyy-MM-dd')
+              format(addDays(parseISO(offer.visit_date), 3), 'yyyy-MM-dd')
             const isExpired = isBefore(parseISO(deadline), new Date())
             const statusInfo = statusMap[offer.status ?? 'pending']
 

--- a/talentify-next-frontend/app/talent/schedule/page.tsx
+++ b/talentify-next-frontend/app/talent/schedule/page.tsx
@@ -49,7 +49,7 @@ export default function SchedulePage() {
               className='flex justify-between items-center border rounded px-4 py-2'
             >
               <div>
-                <p className='font-medium'>{item.fixed_date}</p>
+                <p className='font-medium'>{item.visit_date}</p>
                 {item.store_name && (
                   <p className='text-xs text-gray-500'>店舗: {item.store_name}</p>
                 )}

--- a/talentify-next-frontend/app/talents/[id]/TalentDetailPageClient.tsx
+++ b/talentify-next-frontend/app/talents/[id]/TalentDetailPageClient.tsx
@@ -48,9 +48,7 @@ export default function TalentDetailPageClient({ id, initialTalent }: Props) {
   const [userId, setUserId] = useState<string | null>(null)
   const { role, loading: roleLoading } = useUserRole()
   const [showForm, setShowForm] = useState(false)
-  const [visitDate1, setVisitDate1] = useState('')
-  const [visitDate2, setVisitDate2] = useState('')
-  const [visitDate3, setVisitDate3] = useState('')
+  const [visitDate, setVisitDate] = useState('')
   const [timeRange, setTimeRange] = useState('')
   const [note, setNote] = useState('')
   const [isAgreed, setIsAgreed] = useState(false)
@@ -104,15 +102,13 @@ export default function TalentDetailPageClient({ id, initialTalent }: Props) {
       return
     }
 
-    const message = `第1希望:${visitDate1}\n第2希望:${visitDate2}\n第3希望:${visitDate3}\n希望時間帯:${timeRange}\n備考:${note}`
+    const message = `来店希望日:${visitDate}\n希望時間帯:${timeRange}\n備考:${note}`
     const payload = {
       user_id: user.id,
       store_id: store.id,
       talent_id: id,
       message,
-      date: visitDate1,
-      second_date: visitDate2 || null,
-      third_date: visitDate3 || null,
+      visit_date: visitDate,
       time_range: timeRange || null,
       notes: note || null,
       agreed: isAgreed,
@@ -284,16 +280,8 @@ export default function TalentDetailPageClient({ id, initialTalent }: Props) {
                 {showForm && (
                   <form onSubmit={handleSubmit} className="space-y-4 border p-4 rounded">
                     <div>
-                      <label className="block text-sm font-medium mb-1">来店希望日(第1希望)</label>
-                      <Input type="date" value={visitDate1} onChange={e => setVisitDate1(e.target.value)} required />
-                    </div>
-                    <div>
-                      <label className="block text-sm font-medium mb-1">来店希望日(第2希望)</label>
-                      <Input type="date" value={visitDate2} onChange={e => setVisitDate2(e.target.value)} />
-                    </div>
-                    <div>
-                      <label className="block text-sm font-medium mb-1">来店希望日(第3希望)</label>
-                      <Input type="date" value={visitDate3} onChange={e => setVisitDate3(e.target.value)} />
+                      <label className="block text-sm font-medium mb-1">来店希望日</label>
+                      <Input type="date" value={visitDate} onChange={e => setVisitDate(e.target.value)} required />
                     </div>
                     <div>
                       <label className="block text-sm font-medium mb-1">希望時間帯</label>

--- a/talentify-next-frontend/app/talents/[id]/offer/page.tsx
+++ b/talentify-next-frontend/app/talents/[id]/offer/page.tsx
@@ -14,7 +14,7 @@ export default function OfferPage() {
   const { id } = useParams()
   const talentId = Array.isArray(id) ? id[0] : id
   const [message, setMessage] = useState('')
-  const [date, setDate] = useState('')
+  const [visitDate, setVisitDate] = useState('')
   const [submitted, setSubmitted] = useState(false)
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -44,7 +44,7 @@ export default function OfferPage() {
         store_id: store.id,
         talent_id: talentId,
         message: message,
-        date: date,
+        visit_date: visitDate,
         status: 'pending', // "offer_created" is not allowed
       },
     ])
@@ -75,8 +75,8 @@ export default function OfferPage() {
           <label className="block text-sm font-medium mb-1">希望日</label>
           <Input
             type="date"
-            value={date}
-            onChange={e => setDate(e.target.value)}
+            value={visitDate}
+            onChange={e => setVisitDate(e.target.value)}
           />
         </div>
         <div>

--- a/talentify-next-frontend/components/modals/OfferModal.tsx
+++ b/talentify-next-frontend/components/modals/OfferModal.tsx
@@ -31,14 +31,14 @@ const TEMPLATE_KEY = 'offer_templates'
 export default function OfferModal({ open, onOpenChange, initialDate }: OfferModalProps) {
   const supabase = createClient()
   const [talents, setTalents] = useState<{ id: string; stage_name: string | null }[]>([])
-  const [date, setDate] = useState('')
+  const [visitDate, setVisitDate] = useState('')
   const [talentId, setTalentId] = useState('')
   const [message, setMessage] = useState('')
   const [templates, setTemplates] = useState<Template[]>([])
 
   useEffect(() => {
     if (open) {
-      if (initialDate) setDate(formatDate(initialDate))
+      if (initialDate) setVisitDate(formatDate(initialDate))
       loadTalents()
       loadTemplates()
     }
@@ -102,7 +102,7 @@ export default function OfferModal({ open, onOpenChange, initialDate }: OfferMod
         store_id: store.id,
         talent_id: talentId,
         message,
-        date,
+        visit_date: visitDate,
         status: 'pending', // "offer_created" is not a valid status_type. Use pending.
       },
     ])
@@ -121,8 +121,8 @@ export default function OfferModal({ open, onOpenChange, initialDate }: OfferMod
         </ModalHeader>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className="block text-sm font-medium mb-1">日付</label>
-            <Input type="date" value={date} onChange={e => setDate(e.target.value)} />
+            <label className="block text-sm font-medium mb-1">来店日</label>
+            <Input type="date" value={visitDate} onChange={e => setVisitDate(e.target.value)} />
           </div>
           <div>
             <label className="block text-sm font-medium mb-1">演者</label>

--- a/talentify-next-frontend/lib/contracts.ts
+++ b/talentify-next-frontend/lib/contracts.ts
@@ -24,7 +24,7 @@ export async function getContractsForStore(): Promise<StoreContract[]> {
 
   const { data: offers } = await supabase
     .from('offers')
-    .select('id, talent_id, date, contract_url')
+    .select('id, talent_id, visit_date, contract_url')
     .eq('store_id', store.id)
 
   if (!offers) return []
@@ -49,7 +49,7 @@ export async function getContractsForStore(): Promise<StoreContract[]> {
     results.push({
       offer_id: offer.id,
       talent_name: talent?.stage_name || '',
-      performance_date: offer.date,
+      performance_date: offer.visit_date,
       amount: payment?.amount ?? null,
       pdf_url: url,
     })

--- a/talentify-next-frontend/supabase-docs/enums.md
+++ b/talentify-next-frontend/supabase-docs/enums.md
@@ -58,7 +58,6 @@
 - pending
 - accepted
 - rejected
-- confirmed
 
 ### auth.one_time_token_type
 - confirmation_token

--- a/talentify-next-frontend/supabase-docs/functions.sql
+++ b/talentify-next-frontend/supabase-docs/functions.sql
@@ -20,7 +20,7 @@ BEGIN
       'offer_id', NEW.id,
       'store_id', NEW.store_id,
       'event_name', NEW.event_name,
-      'date', NEW.date
+      'visit_date', NEW.visit_date
     ),
     false,
     now()

--- a/talentify-next-frontend/supabase-docs/schema.md
+++ b/talentify-next-frontend/supabase-docs/schema.md
@@ -63,7 +63,7 @@
 - id: uuid, NOT NULL, DEFAULT gen_random_uuid()
 - talent_id: uuid
 - user_id: uuid
-- date: date, NOT NULL
+- visit_date: timestamp with time zone
 - message: text
 - created_at: timestamp with time zone, DEFAULT timezone('utc'::text, now())
 - status: USER-DEFINED
@@ -78,10 +78,7 @@
 - notes: text
 - store_id: uuid
 - agreed: boolean
-- second_date: date
-- third_date: date
 - time_range: text
-- fixed_date: date
 - paid: boolean, DEFAULT false
 - paid_at: timestamp with time zone
 - invoice_date: date

--- a/talentify-next-frontend/types/supabase.ts
+++ b/talentify-next-frontend/types/supabase.ts
@@ -391,11 +391,8 @@ export type Database = {
           store_id: string | null
           talent_id: string
           message: string
-          date: string
-          second_date: string | null
-          third_date: string | null
+          visit_date: string
           time_range: string | null
-          fixed_date: string | null
           contract_url: string | null
           notes: string | null
           agreed: boolean | null
@@ -416,11 +413,8 @@ export type Database = {
           store_id?: string | null
           talent_id: string
           message: string
-          date: string
-          second_date?: string | null
-          third_date?: string | null
+          visit_date: string
           time_range?: string | null
-          fixed_date?: string | null
           contract_url?: string | null
           notes?: string | null
           agreed?: boolean | null
@@ -441,11 +435,8 @@ export type Database = {
           store_id?: string | null
           talent_id?: string
           message?: string
-          date?: string
-          second_date?: string | null
-          third_date?: string | null
+          visit_date?: string
           time_range?: string | null
-          fixed_date?: string | null
           contract_url?: string | null
           notes?: string | null
           agreed?: boolean | null
@@ -480,7 +471,7 @@ export type Database = {
         | 'invoice_submitted'
         | 'payment_completed'
         | 'message'
-      offer_status: 'pending' | 'accepted' | 'rejected' | 'confirmed'
+      offer_status: 'pending' | 'accepted' | 'rejected'
       payment_status: 'pending' | 'paid' | 'cancelled'
       status_type: 'draft' | 'pending' | 'approved' | 'rejected' | 'completed'
       visit_status: 'scheduled' | 'confirmed' | 'visited'
@@ -610,7 +601,7 @@ export const Constants = {
         'payment_completed',
         'message'
       ],
-      offer_status: ['pending', 'accepted', 'rejected', 'confirmed'],
+      offer_status: ['pending', 'accepted', 'rejected'],
       payment_status: ['pending', 'paid', 'cancelled'],
       status_type: ['draft', 'pending', 'approved', 'rejected', 'completed'],
       visit_status: ['scheduled', 'confirmed', 'visited']

--- a/talentify-next-frontend/utils/getOffersForCompany.ts
+++ b/talentify-next-frontend/utils/getOffersForCompany.ts
@@ -7,7 +7,7 @@ export type CompanyOffer = {
   talent_name: string | null
   store_name: string | null
   status: string | null
-  fixed_date: string | null
+  visit_date: string | null
   reward: number | null
   invoice_amount: number | null
   invoice_date: string | null
@@ -23,7 +23,7 @@ export async function getOffersForCompany(): Promise<CompanyOffer[]> {
   const { data, error } = await supabase
     .from('offers')
     .select(
-      'id, status, fixed_date, reward, invoice_amount, invoice_date, agreed, invoice_submitted, paid, paid_at, talents(stage_name), stores(store_name)'
+      'id, status, visit_date, reward, invoice_amount, invoice_date, agreed, invoice_submitted, paid, paid_at, talents(stage_name), stores(store_name)'
     )
     .order('created_at', { ascending: false })
 
@@ -35,7 +35,7 @@ export async function getOffersForCompany(): Promise<CompanyOffer[]> {
   return (data || []).map((o: any) => ({
     id: o.id,
     status: o.status,
-    fixed_date: o.fixed_date,
+    visit_date: o.visit_date,
     reward: o.reward,
     invoice_amount: o.invoice_amount,
     invoice_date: o.invoice_date,

--- a/talentify-next-frontend/utils/getOffersForStore.ts
+++ b/talentify-next-frontend/utils/getOffersForStore.ts
@@ -12,7 +12,6 @@ export type Offer = {
   message: string
   created_at: string | null
   status: string | null
-  fixed_date?: string | null
   paid?: boolean | null
   paid_at?: string | null
 }

--- a/talentify-next-frontend/utils/getReviewsForTalent.ts
+++ b/talentify-next-frontend/utils/getReviewsForTalent.ts
@@ -19,7 +19,7 @@ export async function getReviewsForTalent() {
 
   const { data, error } = await supabase
     .from('reviews' as any)
-    .select('id, rating, category_ratings, comment, created_at, store:store_id(store_name), offers(date)')
+    .select('id, rating, category_ratings, comment, created_at, store:store_id(store_name), offers(visit_date)')
     .eq('talent_id', user.id)
     .order('created_at', { ascending: false })
 
@@ -31,7 +31,7 @@ export async function getReviewsForTalent() {
   return (data || []).map((r: any) => ({
     id: r.id as string,
     store_name: r.store?.store_name ?? null,
-    visit_date: r.offers?.date ?? null,
+    visit_date: r.offers?.visit_date ?? null,
     rating: r.rating as number,
     category_ratings: r.category_ratings,
     comment: r.comment,

--- a/talentify-next-frontend/utils/getTalentSchedule.ts
+++ b/talentify-next-frontend/utils/getTalentSchedule.ts
@@ -1,7 +1,7 @@
 export type TalentSchedule = {
   id: string
   store_name: string | null
-  fixed_date: string
+  visit_date: string
   time_range: string | null
 }
 
@@ -20,11 +20,10 @@ export async function getTalentSchedule(): Promise<TalentSchedule[]> {
 
   const { data, error } = await supabase
     .from('offers')
-    .select('id, fixed_date, time_range, stores(store_name)')
+    .select('id, visit_date, time_range, stores(store_name)')
     .eq('talent_id', user.id)
-    .eq('status', 'confirmed')
-    .not('fixed_date', 'is', null)
-    .order('fixed_date', { ascending: true })
+    .eq('status', 'accepted')
+    .order('visit_date', { ascending: true })
 
   if (error) {
     console.error('failed to fetch schedules', error)
@@ -35,7 +34,7 @@ export async function getTalentSchedule(): Promise<TalentSchedule[]> {
     data ?? []
   ).map((o: any) => ({
     id: o.id,
-    fixed_date: o.fixed_date,
+    visit_date: o.visit_date,
     time_range: o.time_range,
     store_name: o.stores?.store_name ?? null,
   }))

--- a/talentify-next-frontend/utils/getVisitedOffersForStore.ts
+++ b/talentify-next-frontend/utils/getVisitedOffersForStore.ts
@@ -6,7 +6,7 @@ export type VisitedOffer = {
   id: string
   talent_id: string
   store_id: string
-  date: string
+  visit_date: string
   message: string
   reviewed: boolean
   talent_name: string | null
@@ -27,7 +27,7 @@ export async function getVisitedOffersForStore() {
 
   const { data, error } = await supabase
     .from('offers')
-    .select('id, talent_id, store_id, date, message, reviews(id), talents(stage_name)')
+    .select('id, talent_id, store_id, visit_date, message, reviews(id), talents(stage_name)')
     .eq('store_id', store.id)
     .eq('status', 'visited')
   if (error) {
@@ -38,7 +38,7 @@ export async function getVisitedOffersForStore() {
     id: o.id,
     talent_id: o.talent_id,
     store_id: o.store_id,
-    date: o.date,
+    visit_date: o.visit_date,
     message: o.message,
     reviewed: !!(o as any).reviews?.length,
     talent_name: (o as any).talents?.stage_name || null,


### PR DESCRIPTION
## Summary
- simplify offer creation and scheduling to use a single `visit_date`
- update offer detail and schedule views to show accepted visit dates
- refresh Supabase types and docs for the new `visit_date` column and slimmer status enum

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890413559f8833298b9e91b17a44ec0