### PR TITLE
feat: add invoice url support

### DIFF
--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -170,7 +170,7 @@ export default function TalentOfferDetailPage() {
     const res = await fetch(`/api/offers/${offer.id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ invoice_url: url, invoice_submitted: true }) // TODO: add invoice_url column in Supabase
+      body: JSON.stringify({ invoice_url: url, invoice_submitted: true })
     })
     if (res.ok) {
       setOffer({ ...offer, invoice_url: url, invoice_submitted: true })

--- a/talentify-next-frontend/supabase-docs/schema.md
+++ b/talentify-next-frontend/supabase-docs/schema.md
@@ -88,6 +88,7 @@
 - bank_account_number: text
 - bank_account_holder: text
 - invoice_submitted: boolean, DEFAULT false
+- invoice_url: text
 - contract_url: text
 
 `date` は `timestamp with time zone` 型で、`YYYY-MM-DD` もしくは ISO 8601 形式で送信する必要があります。`status` では `draft` / `pending` / `approved` / `rejected` / `completed` / `offer_created` / `confirmed` の値を使用でき、オファー作成時のデフォルトは `pending` です。

--- a/talentify-next-frontend/types/supabase.ts
+++ b/talentify-next-frontend/types/supabase.ts
@@ -395,16 +395,26 @@ export type Database = {
       offers: {
         Row: {
           id: string
-          user_id: string
-          store_id: string | null
           talent_id: string
-          message: string
+          user_id: string
           date: string
-          time_range: string | null
-          contract_url: string | null
-          notes: string | null
-          agreed: boolean | null
+          message: string
+          created_at: string | null
+          status: string | null
+          respond_deadline: string | null
+          is_read_by_talent: boolean | null
+          updated_at: string | null
+          event_name: string | null
+          start_time: string | null
+          end_time: string | null
           reward: number | null
+          question_allowed: boolean | null
+          notes: string | null
+          store_id: string | null
+          agreed: boolean | null
+          time_range: string | null
+          paid: boolean | null
+          paid_at: string | null
           invoice_date: string | null
           invoice_amount: number | null
           bank_name: string | null
@@ -412,21 +422,31 @@ export type Database = {
           bank_account_number: string | null
           bank_account_holder: string | null
           invoice_submitted: boolean | null
-          created_at: string | null
-          status: string | null
+          invoice_url: string | null
+          contract_url: string | null
         }
         Insert: {
           id?: string
-          user_id: string
-          store_id?: string | null
           talent_id: string
-          message: string
+          user_id: string
           date: string
-          time_range?: string | null
-          contract_url?: string | null
-          notes?: string | null
-          agreed?: boolean | null
+          message: string
+          created_at?: string | null
+          status?: string | null
+          respond_deadline?: string | null
+          is_read_by_talent?: boolean | null
+          updated_at?: string | null
+          event_name?: string | null
+          start_time?: string | null
+          end_time?: string | null
           reward?: number | null
+          question_allowed?: boolean | null
+          notes?: string | null
+          store_id?: string | null
+          agreed?: boolean | null
+          time_range?: string | null
+          paid?: boolean | null
+          paid_at?: string | null
           invoice_date?: string | null
           invoice_amount?: number | null
           bank_name?: string | null
@@ -434,21 +454,31 @@ export type Database = {
           bank_account_number?: string | null
           bank_account_holder?: string | null
           invoice_submitted?: boolean | null
-          created_at?: string | null
-          status?: string | null
+          invoice_url?: string | null
+          contract_url?: string | null
         }
         Update: {
           id?: string
-          user_id?: string
-          store_id?: string | null
           talent_id?: string
-          message?: string
+          user_id?: string
           date?: string
-          time_range?: string | null
-          contract_url?: string | null
-          notes?: string | null
-          agreed?: boolean | null
+          message?: string
+          created_at?: string | null
+          status?: string | null
+          respond_deadline?: string | null
+          is_read_by_talent?: boolean | null
+          updated_at?: string | null
+          event_name?: string | null
+          start_time?: string | null
+          end_time?: string | null
           reward?: number | null
+          question_allowed?: boolean | null
+          notes?: string | null
+          store_id?: string | null
+          agreed?: boolean | null
+          time_range?: string | null
+          paid?: boolean | null
+          paid_at?: string | null
           invoice_date?: string | null
           invoice_amount?: number | null
           bank_name?: string | null
@@ -456,8 +486,8 @@ export type Database = {
           bank_account_number?: string | null
           bank_account_holder?: string | null
           invoice_submitted?: boolean | null
-          created_at?: string | null
-          status?: string | null
+          invoice_url?: string | null
+          contract_url?: string | null
         }
         Relationships: []
       }


### PR DESCRIPTION
## Summary
- document `invoice_url` column in offers schema
- expand Supabase types for offers with `invoice_url` and related fields
- clean up talent offer invoice upload

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68930c865d2c8332b2b6f42332d1136f