### PR TITLE
feat: display review notifications

### DIFF
--- a/talentify-next-frontend/__tests__/notifications.test.ts
+++ b/talentify-next-frontend/__tests__/notifications.test.ts
@@ -1,0 +1,48 @@
+import { createClient } from '@/utils/supabase/client'
+
+jest.mock('@/utils/supabase/client')
+
+test('getNotifications fetches review and offer notifications without extra filters', async () => {
+  const mockData = [
+    {
+      id: '1',
+      user_id: 'user1',
+      type: 'offer_created',
+      title: 'offer',
+      body: 'body',
+      created_at: '2024-01-01',
+      is_read: false,
+    },
+    {
+      id: '2',
+      user_id: 'user1',
+      type: 'review_received',
+      title: 'review',
+      body: 'body',
+      created_at: '2023-01-01',
+      is_read: true,
+      data: { rating: 5 },
+    },
+  ]
+
+  let builder: any
+  const mockIn = jest.fn(() => builder)
+  builder = {
+    select: jest.fn(() => builder),
+    eq: jest.fn(() => builder),
+    in: mockIn,
+    order: jest.fn(() => builder),
+    limit: jest.fn(() => builder),
+    then: (resolve: any) => resolve({ data: mockData, error: null }),
+  }
+
+  ;(createClient as jest.Mock).mockReturnValue({
+    auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'user1' } } }) },
+    from: jest.fn(() => builder),
+  })
+
+  const { getNotifications } = require('@/utils/notifications')
+  const data = await getNotifications()
+  expect(data).toHaveLength(2)
+  expect(mockIn).toHaveBeenCalledWith('type', ['offer_created', 'review_received'])
+})

--- a/talentify-next-frontend/components/ui/notification-item.tsx
+++ b/talentify-next-frontend/components/ui/notification-item.tsx
@@ -2,22 +2,20 @@ import React from 'react'
 import { Badge } from './badge'
 import { cn } from '@/lib/utils'
 import type { Notification } from '@/types/ui'
-import { Bell, Mail, Calendar as CalendarIcon, Info } from 'lucide-react'
+import { Bell, Mail, Calendar as CalendarIcon, Info, Star } from 'lucide-react'
 
 interface NotificationItemProps extends React.HTMLAttributes<HTMLDivElement> {
   notification: Notification
 }
 
-const typeIcon = {
-  message: Mail,
-  offer: Bell,
-  schedule: CalendarIcon,
-  system: Info,
-}
-
-export function NotificationItem({ notification, className, ...props }: NotificationItemProps) {
+function GenericNotification({ notification, className, ...props }: NotificationItemProps) {
+  const typeIcon = {
+    message: Mail,
+    offer: Bell,
+    schedule: CalendarIcon,
+    system: Info,
+  }
   const Icon = typeIcon[notification.type] || Info
-
   return (
     <div
       className={cn(
@@ -36,7 +34,63 @@ export function NotificationItem({ notification, className, ...props }: Notifica
             : String(notification.created_at)}
         </div>
       </div>
-      {!notification.is_read && <Badge className="self-start" variant="destructive">NEW</Badge>}
+      {!notification.is_read && (
+        <Badge className="self-start" variant="destructive">
+          NEW
+        </Badge>
+      )}
     </div>
   )
+}
+
+function ReviewReceivedNotification({ notification, className, ...props }: NotificationItemProps) {
+  const rating = (notification.data as any)?.rating
+  return (
+    <div
+      className={cn(
+        'flex items-start gap-2 rounded-md border p-3 bg-white',
+        !notification.is_read && 'font-semibold',
+        className
+      )}
+      {...props}
+    >
+      <Star className="h-4 w-4 mt-0.5" />
+      <div className="text-sm flex-1">
+        <div>
+          レビューが届きました{rating ? `（評価: ${rating}）` : ''}
+        </div>
+        <div className="text-xs text-muted-foreground">
+          {typeof notification.created_at === 'string'
+            ? notification.created_at.slice(0, 10)
+            : String(notification.created_at)}
+        </div>
+      </div>
+      {!notification.is_read && (
+        <Badge className="self-start" variant="destructive">
+          NEW
+        </Badge>
+      )}
+    </div>
+  )
+}
+
+export function NotificationItem({ notification, className, ...props }: NotificationItemProps) {
+  switch (notification.type) {
+    case 'review_received':
+      return (
+        <ReviewReceivedNotification
+          notification={notification}
+          className={className}
+          {...props}
+        />
+      )
+    default:
+      return (
+        <GenericNotification
+          notification={notification}
+          className={className}
+          {...props}
+        />
+      )
+  }
 }

--- a/talentify-next-frontend/types/supabase.ts
+++ b/talentify-next-frontend/types/supabase.ts
@@ -418,7 +418,19 @@ export type Database = {
           id?: string
           user_id?: string
           offer_id?: string | null
-          type?: string
+          type?:
+            | 'offer'
+            | 'offer_created'
+            | 'offer_updated'
+            | 'offer_accepted'
+            | 'schedule_fixed'
+            | 'contract_uploaded'
+            | 'contract_checked'
+            | 'payment_created'
+            | 'invoice_submitted'
+            | 'payment_completed'
+            | 'review_received'
+            | 'message'
           title?: string
           body?: string | null
           is_read?: boolean

--- a/talentify-next-frontend/types/ui.ts
+++ b/talentify-next-frontend/types/ui.ts
@@ -1,4 +1,12 @@
-export type NotificationType = 'message' | 'offer' | 'schedule' | 'system'
+export type NotificationType =
+  | 'offer_created'
+  | 'review_received'
+  | 'payment_completed'
+  | 'schedule_confirmed'
+  | 'message'
+  | 'offer'
+  | 'schedule'
+  | 'system'
 
 export type TaskType = 'respond_offer' | 'update_profile' | 'check_message'
 
@@ -7,6 +15,7 @@ export interface Notification {
   type: NotificationType
   title: string
   body: string
+  data?: Record<string, any>
   created_at: string
   is_read: boolean
 }

--- a/talentify-next-frontend/utils/notifications.ts
+++ b/talentify-next-frontend/utils/notifications.ts
@@ -8,20 +8,27 @@ export type NotificationRow = Database['public']['Tables']['notifications']['Row
 export type NotificationInsert = Database['public']['Tables']['notifications']['Insert']
 
 export async function getNotifications(limit?: number): Promise<NotificationRow[]> {
-  const { data: { user } } = await supabase.auth.getUser()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  console.log('session uid=', user?.id)
   if (!user) return []
+
   let query = supabase
     .from('notifications')
     .select('*')
     .eq('user_id', user.id)
+    .in('type', ['offer_created', 'review_received'])
     .order('created_at', { ascending: false })
+
   if (limit) query = query.limit(limit)
+
   const { data, error } = await query
   if (error) {
     console.error('failed to fetch notifications', error)
     return []
   }
-  return data as NotificationRow[]
+  return (data ?? []) as NotificationRow[]
 }
 
 export async function markNotificationRead(id: string) {


### PR DESCRIPTION
## Summary
- ensure notification query includes offer_created and review_received types
- extend notification types and add review renderer with fallback
- add unit test for notification retrieval

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68998d577d788332bf86d30c7e513f9f