### PR TITLE
fix: allow talents to accept offers

### DIFF
--- a/supabase/sql/offer_rls_fix.sql
+++ b/supabase/sql/offer_rls_fix.sql
@@ -1,0 +1,19 @@
+-- Allow talents to update their own offers
+-- This policy permits a talent to modify offers where they are the talent.
+-- It should be executed on the Supabase project.
+
+-- Ensure enum offer_status includes 'accepted'
+-- (if not already present)
+--   ALTER TYPE offer_status ADD VALUE IF NOT EXISTS 'accepted';
+
+-- Allow talents to update offers
+create policy "Talents can update their offers"
+  on public.offers for update
+  using ( auth.uid() = talent_id )
+  with check ( auth.uid() = talent_id );
+
+-- Optionally ensure stores retain update rights
+create policy if not exists "Stores can update their offers"
+  on public.offers for update
+  using ( auth.uid() = store_id )
+  with check ( auth.uid() = store_id );


### PR DESCRIPTION
## Summary
- add SQL policy so talents can update their own offers
- document enum adjustment for `offer_status`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68916c9dc6108332a23bb78b48f2ab22