### PR TITLE
feat: enable collapsible sidebar across layouts

### DIFF
--- a/talentify-next-frontend/app/search/layout.tsx
+++ b/talentify-next-frontend/app/search/layout.tsx
@@ -24,10 +24,8 @@ export default async function SearchLayout({
         <SupabaseProvider session={session}>
           <Header sidebarRole="store" />
           <div className="flex h-[calc(100vh-64px)] pt-16">
-            <aside className="hidden md:block">
-              <Sidebar role="store" collapsible />
-            </aside>
-            <main className="flex-1 overflow-y-auto p-6">{children}</main>
+            <Sidebar role="store" collapsible />
+            <main className="flex-1 overflow-y-auto p-6 transition-[margin,width]">{children}</main>
           </div>
         </SupabaseProvider>
       </body>

--- a/talentify-next-frontend/app/store/layout.tsx
+++ b/talentify-next-frontend/app/store/layout.tsx
@@ -24,10 +24,8 @@ export default async function StoreLayout({
         <SupabaseProvider session={session}>
           <Header sidebarRole="store" />
           <div className="flex h-[calc(100vh-64px)] pt-16">
-            <aside className="hidden md:block">
-              <Sidebar role="store" collapsible />
-            </aside>
-            <main className="flex-1 overflow-y-auto p-6">{children}</main>
+            <Sidebar role="store" collapsible />
+            <main className="flex-1 overflow-y-auto p-6 transition-[margin,width]">{children}</main>
           </div>
         </SupabaseProvider>
       </body>

--- a/talentify-next-frontend/app/talent/layout.tsx
+++ b/talentify-next-frontend/app/talent/layout.tsx
@@ -27,13 +27,10 @@ export default async function TalentLayout({
 
           {/* ヘッダー高さ分の余白を考慮して下部を分割 */}
           <div className="flex h-[calc(100vh-64px)] pt-16">
-            {/* サイドバー（デスクトップのみ表示） */}
-            <aside className="hidden md:block w-[220px] shrink-0">
-              <Sidebar role="talent" collapsible />
-            </aside>
+            <Sidebar role="talent" collapsible />
 
             {/* メインコンテンツ */}
-            <main className="flex-1 overflow-y-auto p-6">{children}</main>
+            <main className="flex-1 overflow-y-auto p-6 transition-[margin,width]">{children}</main>
           </div>
         </SupabaseProvider>
       </body>

--- a/talentify-next-frontend/app/talents/layout.tsx
+++ b/talentify-next-frontend/app/talents/layout.tsx
@@ -24,10 +24,8 @@ export default async function TalentsLayout({
         <SupabaseProvider session={session}>
           <Header sidebarRole="store" />
           <div className="flex h-[calc(100vh-64px)] pt-16">
-            <aside className="hidden md:block">
-              <Sidebar role="store" collapsible />
-            </aside>
-            <main className="flex-1 overflow-y-auto p-6">{children}</main>
+            <Sidebar role="store" collapsible />
+            <main className="flex-1 overflow-y-auto p-6 transition-[margin,width]">{children}</main>
           </div>
         </SupabaseProvider>
       </body>

--- a/talentify-next-frontend/components/Header.tsx
+++ b/talentify-next-frontend/components/Header.tsx
@@ -61,7 +61,7 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
                 </button>
               </SheetTrigger>
               <SheetContent side="left" className="p-4">
-                <Sidebar role={sidebarRole} />
+                <Sidebar role={sidebarRole} collapsible />
               </SheetContent>
             </Sheet>
           )}

--- a/talentify-next-frontend/components/Sidebar.tsx
+++ b/talentify-next-frontend/components/Sidebar.tsx
@@ -68,26 +68,15 @@ export default function Sidebar({
   const [collapsed, setCollapsed] = useState(false);
   const [loggedIn, setLoggedIn] = useState(false);
 
-  // Load sidebar state from localStorage on mount
-  useEffect(() => {
-    try {
-      const stored = localStorage.getItem('sidebarCollapsed');
-      if (stored !== null) {
-        setCollapsed(stored === 'true');
-      }
-    } catch (err) {
-      console.error('Failed to read sidebar state', err);
-    }
-  }, [supabase]);
+  const STORAGE_KEY = "sidebar:collapsed";
 
-  // Persist sidebar state
   useEffect(() => {
     try {
-      localStorage.setItem('sidebarCollapsed', String(collapsed));
-    } catch (err) {
-      console.error('Failed to save sidebar state', err);
-    }
-  }, [collapsed]);
+      const saved =
+        typeof window !== "undefined" ? localStorage.getItem(STORAGE_KEY) : null;
+      if (saved != null) setCollapsed(saved === "true");
+    } catch {}
+  }, []);
 
   useEffect(() => {
     const checkSession = async () => {
@@ -116,11 +105,13 @@ export default function Sidebar({
   };
 
   const handleToggle = () => {
-    try {
-      setCollapsed((prev) => !prev);
-    } catch (err) {
-      console.error('Failed to toggle sidebar', err);
-    }
+    setCollapsed((v) => {
+      const next = !v;
+      try {
+        localStorage.setItem(STORAGE_KEY, String(next));
+      } catch {}
+      return next;
+    });
   };
 
   const items = role === "store" ? navItems.store : navItems.talent;
@@ -128,8 +119,8 @@ export default function Sidebar({
   return (
     <div
       className={cn(
-        "relative bg-background border-r shadow-sm flex flex-col justify-between h-full",
-        collapsible && collapsed ? "w-16 min-w-[64px]" : "min-w-[220px]",
+        "relative bg-background border-r shadow-sm flex flex-col justify-between h-full overflow-hidden transition-[width]",
+        collapsible ? (collapsed ? "w-16" : "w-64") : "w-64",
       )}
     >
       <TooltipProvider delayDuration={0}>
@@ -197,7 +188,7 @@ export default function Sidebar({
       {collapsible && (
         <button
           onClick={handleToggle}
-          className="absolute -right-3 top-2 hidden h-6 w-6 items-center justify-center rounded-full border bg-background shadow md:flex"
+          className="absolute z-50 -right-3 top-2 flex h-6 w-6 items-center justify-center rounded-full border bg-background shadow md:flex"
         >
           {collapsed ? (
             <ChevronRight className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- persist sidebar collapse state in localStorage and show toggle on mobile
- render collapsible Sidebar in all layouts with smooth width transitions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689976d3a744833292434342a5cfe0b2