### PR TITLE
docs: sync supabase schema with production

### DIFF
--- a/talentify-next-frontend/supabase-docs/enums.md
+++ b/talentify-next-frontend/supabase-docs/enums.md
@@ -53,11 +53,14 @@
 - review_received
 - message
 - offer
+- offer_accepted
+- schedule_fixed
 
 ### public.offer_status
 - pending
 - accepted
 - rejected
+- confirmed
 
 ### auth.one_time_token_type
 - confirmation_token

--- a/talentify-next-frontend/supabase-docs/schema.md
+++ b/talentify-next-frontend/supabase-docs/schema.md
@@ -66,7 +66,7 @@
 - date: timestamp with time zone
 - message: text
 - created_at: timestamp with time zone, DEFAULT timezone('utc'::text, now())
-- status: USER-DEFINED
+- status: USER-DEFINED, DEFAULT 'pending'
 - respond_deadline: timestamp with time zone
 - is_read_by_talent: boolean, DEFAULT false
 - updated_at: timestamp with time zone, DEFAULT now()
@@ -90,7 +90,7 @@
 - invoice_submitted: boolean, DEFAULT false
 - contract_url: text
 
-`date` は `timestamp with time zone` 型で、`YYYY-MM-DD` もしくは ISO 8601 形式で送信する必要があります。`status` では `draft` / `pending` / `approved` / `rejected` / `completed` の値を使用でき、オファー作成時のデフォルトは `pending` です。
+`date` は `timestamp with time zone` 型で、`YYYY-MM-DD` もしくは ISO 8601 形式で送信する必要があります。`status` では `draft` / `pending` / `approved` / `rejected` / `completed` / `offer_created` / `confirmed` の値を使用でき、オファー作成時のデフォルトは `pending` です。
 
 ### payments
 - id: uuid, NOT NULL, DEFAULT gen_random_uuid()
@@ -195,7 +195,8 @@
 - height_cm: integer
 - agency_name: text
 - social_tiktok: text
-- gender: USER-DEFINED
+- gender: USER-DEFINED, DEFAULT 'other'
+- bio_others: text
 
 ### visits
 - id: uuid, NOT NULL, DEFAULT gen_random_uuid()


### PR DESCRIPTION
## Summary
- document default offer status and extended status values
- document talent gender default and bio_others field
- update enums for notifications and offer status

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68916211f2308332bb53eeaa8aaa5f4d