### PR TITLE
docs: update reviews RLS policies

### DIFF
--- a/talentify-next-frontend/supabase-docs/rls.md
+++ b/talentify-next-frontend/supabase-docs/rls.md
@@ -35,9 +35,9 @@
 - ストアは支払いを更新可能 (`UPDATE`): USING `(auth.uid() = ( SELECT invoices.store_id FROM invoices WHERE (invoices.offer_id = payments.offer_id)))`
 
 ### reviews
-- ストアユーザーは自分のストアのオファーに対してのみレビューを登録可能 (`INSERT`): CHECK `EXISTS (SELECT 1 FROM stores s WHERE s.id = reviews.store_id AND s.user_id = auth.uid()) AND EXISTS (SELECT 1 FROM offers o WHERE o.id = reviews.offer_id AND o.store_id = reviews.store_id AND (reviews.talent_id IS NULL OR o.talent_id = reviews.talent_id))`
-- ストア所有ユーザーまたはタレント本人のみレビューを閲覧可能 (`SELECT`): USING `EXISTS (SELECT 1 FROM stores s WHERE s.id = reviews.store_id AND s.user_id = auth.uid()) OR EXISTS (SELECT 1 FROM talents t WHERE t.id = reviews.talent_id AND t.user_id = auth.uid())`
-- ※ `auth.uid()` はユーザーID、`store_id` はストアIDのため直接比較不可。`stores.user_id` と突合せる
+- ストア所有ユーザーのみ、自分のオファーに対してレビュー投稿可 (`INSERT`): CHECK `EXISTS (SELECT 1 FROM public.stores s WHERE s.id = reviews.store_id AND s.user_id = auth.uid()) AND EXISTS (SELECT 1 FROM public.offers o WHERE o.id = reviews.offer_id AND o.store_id = reviews.store_id AND (reviews.talent_id IS NULL OR o.talent_id = reviews.talent_id))`
+- 関連ユーザー（ストア所有ユーザー or タレント本人）のみレビュー閲覧可 (`SELECT`): USING `EXISTS (SELECT 1 FROM public.stores s WHERE s.id = reviews.store_id AND s.user_id = auth.uid()) OR EXISTS (SELECT 1 FROM public.talents t WHERE t.id = reviews.talent_id AND t.user_id = auth.uid())`
+- ※ `auth.uid()` と `store_id` は直接比較できないため、`stores.user_id` 経由で判定
 
 ### schedules
 - 認証済みユーザーは読み書き可能 (`*`): USING `true`, CHECK `true`

--- a/talentify-next-frontend/supabase-docs/schema.md
+++ b/talentify-next-frontend/supabase-docs/schema.md
@@ -121,8 +121,8 @@
 - rating: integer
 - comment: text
 - created_at: timestamp without time zone, DEFAULT now()
-- category_ratings: jsonb <!-- カテゴリごとの評価。NULL可 -->
-- is_public: boolean, DEFAULT true <!-- レビュー公開設定。デフォルトは公開（true） -->
+- category_ratings: jsonb (カテゴリごとの評価。NULL可)
+- is_public: boolean, DEFAULT true (レビュー公開設定。デフォルトは公開（true）)
 
 ### schedules
 - id: uuid, NOT NULL, DEFAULT gen_random_uuid()


### PR DESCRIPTION
## Summary
- document new review INSERT policy restricted to store owners and their offers
- document SELECT policy for related users (store owners or talent)
- note `auth.uid()` vs `store_id` comparison through `stores.user_id`
- clarify review table columns `category_ratings` and `is_public`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68996e74d7dc8332b568b2f64c18db62