### PR TITLE
feat: harden review posting and update docs

### DIFF
--- a/supabase/migrations/20250811055357_reviews_hardening.sql
+++ b/supabase/migrations/20250811055357_reviews_hardening.sql
@@ -1,0 +1,72 @@
+alter table public.reviews
+  alter column category_ratings set data type jsonb using category_ratings::jsonb,
+  alter column category_ratings set default '{}'::jsonb,
+  alter column is_public set default true;
+
+update public.reviews
+set category_ratings = '{}'::jsonb
+where category_ratings is null;
+
+do $$
+begin
+  if not exists (select 1 from pg_constraint where conname = 'reviews_category_ratings_is_object') then
+    alter table public.reviews
+      add constraint reviews_category_ratings_is_object
+      check (category_ratings is null or jsonb_typeof(category_ratings) = 'object');
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (select 1 from pg_indexes where schemaname='public' and indexname='uniq_offer_store_review') then
+    create unique index uniq_offer_store_review on public.reviews(offer_id, store_id);
+  end if;
+end$$;
+
+alter table public.reviews enable row level security;
+
+drop policy if exists reviews_insert_by_store on public.reviews;
+drop policy if exists reviews_select_related_users on public.reviews;
+drop policy if exists public_can_read_public_reviews on public.reviews;
+
+create policy reviews_insert_by_store
+  on public.reviews
+  for insert
+  to authenticated
+  with check (
+    exists (
+      select 1
+      from public.offers o
+      join public.stores s on s.id = o.store_id
+      where o.id = reviews.offer_id
+        and s.user_id = auth.uid()
+    )
+  );
+
+create policy reviews_select_related_users
+  on public.reviews
+  for select
+  to authenticated
+  using (
+    is_public = true
+    or exists (
+      select 1
+      from public.offers o
+      join public.stores st on st.id = o.store_id
+      where o.id = reviews.offer_id
+        and st.user_id = auth.uid()
+    )
+    or exists (
+      select 1
+      from public.offers o
+      join public.talents t on t.id = o.talent_id
+      where o.id = reviews.offer_id
+        and t.user_id = auth.uid()
+    )
+  );
+
+create policy public_can_read_public_reviews
+  on public.reviews
+  for select
+  to anon
+  using (is_public = true);

--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -211,12 +211,10 @@ export default function StoreOfferDetailPage() {
             <ReviewModal
               offerId={offer.id}
               talentId={offer.talent_id || ''}
-              storeId={offer.user_id || ''}
               trigger={<Button>レビューを投稿する</Button>}
               onSubmitted={() => {
                 setReviewed(true)
                 setOffer({ ...offer, status: 'completed' })
-                toast.success('レビューを投稿しました')
               }}
             />
           </div>

--- a/talentify-next-frontend/app/store/reviews/page.tsx
+++ b/talentify-next-frontend/app/store/reviews/page.tsx
@@ -8,14 +8,12 @@ import ReviewModal from '@/components/modals/ReviewModal'
 export default function StoreReviewsPage() {
   const [offers, setOffers] = useState<CompletedOffer[]>([])
   const [loading, setLoading] = useState(true)
-  const [storeId, setStoreId] = useState('')
 
   useEffect(() => {
     const load = async () => {
       const data = await getCompletedOffersForStore()
       setOffers(data)
       setLoading(false)
-      if (data[0]) setStoreId(data[0].store_id)
     }
     load()
   }, [])
@@ -48,7 +46,6 @@ export default function StoreReviewsPage() {
                     <ReviewModal
                       offerId={o.id}
                       talentId={o.talent_id}
-                      storeId={o.store_id}
                       trigger={<Button size="sm">レビューする</Button>}
                       onSubmitted={() => {
                         setOffers(prev => prev.map(p => p.id === o.id ? { ...p, reviewed: true } : p))

--- a/talentify-next-frontend/supabase-docs/schema.md
+++ b/talentify-next-frontend/supabase-docs/schema.md
@@ -121,7 +121,7 @@
 - rating: integer
 - comment: text
 - created_at: timestamp without time zone, DEFAULT now()
-- category_ratings: jsonb (カテゴリごとの評価。NULL可)
+- category_ratings: jsonb, DEFAULT '{}'::jsonb (カテゴリごとの評価。未指定時は空オブジェクト)
 - is_public: boolean, DEFAULT true (レビュー公開設定。デフォルトは公開（true）)
 
 ### schedules

--- a/talentify-next-frontend/types/supabase.ts
+++ b/talentify-next-frontend/types/supabase.ts
@@ -247,8 +247,43 @@ export type Database = {
           created_at?: string | null
         }
         Relationships: []
-      }
-      ,
+      },
+      reviews: {
+        Row: {
+          id: string
+          offer_id: string | null
+          store_id: string | null
+          talent_id: string | null
+          rating: number | null
+          comment: string | null
+          created_at: string | null
+          category_ratings: Json | null
+          is_public: boolean | null
+        }
+        Insert: {
+          id?: string
+          offer_id?: string | null
+          store_id?: string | null
+          talent_id?: string | null
+          rating?: number | null
+          comment?: string | null
+          created_at?: string | null
+          category_ratings?: Json | null
+          is_public?: boolean | null
+        }
+        Update: {
+          id?: string
+          offer_id?: string | null
+          store_id?: string | null
+          talent_id?: string | null
+          rating?: number | null
+          comment?: string | null
+          created_at?: string | null
+          category_ratings?: Json | null
+          is_public?: boolean | null
+        }
+        Relationships: []
+      },
       invoices: {
         Row: {
           id: string


### PR DESCRIPTION
## Summary
- allow posting reviews with minimal payload and surfaced errors
- document new RLS and defaults for reviews
- add migration to harden reviews table and policies

## Testing
- `npm test`
- `npm run lint`
- `npx supabase gen types typescript --local` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_689984d1ab5c833294c9ff6db18ad29f