### PR TITLE
feat: use confirmed offer status

### DIFF
--- a/docs/dashboard-sections.md
+++ b/docs/dashboard-sections.md
@@ -13,7 +13,7 @@ This document lists the planned dashboard sections for each role and notes which
 Sections displayed:
 
 1. **Offer Stats** – summary of offers received recently.
-2. **Next Event** – upcoming accepted schedule.
+2. **Next Event** – upcoming confirmed schedule.
 3. **Unread Messages** – badge showing unread message count.
 
 These can all be presented using `DashboardCard` with specific content.

--- a/talentify-next-frontend/app/company/offers/page.tsx
+++ b/talentify-next-frontend/app/company/offers/page.tsx
@@ -70,7 +70,7 @@ export default function CompanyOffersPage() {
 
   const statusLabels: Record<string, string> = {
     pending: '保留中',
-    accepted: '承諾済み',
+    confirmed: '承諾済み',
     rejected: '拒否',
     expired: '期限切れ',
   }
@@ -84,7 +84,7 @@ export default function CompanyOffersPage() {
           <select value={status} onChange={e=>setStatus(e.target.value)} className='border rounded p-1'>
             <option value='all'>すべて</option>
             <option value='pending'>保留中</option>
-            <option value='accepted'>承諾済み</option>
+            <option value='confirmed'>承諾済み</option>
             <option value='rejected'>拒否</option>
             <option value='expired'>期限切れ</option>
           </select>

--- a/talentify-next-frontend/app/store/dashboard/page.tsx
+++ b/talentify-next-frontend/app/store/dashboard/page.tsx
@@ -14,7 +14,7 @@ import { useEffect, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
 
 export default function StoreDashboard() {
-  const offerStats = { pending: 1, accepted: 2 }
+  const offerStats = { pending: 1, confirmed: 2 }
   const schedule: ScheduleItem[] = [
     { date: '7/22', performer: 'タレントA', status: 'confirmed', href: '#' },
   ]
@@ -23,7 +23,7 @@ export default function StoreDashboard() {
   const [toast, setToast] = useState<string | null>(null)
   const searchParams = useSearchParams()
 
-  const hasData = offerStats.pending + offerStats.accepted > 0
+  const hasData = offerStats.pending + offerStats.confirmed > 0
 
   useEffect(() => {
     setTimeout(() => setLoading(false), 500)
@@ -70,7 +70,7 @@ export default function StoreDashboard() {
             </CardFooter>
           </Card>
           <ScheduleCard items={schedule} />
-          <OfferSummaryCard pending={offerStats.pending} accepted={offerStats.accepted} link='/store/offers' />
+          <OfferSummaryCard pending={offerStats.pending} confirmed={offerStats.confirmed} link='/store/offers' />
           <div className='sm:col-span-2'>
             <MessageAlertCard count={unread} link='/store/messages' />
           </div>

--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -179,7 +179,7 @@ export default function StoreOfferDetailPage() {
       ) : (
         <div className='text-sm'>まだ請求書が提出されていません</div>
       )}
-      {offer.status === 'accepted' && (
+      {offer.status === 'confirmed' && (
         <div className='space-y-2'>
           <input type='file' accept='application/pdf,image/*' onChange={e => setFile(e.target.files?.[0] || null)} />
           <Button onClick={uploadContract} disabled={!file}>アップロード</Button>

--- a/talentify-next-frontend/app/store/offers/page.tsx
+++ b/talentify-next-frontend/app/store/offers/page.tsx
@@ -19,7 +19,7 @@ import {
 
 const statusLabels: Record<string, string> = {
   pending: '保留中',
-  accepted: '承諾済み',
+  confirmed: '承諾済み',
   rejected: '拒否',
   expired: '期限切れ',
 }
@@ -49,7 +49,7 @@ export default function StoreOffersPage() {
 
   const groups: Record<string, Offer[]> = {
     pending: [],
-    accepted: [],
+    confirmed: [],
     rejected: [],
     expired: [],
   }
@@ -70,7 +70,7 @@ export default function StoreOffersPage() {
         >
           <option value="all">すべて</option>
           <option value="pending">保留中</option>
-          <option value="accepted">承諾済み</option>
+          <option value="confirmed">承諾済み</option>
           <option value="rejected">拒否</option>
           <option value="expired">期限切れ</option>
         </select>
@@ -88,7 +88,7 @@ export default function StoreOffersPage() {
       ) : offers.length === 0 ? (
         <EmptyState title='まだオファーがありません' actionHref='/talent-search' actionLabel='オファーを送ってみましょう' />
       ) : (
-        (['pending', 'accepted', 'rejected', 'expired'] as const).map(status => (
+        (['pending', 'confirmed', 'rejected', 'expired'] as const).map(status => (
           groups[status].length > 0 && (
             <div key={status} className="space-y-2">
               <h2 className="font-semibold">{statusLabels[status]}</h2>

--- a/talentify-next-frontend/app/store/schedule/page.tsx
+++ b/talentify-next-frontend/app/store/schedule/page.tsx
@@ -51,7 +51,7 @@ export default function StoreSchedulePage() {
         .from('offers')
         .select('id, talent_id, date, status, talents(stage_name)')
         .eq('user_id', user.id)
-        .eq('status', 'accepted')
+        .eq('status', 'confirmed')
 
       if (error) {
         console.error('Failed to fetch offers', error)

--- a/talentify-next-frontend/app/talent/dashboard/page.tsx
+++ b/talentify-next-frontend/app/talent/dashboard/page.tsx
@@ -51,7 +51,7 @@ export default function TalentDashboard() {
       ) : (
         <>
           <ScheduleCard items={schedule} />
-          <OfferSummaryCard pending={pending} accepted={schedule.length} link='/talent/offers' />
+          <OfferSummaryCard pending={pending} confirmed={schedule.length} link='/talent/offers' />
           <MessageAlertCard count={unread} link='/messages' />
           <NotificationListCard className='sm:col-span-2 lg:col-span-3' />
           <div className='sm:col-span-2 lg:col-span-3'>

--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -58,7 +58,7 @@ export default function TalentOfferDetailPage() {
   const [bankAccountNumber, setBankAccountNumber] = useState('')
   const [bankAccountHolder, setBankAccountHolder] = useState('')
 
-  const handleStatusChange = async (status: 'accepted' | 'rejected') => {
+  const handleStatusChange = async (status: 'confirmed' | 'rejected') => {
     if (!offer) return
     const res = await fetch(`/api/offers/${offer.id}`, {
       method: 'PUT',
@@ -67,7 +67,7 @@ export default function TalentOfferDetailPage() {
     })
     if (res.ok) {
       setOffer({ ...offer, status })
-      if (status === 'accepted' && offer.user_id) {
+      if (status === 'confirmed' && offer.user_id) {
         await addNotification({
           user_id: offer.user_id,
           offer_id: offer.id,
@@ -75,7 +75,7 @@ export default function TalentOfferDetailPage() {
           title: 'オファーが承諾されました'
         })
       }
-      setToast(status === 'accepted' ? 'オファーを承諾しました' : 'オファーを辞退しました')
+      setToast(status === 'confirmed' ? 'オファーを承諾しました' : 'オファーを辞退しました')
       setTimeout(() => setToast(null), 3000)
     } else {
       setToast('処理に失敗しました。もう一度お試しください')
@@ -199,7 +199,7 @@ export default function TalentOfferDetailPage() {
 
   const statusMap: Record<string, { label: string; className?: string }> = {
     pending: { label: '対応待ち', className: 'bg-yellow-500 text-white' },
-    accepted: { label: '承諾済', className: 'bg-green-600 text-white' },
+    confirmed: { label: '承諾済', className: 'bg-green-600 text-white' },
     rejected: { label: '辞退済み', className: 'bg-gray-400 text-white' },
   }
 
@@ -253,7 +253,7 @@ export default function TalentOfferDetailPage() {
             <div className='text-green-600 text-sm'>✅ お支払いが完了しました（{format(parseISO(offer.paid_at || ''), 'yyyy年M月d日', { locale: ja })}）</div>
           )}
         </>
-      ) : offer.status === 'accepted' && offer.agreed ? (
+      ) : offer.status === 'confirmed' && offer.agreed ? (
         <Card>
           <CardHeader>
             <CardTitle>請求書作成</CardTitle>
@@ -361,7 +361,7 @@ export default function TalentOfferDetailPage() {
           >
             見送る
           </Button>
-          <Button onClick={() => handleStatusChange('accepted')}>承諾する</Button>
+          <Button onClick={() => handleStatusChange('confirmed')}>承諾する</Button>
         </div>
       )}
 

--- a/talentify-next-frontend/app/talent/offers/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/page.tsx
@@ -64,7 +64,7 @@ export default function TalentOffersPage() {
 
   const statusMap: Record<string, { label: string; className?: string }> = {
     pending: { label: '対応待ち', className: 'bg-yellow-500 text-white' },
-    accepted: { label: '承諾済み', className: 'bg-gray-400 text-white' },
+    confirmed: { label: '承諾済み', className: 'bg-gray-400 text-white' },
     rejected: { label: '辞退済み', className: 'bg-gray-400 text-white' },
   }
 

--- a/talentify-next-frontend/components/OfferSummaryCard.tsx
+++ b/talentify-next-frontend/components/OfferSummaryCard.tsx
@@ -6,14 +6,14 @@ import { Badge } from './ui/badge'
 interface OfferSummaryCardProps {
   title?: string
   pending: number
-  accepted: number
+  confirmed: number
   link?: string
 }
 
 export default function OfferSummaryCard({
   title = '進行中のオファー',
   pending,
-  accepted,
+  confirmed,
   link,
 }: OfferSummaryCardProps) {
   return (
@@ -27,7 +27,7 @@ export default function OfferSummaryCard({
           保留中: <Badge variant="secondary">{pending}</Badge>
         </div>
         <div>
-          承認済み: <Badge>{accepted}</Badge>
+          承認済み: <Badge>{confirmed}</Badge>
         </div>
       </div>
     </DashboardCard>

--- a/talentify-next-frontend/supabase-docs/enums.md
+++ b/talentify-next-frontend/supabase-docs/enums.md
@@ -58,9 +58,8 @@
 
 ### public.offer_status
 - pending
-- accepted
-- rejected
 - confirmed
+- rejected
 
 ### auth.one_time_token_type
 - confirmation_token

--- a/talentify-next-frontend/types/supabase.ts
+++ b/talentify-next-frontend/types/supabase.ts
@@ -471,7 +471,7 @@ export type Database = {
         | 'invoice_submitted'
         | 'payment_completed'
         | 'message'
-      offer_status: 'pending' | 'accepted' | 'rejected'
+      offer_status: 'pending' | 'confirmed' | 'rejected'
       payment_status: 'pending' | 'paid' | 'cancelled'
       status_type: 'draft' | 'pending' | 'approved' | 'rejected' | 'completed'
       visit_status: 'scheduled' | 'confirmed' | 'visited'
@@ -601,7 +601,7 @@ export const Constants = {
         'payment_completed',
         'message'
       ],
-      offer_status: ['pending', 'accepted', 'rejected'],
+      offer_status: ['pending', 'confirmed', 'rejected'],
       payment_status: ['pending', 'paid', 'cancelled'],
       status_type: ['draft', 'pending', 'approved', 'rejected', 'completed'],
       visit_status: ['scheduled', 'confirmed', 'visited']

--- a/talentify-next-frontend/utils/getTalentSchedule.ts
+++ b/talentify-next-frontend/utils/getTalentSchedule.ts
@@ -22,7 +22,7 @@ export async function getTalentSchedule(): Promise<TalentSchedule[]> {
     .from('offers')
     .select('id, date, time_range, stores(store_name)')
     .eq('talent_id', user.id)
-    .eq('status', 'accepted')
+    .eq('status', 'confirmed')
     .order('date', { ascending: true })
 
   if (error) {


### PR DESCRIPTION
## Summary
- send `confirmed` instead of `accepted` when talent approves an offer
- align Supabase `offer_status` types with `confirmed`
- update related queries and UI to check for `confirmed`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891833e33ec8332b8b10a2bfd6bf93a