### PR TITLE
feat: auto-complete offers on review

### DIFF
--- a/talentify-next-frontend/supabase-docs/functions.sql
+++ b/talentify-next-frontend/supabase-docs/functions.sql
@@ -73,3 +73,61 @@ BEGIN
   RETURN NEW;
 END;
 $function$;
+
+-- handle_review_insert
+CREATE OR REPLACE FUNCTION public.handle_review_insert()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+  UPDATE offers
+  SET status = 'completed'
+  WHERE id = NEW.offer_id;
+
+  RETURN NEW;
+END;
+$function$;
+
+-- notify_talent_on_review_created
+CREATE OR REPLACE FUNCTION public.notify_talent_on_review_created()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+  INSERT INTO notifications (
+    id,
+    user_id,
+    type,
+    data,
+    is_read,
+    created_at
+  )
+  VALUES (
+    gen_random_uuid(),
+    NEW.talent_id,
+    'review_received',
+    jsonb_build_object(
+      'review_id', NEW.id,
+      'offer_id', NEW.offer_id
+    ),
+    false,
+    now()
+  );
+
+  RETURN NEW;
+END;
+$function$;
+
+-- trigger to update offer status on review creation
+DROP TRIGGER IF EXISTS trigger_set_offer_completed_on_review ON reviews;
+CREATE TRIGGER trigger_set_offer_completed_on_review
+AFTER INSERT ON reviews
+FOR EACH ROW
+EXECUTE FUNCTION public.handle_review_insert();
+
+-- trigger to notify talent when review is created
+DROP TRIGGER IF EXISTS trigger_notify_talent_on_review_created ON reviews;
+CREATE TRIGGER trigger_notify_talent_on_review_created
+AFTER INSERT ON reviews
+FOR EACH ROW
+EXECUTE FUNCTION public.notify_talent_on_review_created();

--- a/talentify-next-frontend/supabase-docs/triggers.md
+++ b/talentify-next-frontend/supabase-docs/triggers.md
@@ -15,3 +15,5 @@
 | set_updated_at | talents | BEFORE | UPDATE | update_updated_at_column |
 | set_updated_at_talents | talents | BEFORE | UPDATE | update_updated_at_column |
 | set_updated_at_visits | visits | BEFORE | UPDATE | update_updated_at_column |
+| trigger_set_offer_completed_on_review | reviews | AFTER | INSERT | handle_review_insert |
+| trigger_notify_talent_on_review_created | reviews | AFTER | INSERT | notify_talent_on_review_created |


### PR DESCRIPTION
## Summary
- update offers.status to `completed` when a review is created
- notify talents via `review_received` when a review is inserted

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68995bb59cb08332ac41770228925322