### PR TITLE
fix: wrap layout with tooltip provider

### DIFF
--- a/talentify-next-frontend/app/layout.tsx
+++ b/talentify-next-frontend/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css";
 import Header from "../components/Header";
 import Footer from "../components/Footer";
 import { Toaster } from "@/components/ui/toaster";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
 export const metadata = {
   title: "Talentify",
@@ -22,10 +23,12 @@ export default async function RootLayout({
   return (
     <html lang="ja">
       <body className="font-sans antialiased bg-white text-black">
-        <Header />
-        <Toaster />
-        {children}
-        <Footer />
+        <TooltipProvider delayDuration={200} disableHoverableContent>
+          <Header />
+          <Toaster />
+          {children}
+          <Footer />
+        </TooltipProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- wrap root layout with TooltipProvider to enable tooltips across the app

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689981be8894833293175f5d093ede26