### PR TITLE
fix: ensure toast notifications appear above header

### DIFF
--- a/docs/ui/toast-guidelines.md
+++ b/docs/ui/toast-guidelines.md
@@ -1,0 +1,48 @@
+# Toast Guidelines
+
+This project uses [sonner](https://sonner.emilkowal.ski/) for toast notifications.
+All toasts are rendered through a single `<Toaster />` mounted in `app/layout.tsx`.
+
+## Usage
+
+```tsx
+import { toast } from "sonner"
+
+toast.success("保存しました")
+toast.error("エラーが発生しました")
+```
+
+Do **not** mount `<Toaster />` inside pages or components. Use the global instance and the
+`toast` API instead.
+
+## Z-index policy
+
+Global z-index variables are defined in `app/globals.css`:
+
+```css
+:root {
+  --z-header: 50;
+  --z-toast: 9999;
+}
+```
+
+The toast portal uses `z-[var(--z-toast)]` so it always appears above the fixed header
+(`z-[var(--z-header)]`). If you introduce other layers (e.g. modals), ensure their
+z-index is higher than `--z-toast`.
+
+## Safe area
+
+For devices with a notch, the toast container applies `padding-top: env(safe-area-inset-top)`
+to avoid overlap with the system status bar.
+
+## Prohibited patterns
+
+- Adding `transform` or `overflow: hidden` to `html`, `body` or layout wrappers.
+- Rendering additional `<Toaster />` instances.
+- Manually positioning page-specific toast elements.
+
+## Checklist
+
+- [ ] Use `toast` from `sonner` for notifications.
+- [ ] No page-level `Toaster` or custom toast markup.
+- [ ] Headers and other layers use the shared z-index variables.

--- a/talentify-next-frontend/__tests__/toaster.test.ts
+++ b/talentify-next-frontend/__tests__/toaster.test.ts
@@ -1,0 +1,9 @@
+import { Toaster } from '../components/ui/toaster'
+
+describe('Toaster', () => {
+  it('renders with toast z-index class', () => {
+    const element = Toaster()
+    expect(element.props.className).toContain('toast-portal')
+    expect(element.props.className).toContain('z-[var(--z-toast)]')
+  })
+})

--- a/talentify-next-frontend/app/globals.css
+++ b/talentify-next-frontend/app/globals.css
@@ -7,6 +7,8 @@
   --background: #ffffff;
   --foreground: #171717;
   --font-inter: 'Inter', sans-serif;
+  --z-header: 50;
+  --z-toast: 9999;
 }
 
 /* ダークモード用（任意） */
@@ -23,4 +25,14 @@ body {
   color: var(--foreground);
   font-family: var(--font-inter), Arial, Helvetica, sans-serif;
   line-height: 1.75;
+}
+
+.toast-portal {
+  z-index: var(--z-toast);
+}
+
+@supports (padding: max(0px)) {
+  .toast-top {
+    padding-top: env(safe-area-inset-top);
+  }
 }

--- a/talentify-next-frontend/app/layout.tsx
+++ b/talentify-next-frontend/app/layout.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import "./globals.css";
 import Header from "../components/Header";
 import Footer from "../components/Footer";
+import { Toaster } from "@/components/ui/toaster";
 
 export const metadata = {
   title: "Talentify",
@@ -22,6 +23,7 @@ export default async function RootLayout({
     <html lang="ja">
       <body className="font-sans antialiased bg-white text-black">
         <Header />
+        <Toaster />
         {children}
         <Footer />
       </body>

--- a/talentify-next-frontend/app/store/dashboard/page.tsx
+++ b/talentify-next-frontend/app/store/dashboard/page.tsx
@@ -12,6 +12,7 @@ import Link from 'next/link'
 import { Search as SearchIcon } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
+import { toast } from 'sonner'
 
 export default function StoreDashboard() {
   const offerStats = { pending: 1, confirmed: 2 }
@@ -20,7 +21,6 @@ export default function StoreDashboard() {
   ]
   const unread = 3
   const [loading, setLoading] = useState(true)
-  const [toast, setToast] = useState<string | null>(null)
   const searchParams = useSearchParams()
 
   const hasData = offerStats.pending + offerStats.confirmed > 0
@@ -31,9 +31,7 @@ export default function StoreDashboard() {
 
   useEffect(() => {
     if (searchParams.get('saved') === '1') {
-      setToast('保存しました')
-      const timer = setTimeout(() => setToast(null), 3000)
-      return () => clearTimeout(timer)
+      toast.success('保存しました')
     }
   }, [searchParams])
 
@@ -77,11 +75,7 @@ export default function StoreDashboard() {
         <NotificationListCard className='sm:col-span-2' />
       </div>
       )}
-      {toast && (
-        <div className='fixed top-4 right-4 bg-green-600 text-white px-4 py-2 rounded shadow'>
-          {toast}
-        </div>
-      )}
+      {/* Toasts are handled globally */}
     </div>
   )
 }

--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link'
 import jsPDF from 'jspdf'
 import { addNotification } from '@/utils/notifications'
 import ReviewModal from '@/components/modals/ReviewModal'
+import { toast } from 'sonner'
 
 interface Offer {
   id: string
@@ -38,7 +39,6 @@ export default function StoreOfferDetailPage() {
   const params = useParams<{ id: string }>()
   const supabase = createClient()
   const [offer, setOffer] = useState<Offer | null>(null)
-  const [toast, setToast] = useState<string | null>(null)
   const [file, setFile] = useState<File | null>(null)
   const [reviewed, setReviewed] = useState(false)
 
@@ -74,8 +74,7 @@ export default function StoreOfferDetailPage() {
       .from('contracts')
       .upload(path, file, { upsert: true })
     if (error) {
-      setToast('アップロードに失敗しました')
-      setTimeout(() => setToast(null), 3000)
+      toast.error('アップロードに失敗しました')
       return
     }
     const { data } = await supabase.storage
@@ -98,11 +97,10 @@ export default function StoreOfferDetailPage() {
           title: '契約書がアップロードされました'
         })
       }
-      setToast('契約書をアップロードしました')
+      toast.success('契約書をアップロードしました')
     } else {
-      setToast('更新に失敗しました')
+      toast.error('更新に失敗しました')
     }
-    setTimeout(() => setToast(null), 3000)
   }
 
   const downloadInvoice = () => {
@@ -142,11 +140,10 @@ export default function StoreOfferDetailPage() {
           title: 'お支払いが完了しました'
         })
       }
-      setToast('支払い完了を登録しました')
+      toast.success('支払い完了を登録しました')
     } else {
-      setToast('更新に失敗しました')
+      toast.error('更新に失敗しました')
     }
-    setTimeout(() => setToast(null), 3000)
   }
 
   if (!offer) return <p className='p-4'>Loading...</p>
@@ -219,18 +216,13 @@ export default function StoreOfferDetailPage() {
               onSubmitted={() => {
                 setReviewed(true)
                 setOffer({ ...offer, status: 'completed' })
-                setToast('レビューを投稿しました')
-                setTimeout(() => setToast(null), 3000)
+                toast.success('レビューを投稿しました')
               }}
             />
           </div>
         )
       )}
-      {toast && (
-        <div className='fixed top-4 right-4 bg-green-600 text-white px-4 py-2 rounded shadow'>
-          {toast}
-        </div>
-      )}
+      {/* Toasts are handled globally */}
     </div>
   )
 }

--- a/talentify-next-frontend/app/store/settings/page.tsx
+++ b/talentify-next-frontend/app/store/settings/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useMemo } from 'react'
 import { createClient } from '@/utils/supabase/client'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
+import { toast } from 'sonner'
 
 interface Settings {
   store_name: string
@@ -21,7 +22,6 @@ export default function StoreSettingsPage() {
     email: '',
     phone: '',
   })
-  const [toast, setToast] = useState<string | null>(null)
 
   useEffect(() => {
     const load = async () => {
@@ -76,8 +76,7 @@ export default function StoreSettingsPage() {
         console.warn('RLS policy may prevent inserting/updating stores')
       }
     } else {
-      setToast('更新しました')
-      setTimeout(() => setToast(null), 3000)
+      toast.success('更新しました')
     }
   }
 
@@ -107,11 +106,7 @@ export default function StoreSettingsPage() {
         <Button onClick={handleSave} className="mt-2">保存</Button>
       </div>
 
-      {toast && (
-        <div className="fixed top-4 right-4 bg-green-600 text-white px-4 py-2 rounded shadow">
-          {toast}
-        </div>
-      )}
+      {/* Toasts are handled globally */}
     </main>
   )
 }

--- a/talentify-next-frontend/app/talent/dashboard/page.tsx
+++ b/talentify-next-frontend/app/talent/dashboard/page.tsx
@@ -9,13 +9,13 @@ import { CardSkeleton } from '@/components/ui/skeleton'
 import { useEffect, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { getTalentSchedule } from '@/utils/getTalentSchedule'
+import { toast } from 'sonner'
 
 export default function TalentDashboard() {
   const pending = 2
   const [schedule, setSchedule] = useState<ScheduleItem[]>([])
   const unread = 5
   const [loading, setLoading] = useState(true)
-  const [toast, setToast] = useState<string | null>(null)
   const searchParams = useSearchParams()
 
   useEffect(() => {
@@ -33,9 +33,7 @@ export default function TalentDashboard() {
 
   useEffect(() => {
     if (searchParams.get('saved') === '1') {
-      setToast('保存しました')
-      const timer = setTimeout(() => setToast(null), 3000)
-      return () => clearTimeout(timer)
+      toast.success('保存しました')
     }
   }, [searchParams])
 
@@ -59,11 +57,7 @@ export default function TalentDashboard() {
           </div>
         </>
       )}
-      {toast && (
-        <div className='fixed top-4 right-4 bg-green-600 text-white px-4 py-2 rounded shadow'>
-          {toast}
-        </div>
-      )}
+      {/* Toasts are handled globally */}
     </div>
   )
 }

--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -12,6 +12,7 @@ import { Input } from '@/components/ui/input'
 import { format, isBefore, parseISO } from 'date-fns'
 import ja from 'date-fns/locale/ja'
 import { addNotification } from '@/utils/notifications'
+import { toast } from 'sonner'
 
 interface Offer {
   id: string
@@ -50,7 +51,6 @@ export default function TalentOfferDetailPage() {
   const supabase = createClient()
   const [offer, setOffer] = useState<Offer | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
-  const [toast, setToast] = useState<string | null>(null)
   const [editingInvoice, setEditingInvoice] = useState(false)
   const [invoiceDate, setInvoiceDate] = useState('')
   const [invoiceAmount, setInvoiceAmount] = useState(0)
@@ -77,11 +77,9 @@ export default function TalentOfferDetailPage() {
           title: 'オファーが承諾されました'
         })
       }
-      setToast(status === 'confirmed' ? 'オファーを承諾しました' : 'オファーを辞退しました')
-      setTimeout(() => setToast(null), 3000)
+      toast.success(status === 'confirmed' ? 'オファーを承諾しました' : 'オファーを辞退しました')
     } else {
-      setToast('処理に失敗しました。もう一度お試しください')
-      setTimeout(() => setToast(null), 3000)
+      toast.error('処理に失敗しました。もう一度お試しください')
     }
   }
 
@@ -102,11 +100,10 @@ export default function TalentOfferDetailPage() {
           title: 'タレントが契約書を確認しました'
         })
       }
-      setToast('契約書を確認しました')
+      toast.success('契約書を確認しました')
     } else {
-      setToast('更新に失敗しました')
+      toast.error('更新に失敗しました')
     }
-    setTimeout(() => setToast(null), 3000)
   }
 
   const submitInvoice = async () => {
@@ -144,11 +141,10 @@ export default function TalentOfferDetailPage() {
         })
       }
       setEditingInvoice(false)
-      setToast('請求書を提出しました')
+      toast.success('請求書を提出しました')
     } else {
-      setToast('更新に失敗しました')
+      toast.error('更新に失敗しました')
     }
-    setTimeout(() => setToast(null), 3000)
   }
 
   const handleInvoiceFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -159,8 +155,7 @@ export default function TalentOfferDetailPage() {
       .from('invoices')
       .upload(path, file, { upsert: true })
     if (error) {
-      setToast('アップロードに失敗しました')
-      setTimeout(() => setToast(null), 3000)
+      toast.error('アップロードに失敗しました')
       return
     }
     const { data } = await supabase.storage
@@ -182,11 +177,10 @@ export default function TalentOfferDetailPage() {
           title: '請求書が提出されました',
         })
       }
-      setToast('請求書をアップロードしました')
+      toast.success('請求書をアップロードしました')
     } else {
-      setToast('更新に失敗しました')
+      toast.error('更新に失敗しました')
     }
-    setTimeout(() => setToast(null), 3000)
   }
 
   useEffect(() => {
@@ -422,11 +416,7 @@ export default function TalentOfferDetailPage() {
         </div>
       )}
 
-      {toast && (
-        <div className="fixed top-4 right-4 bg-green-600 text-white px-4 py-2 rounded shadow">
-          {toast}
-        </div>
-      )}
+      {/* Toasts are handled globally */}
     </div>
   )
 }

--- a/talentify-next-frontend/app/talent/schedule/page.tsx
+++ b/talentify-next-frontend/app/talent/schedule/page.tsx
@@ -6,28 +6,22 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import Link from 'next/link'
 import { getTalentSchedule, type TalentSchedule } from '@/utils/getTalentSchedule'
-
-// スケジュール確定時のトースト表示用
-function Toast({ message }: { message: string }) {
-  return (
-    <div className='fixed top-4 right-4 bg-green-600 text-white px-4 py-2 rounded shadow'>
-      {message}
-    </div>
-  )
-}
+import { toast } from 'sonner'
 
 export default function SchedulePage() {
   const [items, setItems] = useState<TalentSchedule[]>([])
   const [loading, setLoading] = useState(true)
-  const [toast, setToast] = useState<string | null>(null)
 
   useEffect(() => {
     getTalentSchedule().then((data) => {
       setItems(data)
       setLoading(false)
-      if (data.length > 0 && typeof window !== 'undefined' && window.location.search.includes('confirmed=1')) {
-        setToast('出演スケジュールが確定しました')
-        setTimeout(() => setToast(null), 3000)
+      if (
+        data.length > 0 &&
+        typeof window !== 'undefined' &&
+        window.location.search.includes('confirmed=1')
+      ) {
+        toast.success('出演スケジュールが確定しました')
       }
     })
   }, [])
@@ -65,7 +59,7 @@ export default function SchedulePage() {
           ))}
         </CardContent>
       </Card>
-      {toast && <Toast message={toast} />}
+      {/* Toasts are handled globally */}
     </div>
   )
 }

--- a/talentify-next-frontend/components/Header.tsx
+++ b/talentify-next-frontend/components/Header.tsx
@@ -50,7 +50,7 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
   const isLoggedIn = !!userName
 
   return (
-    <header className="fixed top-0 z-50 w-full h-16 bg-white shadow-sm">
+    <header className="fixed top-0 w-full h-16 bg-white shadow-sm z-[var(--z-header)]">
       <div className="mx-auto flex h-full max-w-5xl items-center justify-between p-4">
         <div className="flex items-center gap-2">
           {sidebarRole && (

--- a/talentify-next-frontend/components/ui/toaster.tsx
+++ b/talentify-next-frontend/components/ui/toaster.tsx
@@ -1,0 +1,11 @@
+"use client"
+
+import React from "react"
+import { Toaster as Sonner } from "sonner"
+
+export function Toaster() {
+  return React.createElement(Sonner, {
+    position: "top-center",
+    className: "toast-portal toast-top z-[var(--z-toast)]",
+  })
+}

--- a/talentify-next-frontend/package-lock.json
+++ b/talentify-next-frontend/package-lock.json
@@ -28,6 +28,7 @@
         "react-big-calendar": "^1.19.4",
         "react-dom": "^18.3.1",
         "react-icons": "^5.5.0",
+        "sonner": "^1.5.0",
         "tailwind-merge": "^3.3.1",
         "tailwind-variants": "^1.0.0"
       },
@@ -9969,6 +9970,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.4.tgz",
+      "integrity": "sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/talentify-next-frontend/package.json
+++ b/talentify-next-frontend/package.json
@@ -30,6 +30,7 @@
     "react-big-calendar": "^1.19.4",
     "react-dom": "^18.3.1",
     "react-icons": "^5.5.0",
+    "sonner": "^1.5.0",
     "tailwind-merge": "^3.3.1",
     "tailwind-variants": "^1.0.0"
   },


### PR DESCRIPTION
## Summary
- mount a single global `<Toaster />` in the app layout and portal it with high z-index
- define shared z-index variables and safe-area padding for toast container
- replace page-local toast elements with `sonner` toasts and document usage

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68995fefa4048332bbc48fa6f720e33a