### PR TITLE
feat: rely on review for offer completion

### DIFF
--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -124,22 +124,6 @@ export default function StoreOfferDetailPage() {
     doc.save(`invoice-${offer.id}.pdf`)
   }
 
-  const handleVisitComplete = async () => {
-    if (!offer) return
-    const res = await fetch(`/api/offers/${offer.id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ status: 'completed' }),
-    })
-    if (res.ok) {
-      setOffer({ ...offer, status: 'completed' })
-      setToast('来店完了として登録しました')
-    } else {
-      setToast('更新に失敗しました')
-    }
-    setTimeout(() => setToast(null), 3000)
-  }
-
   const handlePaid = async () => {
     if (!offer) return
     const res = await fetch(`/api/offers/${offer.id}`, {
@@ -216,29 +200,30 @@ export default function StoreOfferDetailPage() {
         <div className='text-sm'>まだ請求書が提出されていません</div>
       )}
       {offer.status === 'confirmed' && (
-        <>
-          <div className='space-y-2'>
-            <input type='file' accept='application/pdf,image/*' onChange={e => setFile(e.target.files?.[0] || null)} />
-            <Button onClick={uploadContract} disabled={!file}>アップロード</Button>
-          </div>
-          <Button onClick={handleVisitComplete}>来店完了</Button>
-        </>
+        <div className='space-y-2'>
+          <input type='file' accept='application/pdf,image/*' onChange={e => setFile(e.target.files?.[0] || null)} />
+          <Button onClick={uploadContract} disabled={!file}>アップロード</Button>
+        </div>
       )}
-      {offer.status === 'completed' && (
+      {(offer.status === 'confirmed' || offer.status === 'completed') && (
         reviewed ? (
-          <div className='text-sm'>レビュー済</div>
+          <Badge>レビュー投稿済（来店完了）</Badge>
         ) : (
-          <ReviewModal
-            offerId={offer.id}
-            talentId={offer.talent_id || ''}
-            storeId={offer.user_id || ''}
-            trigger={<Button>レビューを投稿する</Button>}
-            onSubmitted={() => {
-              setReviewed(true)
-              setToast('レビューを投稿しました')
-              setTimeout(() => setToast(null), 3000)
-            }}
-          />
+          <div className='space-y-2'>
+            <Badge variant='secondary'>レビュー未投稿</Badge>
+            <ReviewModal
+              offerId={offer.id}
+              talentId={offer.talent_id || ''}
+              storeId={offer.user_id || ''}
+              trigger={<Button>レビューを投稿する</Button>}
+              onSubmitted={() => {
+                setReviewed(true)
+                setOffer({ ...offer, status: 'completed' })
+                setToast('レビューを投稿しました')
+                setTimeout(() => setToast(null), 3000)
+              }}
+            />
+          </div>
         )
       )}
       {toast && (

--- a/talentify-next-frontend/app/store/offers/page.tsx
+++ b/talentify-next-frontend/app/store/offers/page.tsx
@@ -22,6 +22,7 @@ const statusLabels: Record<string, string> = {
   confirmed: '承諾済み',
   rejected: '拒否',
   expired: '期限切れ',
+  completed: '来店完了',
 }
 
 export default function StoreOffersPage() {
@@ -52,6 +53,7 @@ export default function StoreOffersPage() {
     confirmed: [],
     rejected: [],
     expired: [],
+    completed: [],
   }
   for (const o of sorted) {
     const key = o.status || 'pending'
@@ -73,6 +75,7 @@ export default function StoreOffersPage() {
           <option value="confirmed">承諾済み</option>
           <option value="rejected">拒否</option>
           <option value="expired">期限切れ</option>
+          <option value="completed">来店完了</option>
         </select>
         <select
           value={sortKey}
@@ -88,7 +91,7 @@ export default function StoreOffersPage() {
       ) : offers.length === 0 ? (
         <EmptyState title='まだオファーがありません' actionHref='/talent-search' actionLabel='オファーを送ってみましょう' />
       ) : (
-        (['pending', 'confirmed', 'rejected', 'expired'] as const).map(status => (
+        (['pending', 'confirmed', 'rejected', 'expired', 'completed'] as const).map(status => (
           groups[status].length > 0 && (
             <div key={status} className="space-y-2">
               <h2 className="font-semibold">{statusLabels[status]}</h2>

--- a/talentify-next-frontend/app/store/reviews/page.tsx
+++ b/talentify-next-frontend/app/store/reviews/page.tsx
@@ -1,18 +1,18 @@
 'use client'
 import { useEffect, useState } from 'react'
-import { getVisitedOffersForStore, VisitedOffer } from '@/utils/getVisitedOffersForStore'
+import { getCompletedOffersForStore, CompletedOffer } from '@/utils/getCompletedOffersForStore'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { Button } from '@/components/ui/button'
 import ReviewModal from '@/components/modals/ReviewModal'
 
 export default function StoreReviewsPage() {
-  const [offers, setOffers] = useState<VisitedOffer[]>([])
+  const [offers, setOffers] = useState<CompletedOffer[]>([])
   const [loading, setLoading] = useState(true)
   const [storeId, setStoreId] = useState('')
 
   useEffect(() => {
     const load = async () => {
-      const data = await getVisitedOffersForStore()
+      const data = await getCompletedOffersForStore()
       setOffers(data)
       setLoading(false)
       if (data[0]) setStoreId(data[0].store_id)
@@ -22,11 +22,11 @@ export default function StoreReviewsPage() {
 
   return (
     <main className="p-6 space-y-4">
-      <h1 className="text-2xl font-bold">来店完了オファー一覧</h1>
+      <h1 className="text-2xl font-bold">レビュー投稿済みオファー一覧</h1>
       {loading ? (
         <p>読み込み中...</p>
       ) : offers.length === 0 ? (
-        <p>完了したオファーはありません。</p>
+        <p>該当するオファーはありません。</p>
       ) : (
         <Table>
           <TableHeader>

--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -241,6 +241,7 @@ export default function TalentOfferDetailPage() {
     pending: { label: '対応待ち', className: 'bg-yellow-500 text-white' },
     confirmed: { label: '承諾済', className: 'bg-green-600 text-white' },
     rejected: { label: '辞退済み', className: 'bg-gray-400 text-white' },
+    completed: { label: '来店完了（レビュー投稿済）', className: 'bg-green-600 text-white' },
   }
 
   const statusInfo = statusMap[offer.status ?? 'pending']

--- a/talentify-next-frontend/app/talent/offers/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/page.tsx
@@ -66,6 +66,7 @@ export default function TalentOffersPage() {
     pending: { label: '対応待ち', className: 'bg-yellow-500 text-white' },
     confirmed: { label: '承諾済み', className: 'bg-gray-400 text-white' },
     rejected: { label: '辞退済み', className: 'bg-gray-400 text-white' },
+    completed: { label: '来店完了（レビュー投稿済）', className: 'bg-green-600 text-white' },
   }
 
   return (

--- a/talentify-next-frontend/utils/getCompletedOffersForStore.ts
+++ b/talentify-next-frontend/utils/getCompletedOffersForStore.ts
@@ -2,7 +2,7 @@
 import { createClient } from '@/utils/supabase/client'
 
 const supabase = createClient()
-export type VisitedOffer = {
+export type CompletedOffer = {
   id: string
   talent_id: string
   store_id: string
@@ -12,26 +12,26 @@ export type VisitedOffer = {
   talent_name: string | null
 }
 
-export async function getVisitedOffersForStore() {
+export async function getCompletedOffersForStore() {
   const {
     data: { user },
   } = await supabase.auth.getUser()
-  if (!user) return [] as VisitedOffer[]
+  if (!user) return [] as CompletedOffer[]
 
   const { data: store } = await supabase
     .from('stores')
     .select('id')
     .eq('user_id', user.id)
     .single()
-  if (!store) return [] as VisitedOffer[]
+  if (!store) return [] as CompletedOffer[]
 
   const { data, error } = await supabase
     .from('offers')
     .select('id, talent_id, store_id, date, message, reviews(id), talents(stage_name)')
     .eq('store_id', store.id)
-    .eq('status', 'visited')
+    .eq('status', 'completed')
   if (error) {
-    console.error('failed to fetch visited offers', error)
+    console.error('failed to fetch completed offers', error)
     return []
   }
   return (data || []).map(o => ({
@@ -42,5 +42,5 @@ export async function getVisitedOffersForStore() {
     message: o.message,
     reviewed: !!(o as any).reviews?.length,
     talent_name: (o as any).talents?.stage_name || null,
-  })) as VisitedOffer[]
+  })) as CompletedOffer[]
 }


### PR DESCRIPTION
## Summary
- remove manual visit completion and mark offers completed on review submission
- add completed status handling for store and talent offer lists
- fetch completed offers for review management

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68995d6e4a2883329d3f0faa874b8c76