### PR TITLE
fix: handle single genre field on talent search

### DIFF
--- a/talentify-next-frontend/app/search/calendar/page.tsx
+++ b/talentify-next-frontend/app/search/calendar/page.tsx
@@ -10,7 +10,7 @@ const SAMPLE_TALENTS: Talent[] = [
   {
     id: '1',
     stage_name: '山田 花子',
-    genres: ['バラエティ'],
+    genre: 'バラエティ',
     gender: '女性',
     age_group: '20代',
     location: '東京',
@@ -20,7 +20,7 @@ const SAMPLE_TALENTS: Talent[] = [
   {
     id: '2',
     stage_name: '田中 太郎',
-    genres: ['スロット専門'],
+    genre: 'スロット専門',
     gender: '男性',
     age_group: '30代',
     location: '大阪',
@@ -40,7 +40,7 @@ export default function CalendarSearchPage() {
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault()
     const filtered = SAMPLE_TALENTS.filter(
-      t => (!area || t.location === area) && (!genre || t.genres.includes(genre))
+      t => (!area || t.location === area) && (!genre || t.genre === genre)
     )
     setResults(filtered)
   }

--- a/talentify-next-frontend/app/talent/edit/EditClient.tsx
+++ b/talentify-next-frontend/app/talent/edit/EditClient.tsx
@@ -9,7 +9,7 @@ const prefectures = [
   '北海道','青森県','岩手県','宮城県','秋田県','山形県','福島県','茨城県','栃木県','群馬県','埼玉県','千葉県','東京都','神奈川県','新潟県','富山県','石川県','福井県','山梨県','長野県','岐阜県','静岡県','愛知県','三重県','滋賀県','京都府','大阪府','兵庫県','奈良県','和歌山県','鳥取県','島根県','岡山県','広島県','山口県','徳島県','香川県','愛媛県','高知県','福岡県','佐賀県','長崎県','熊本県','大分県','宮崎県','鹿児島県','沖縄県'
 ]
 
-const genres = ['ライター','アイドル','コスプレ','モデル','その他']
+const GENRE_OPTIONS = ['ライター','アイドル','コスプレ','モデル','その他']
 const minHourOptions = ['1時間','2時間','3時間以上']
 
 const supabase = createClient()
@@ -287,7 +287,7 @@ export default function TalentProfileEditPageClient({ code }: { code?: string | 
             className="w-full p-2 border rounded"
           >
             <option value="">選択してください</option>
-            {genres.map(g => (
+            {GENRE_OPTIONS.map(g => (
               <option key={g} value={g}>
                 {g}
               </option>

--- a/talentify-next-frontend/components/talent-search/TalentCard.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentCard.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card'
 export type Talent = {
   id: string
   stage_name: string
-  genres: string[] | null
+  genre: string | null
   gender: string | null
   age_group: string | null
   location: string | null
@@ -33,10 +33,10 @@ export default function TalentCard({ talent }: { talent: Talent }) {
         <div className="text-lg font-semibold">{talent.stage_name}</div>
       </CardHeader>
       <CardContent className="text-sm space-y-1">
-        {(talent.genres?.length || talent.location) && (
+        {(talent.genre || talent.location) && (
           <p className="text-gray-600">
-            {talent.genres?.join('・')}
-            {talent.genres?.length && talent.location ? '・' : ''}
+            {talent.genre}
+            {talent.genre && talent.location ? '・' : ''}
             {talent.location}
           </p>
         )}

--- a/talentify-next-frontend/components/talent-search/TalentSearchPage.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentSearchPage.tsx
@@ -9,7 +9,7 @@ import TalentList from './TalentList'
 type TalentLite = {
   id: string
   stage_name: string
-  genres: string[] | null
+  genre: string | null
   gender: string | null
   age_group: string | null
   location: string | null
@@ -30,7 +30,7 @@ export default function TalentSearchPage() {
       const supabase = createClient() as SupabaseClient<any>
       const { data, error } = await supabase
         .from('talents')
-        .select('id, stage_name, genres, gender, age_group, location, comment, avatar_url')
+        .select('id, stage_name, genre, gender, age_group, location, comment, avatar_url')
         .eq('is_public', true)
         .returns<TalentLite[]>()
 
@@ -55,7 +55,7 @@ export default function TalentSearchPage() {
       (!f.keyword ||
         t.stage_name.toLowerCase().includes(keyword) ||
         (t.comment ? t.comment.toLowerCase().includes(keyword) : false)) &&
-      (!f.genre || (Array.isArray(t.genres) && t.genres.includes(f.genre))) &&
+      (!f.genre || t.genre === f.genre) &&
       (!f.gender || t.gender === f.gender) &&
       (!f.age || t.age_group === f.age) &&
       (!f.location || t.location === f.location)


### PR DESCRIPTION
## Summary
- support single `genre` column by adjusting talent search query and card display
- update calendar search sample data and filters for single genre

## Testing
- `npm test`
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a9f2e1c288332bda8e9bba1acec15