### PR TITLE
feat: expand offer detail with visit and invoice features

### DIFF
--- a/talentify-next-frontend/app/api/offers/[id]/route.ts
+++ b/talentify-next-frontend/app/api/offers/[id]/route.ts
@@ -41,6 +41,7 @@ export async function PUT(
         'bank_account_number',
         'bank_account_holder',
         'invoice_submitted',
+        'invoice_url',
       ]
     } else {
       return NextResponse.json<{ error: string }>({ error: '権限がありません' }, { status: 403 })

--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -133,14 +133,6 @@ export default function StoreOfferDetailPage() {
     })
     if (res.ok) {
       setOffer({ ...offer, status: 'completed' })
-      if (offer.talent_id) {
-        await addNotification({
-          user_id: offer.talent_id,
-          offer_id: offer.id,
-          type: 'visit_completed',
-          title: '来店が完了しました',
-        })
-      }
       setToast('来店完了として登録しました')
     } else {
       setToast('更新に失敗しました')

--- a/talentify-next-frontend/app/store/schedule/page.tsx
+++ b/talentify-next-frontend/app/store/schedule/page.tsx
@@ -82,7 +82,7 @@ export default function StoreSchedulePage() {
   }
 
   const handleSelectEvent = (event: OfferEvent) => {
-    router.push(`/talents/${event.talentId}`)
+    router.push(`/store/offers/${event.offerId}`)
   }
 
   const handleSelectSlot = ({ start, end }: { start: Date; end: Date }) => {

--- a/talentify-next-frontend/components/modals/ReviewModal.tsx
+++ b/talentify-next-frontend/components/modals/ReviewModal.tsx
@@ -14,6 +14,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { Button } from '@/components/ui/button'
 import { createClient } from '@/utils/supabase/client'
 import StarRatingInput from '@/components/StarRatingInput'
+import { addNotification } from '@/utils/notifications'
 
 export default function ReviewModal({
   offerId,
@@ -55,6 +56,14 @@ export default function ReviewModal({
       } as any)
     setSubmitting(false)
     if (!error) {
+      if (talentId) {
+        await addNotification({
+          user_id: talentId,
+          offer_id: offerId,
+          type: 'review_received',
+          title: 'レビューが投稿されました',
+        })
+      }
       setOpen(false)
       onSubmitted?.()
     } else {

--- a/talentify-next-frontend/supabase-docs/enums.md
+++ b/talentify-next-frontend/supabase-docs/enums.md
@@ -46,15 +46,18 @@
 - rejected
 
 ### public.notification_type
+- offer
 - offer_created
 - offer_updated
-- payment_created
-- invoice_submitted
-- review_received
-- message
-- offer
 - offer_accepted
 - schedule_fixed
+- contract_uploaded
+- contract_checked
+- payment_created
+- invoice_submitted
+- payment_completed
+- review_received
+- message
 
 ### public.offer_status
 - pending

--- a/talentify-next-frontend/types/supabase.ts
+++ b/talentify-next-frontend/types/supabase.ts
@@ -337,15 +337,19 @@ export type Database = {
           id: string
           user_id: string
           offer_id: string | null
-          type:
-            | 'offer'
-            | 'offer_accepted'
-            | 'schedule_fixed'
-            | 'contract_uploaded'
-            | 'contract_checked'
-            | 'invoice_submitted'
-            | 'payment_completed'
-            | 'message'
+            type:
+              | 'offer'
+              | 'offer_created'
+              | 'offer_updated'
+              | 'offer_accepted'
+              | 'schedule_fixed'
+              | 'contract_uploaded'
+              | 'contract_checked'
+              | 'payment_created'
+              | 'invoice_submitted'
+              | 'payment_completed'
+              | 'review_received'
+              | 'message'
           title: string
           body: string | null
           is_read: boolean
@@ -356,15 +360,19 @@ export type Database = {
           id?: string
           user_id: string
           offer_id?: string | null
-          type:
-            | 'offer'
-            | 'offer_accepted'
-            | 'schedule_fixed'
-            | 'contract_uploaded'
-            | 'contract_checked'
-            | 'invoice_submitted'
-            | 'payment_completed'
-            | 'message'
+            type:
+              | 'offer'
+              | 'offer_created'
+              | 'offer_updated'
+              | 'offer_accepted'
+              | 'schedule_fixed'
+              | 'contract_uploaded'
+              | 'contract_checked'
+              | 'payment_created'
+              | 'invoice_submitted'
+              | 'payment_completed'
+              | 'review_received'
+              | 'message'
           title: string
           body?: string | null
           is_read?: boolean
@@ -464,12 +472,16 @@ export type Database = {
       invoice_status: 'draft' | 'submitted' | 'approved' | 'rejected'
       notification_type:
         | 'offer'
+        | 'offer_created'
+        | 'offer_updated'
         | 'offer_accepted'
         | 'schedule_fixed'
         | 'contract_uploaded'
         | 'contract_checked'
+        | 'payment_created'
         | 'invoice_submitted'
         | 'payment_completed'
+        | 'review_received'
         | 'message'
       offer_status: 'pending' | 'confirmed' | 'rejected'
       payment_status: 'pending' | 'paid' | 'cancelled'
@@ -593,12 +605,16 @@ export const Constants = {
       invoice_status: ['draft', 'submitted', 'approved', 'rejected'],
       notification_type: [
         'offer',
+        'offer_created',
+        'offer_updated',
         'offer_accepted',
         'schedule_fixed',
         'contract_uploaded',
         'contract_checked',
+        'payment_created',
         'invoice_submitted',
         'payment_completed',
+        'review_received',
         'message'
       ],
       offer_status: ['pending', 'confirmed', 'rejected'],


### PR DESCRIPTION
## Summary
- allow stores to mark visits complete and leave reviews
- support invoice upload or creation for talents
- unify schedule links to offer detail page and permit invoice URL updates

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892fa4241808332a0a42a32eec6ed7f