### PR TITLE
feat: add review received notification api

### DIFF
--- a/talentify-next-frontend/app/api/notifications/review-received/route.ts
+++ b/talentify-next-frontend/app/api/notifications/review-received/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/supabase/service'
+
+export const runtime = 'nodejs'
+
+export async function POST(req: NextRequest) {
+  try {
+    const { offerId, reviewId, recipientUserId } = await req.json()
+
+    if (!offerId || !reviewId || !recipientUserId) {
+      return NextResponse.json({ error: 'missing fields' }, { status: 400 })
+    }
+
+    const supabase = createServiceClient()
+    const { error } = await supabase.from('notifications').insert({
+      user_id: recipientUserId,
+      type: 'review_received',
+      data: { offer_id: offerId, review_id: reviewId },
+    })
+    if (error) return NextResponse.json({ error }, { status: 400 })
+
+    return NextResponse.json({ ok: true })
+  } catch (e) {
+    return NextResponse.json({ error: String(e) }, { status: 500 })
+  }
+}

--- a/talentify-next-frontend/lib/supabase/service.ts
+++ b/talentify-next-frontend/lib/supabase/service.ts
@@ -1,0 +1,17 @@
+export const runtime = 'nodejs'
+
+import { createClient } from '@supabase/supabase-js'
+import type { Database } from '@/types/supabase'
+
+export function createServiceClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceKey = process.env.SUPABASE_SERVICE_KEY
+
+  if (!url || !serviceKey) {
+    throw new Error('Supabase environment variables are not set')
+  }
+
+  return createClient<Database>(url, serviceKey)
+}
+
+export type { Database }


### PR DESCRIPTION
## Summary
- add server-side API to create `review_received` notifications
- create service-role Supabase client for server APIs
- trigger notification API after posting a review

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899996f5e84833297d7152b422d37dd