### PR TITLE
docs: fix reviews RLS policy

### DIFF
--- a/talentify-next-frontend/supabase-docs/rls.md
+++ b/talentify-next-frontend/supabase-docs/rls.md
@@ -35,9 +35,9 @@
 - ストアは支払いを更新可能 (`UPDATE`): USING `(auth.uid() = ( SELECT invoices.store_id FROM invoices WHERE (invoices.offer_id = payments.offer_id)))`
 
 ### reviews
-- 認証済みユーザーは読み書き可能 (`*`): USING `true`, CHECK `true`
-- ストアは自分のオファーにレビューを追加可能 (`INSERT`): CHECK `((auth.uid() = store_id) AND (offer_id IN ( SELECT offers.id FROM offers WHERE (offers.store_id = auth.uid()))))`
-- 関連するユーザーのみレビューを閲覧可能 (`SELECT`): USING `((auth.uid() = store_id) OR (auth.uid() = talent_id))`
+- ストアユーザーは自分のストアのオファーに対してのみレビューを登録可能 (`INSERT`): CHECK `EXISTS (SELECT 1 FROM stores s WHERE s.id = reviews.store_id AND s.user_id = auth.uid()) AND EXISTS (SELECT 1 FROM offers o WHERE o.id = reviews.offer_id AND o.store_id = reviews.store_id AND (reviews.talent_id IS NULL OR o.talent_id = reviews.talent_id))`
+- ストア所有ユーザーまたはタレント本人のみレビューを閲覧可能 (`SELECT`): USING `EXISTS (SELECT 1 FROM stores s WHERE s.id = reviews.store_id AND s.user_id = auth.uid()) OR EXISTS (SELECT 1 FROM talents t WHERE t.id = reviews.talent_id AND t.user_id = auth.uid())`
+- ※ `auth.uid()` はユーザーID、`store_id` はストアIDのため直接比較不可。`stores.user_id` と突合せる
 
 ### schedules
 - 認証済みユーザーは読み書き可能 (`*`): USING `true`, CHECK `true`

--- a/talentify-next-frontend/supabase-docs/schema.md
+++ b/talentify-next-frontend/supabase-docs/schema.md
@@ -121,8 +121,8 @@
 - rating: integer
 - comment: text
 - created_at: timestamp without time zone, DEFAULT now()
-- category_ratings: jsonb <!-- カテゴリごとの評価。API・フロントエンドから利用可能 -->
-- is_public: boolean, DEFAULT true <!-- レビュー公開設定。API・フロントエンドから利用可能 -->
+- category_ratings: jsonb <!-- カテゴリごとの評価。NULL可 -->
+- is_public: boolean, DEFAULT true <!-- レビュー公開設定。デフォルトは公開（true） -->
 
 ### schedules
 - id: uuid, NOT NULL, DEFAULT gen_random_uuid()


### PR DESCRIPTION
## Summary
- revise reviews RLS documentation to match auth.uid vs store user checks
- document category_ratings and is_public fields in reviews schema

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68996cf49e248332a80ca362166145bc