### PR TITLE
refactor: search talents via public profile view

### DIFF
--- a/talentify-next-frontend/app/search/calendar/page.tsx
+++ b/talentify-next-frontend/app/search/calendar/page.tsx
@@ -4,28 +4,26 @@ import { useState } from 'react'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import TalentList from '@/components/talent-search/TalentList'
-import { Talent } from '@/components/talent-search/TalentCard'
+import type { PublicTalent } from '@/components/talent-search/TalentCard'
 
-const SAMPLE_TALENTS: Talent[] = [
+const SAMPLE_TALENTS: PublicTalent[] = [
   {
-    id: '1',
     stage_name: '山田 花子',
     genre: 'バラエティ',
-    gender: '女性',
-    age_group: '20代',
-    location: '東京',
-    comment: '元気いっぱいの女性演者です。',
+    area: '東京',
     avatar_url: '/avatar-default.svg',
+    rating: null,
+    rate: null,
+    bio: '元気いっぱいの女性演者です。',
   },
   {
-    id: '2',
     stage_name: '田中 太郎',
     genre: 'スロット専門',
-    gender: '男性',
-    age_group: '30代',
-    location: '大阪',
-    comment: 'スロットならお任せください。',
+    area: '大阪',
     avatar_url: '/avatar-default.svg',
+    rating: null,
+    rate: null,
+    bio: 'スロットならお任せください。',
   },
 ]
 
@@ -35,12 +33,12 @@ export default function CalendarSearchPage() {
   const [end, setEnd] = useState('')
   const [area, setArea] = useState('')
   const [genre, setGenre] = useState('')
-  const [results, setResults] = useState<Talent[]>(SAMPLE_TALENTS)
+  const [results, setResults] = useState<PublicTalent[]>(SAMPLE_TALENTS)
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault()
     const filtered = SAMPLE_TALENTS.filter(
-      t => (!area || t.location === area) && (!genre || t.genre === genre)
+      t => (!area || t.area === area) && (!genre || t.genre === genre)
     )
     setResults(filtered)
   }

--- a/talentify-next-frontend/components/talent-search/TalentCard.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentCard.tsx
@@ -1,21 +1,18 @@
 import Image from 'next/image'
-import Link from 'next/link'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
 
-// Public talent information used on the search page
-export type Talent = {
-  id: string
-  stage_name: string
+export type PublicTalent = {
+  stage_name: string | null
   genre: string | null
-  gender: string | null
-  age_group: string | null
-  location: string | null
-  comment: string | null
+  area: string | null
   avatar_url: string | null
+  rating: number | null
+  rate: number | null
+  bio: string | null
+  display_name?: string | null
 }
 
-export default function TalentCard({ talent }: { talent: Talent }) {
+export default function TalentCard({ talent }: { talent: PublicTalent }) {
   return (
     <Card className="flex flex-col transition-transform hover:shadow-md hover:scale-[1.02]">
       <CardHeader className="flex items-center gap-3">
@@ -23,7 +20,7 @@ export default function TalentCard({ talent }: { talent: Talent }) {
           {talent.avatar_url && (
             <Image
               src={talent.avatar_url}
-              alt={talent.stage_name}
+              alt={talent.stage_name ?? ''}
               width={64}
               height={64}
               className="object-cover w-full h-full"
@@ -33,25 +30,21 @@ export default function TalentCard({ talent }: { talent: Talent }) {
         <div className="text-lg font-semibold">{talent.stage_name}</div>
       </CardHeader>
       <CardContent className="text-sm space-y-1">
-        {(talent.genre || talent.location) && (
+        {(talent.genre || talent.area) && (
           <p className="text-gray-600">
             {talent.genre}
-            {talent.genre && talent.location ? '・' : ''}
-            {talent.location}
+            {talent.genre && talent.area ? '・' : ''}
+            {talent.area}
           </p>
         )}
-        {(talent.gender || talent.age_group) && (
-          <p className="text-gray-600">
-            {[talent.gender, talent.age_group].filter(Boolean).join('・')}
-          </p>
+        {talent.rating != null && (
+          <p className="text-gray-600">評価: {talent.rating}</p>
         )}
-        {talent.comment && <p className="line-clamp-2">{talent.comment}</p>}
+        {talent.rate != null && (
+          <p className="text-gray-600">料金: {talent.rate}</p>
+        )}
+        {talent.bio && <p className="line-clamp-2">{talent.bio}</p>}
       </CardContent>
-      <CardFooter className="mt-auto">
-        <Button asChild variant="outline" className="w-full">
-          <Link href={`/talents/${talent.id}`}>詳細を見る</Link>
-        </Button>
-      </CardFooter>
     </Card>
   )
 }

--- a/talentify-next-frontend/components/talent-search/TalentList.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentList.tsx
@@ -1,20 +1,20 @@
-import TalentCard, { Talent } from './TalentCard'
+import TalentCard, { PublicTalent } from './TalentCard'
 
-export default function TalentList({ talents, error }: { talents: Talent[]; error?: boolean }) {
+export default function TalentList({ talents, error }: { talents: PublicTalent[]; error?: boolean }) {
   if (error) {
-    return <p className="p-4">キャストを取得できませんでした。</p>
+    return <p className="p-4">取得に失敗しました</p>
   }
 
   if (talents.length === 0) {
-    return <p className="p-4">該当するキャストが見つかりませんでした。</p>
+    return <p className="p-4">検索条件に一致するキャストがいません</p>
   }
 
   return (
     <>
       <p className="mb-4 text-sm text-gray-700">検索結果：{talents.length}件</p>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {talents.map(t => (
-          <TalentCard key={t.id} talent={t} />
+        {talents.map((t, idx) => (
+          <TalentCard key={t.stage_name ?? idx} talent={t} />
         ))}
       </div>
     </>

--- a/talentify-next-frontend/components/talent-search/TalentSearchForm.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentSearchForm.tsx
@@ -6,30 +6,24 @@ import { Button } from '@/components/ui/button'
 export type SearchFilters = {
   keyword: string
   genre: string
-  gender: string
-  age: string
-  location: string
+  area: string
 }
 
 const GENRES = ['バラエティ', 'アイドル', 'お笑い', 'レポーター']
-const GENDERS = ['男性', '女性', 'その他']
-const AGES = ['10代', '20代', '30代', '40代', '50代以上']
-const LOCATIONS = ['東京', '大阪', '福岡', '北海道']
+const AREAS = ['東京', '大阪', '福岡', '北海道']
 
 export default function TalentSearchForm({ onSearch }: { onSearch: (f: SearchFilters) => void }) {
   const [keyword, setKeyword] = useState('')
   const [genre, setGenre] = useState('')
-  const [gender, setGender] = useState('')
-  const [age, setAge] = useState('')
-  const [location, setLocation] = useState('')
+  const [area, setArea] = useState('')
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    onSearch({ keyword, genre, gender, age, location })
+    onSearch({ keyword, genre, area })
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-2 md:grid md:grid-cols-5 md:gap-3 md:space-y-0">
+    <form onSubmit={handleSubmit} className="space-y-2 md:grid md:grid-cols-3 md:gap-3 md:space-y-0">
       <Input
         placeholder="キーワード"
         value={keyword}
@@ -42,25 +36,13 @@ export default function TalentSearchForm({ onSearch }: { onSearch: (f: SearchFil
           <option key={g} value={g}>{g}</option>
         ))}
       </select>
-      <select value={gender} onChange={e => setGender(e.target.value)} className="h-9 rounded-md border px-2 md:col-span-1">
-        <option value="">性別</option>
-        {GENDERS.map(g => (
-          <option key={g} value={g}>{g}</option>
-        ))}
-      </select>
-      <select value={age} onChange={e => setAge(e.target.value)} className="h-9 rounded-md border px-2 md:col-span-1">
-        <option value="">年齢層</option>
-        {AGES.map(a => (
+      <select value={area} onChange={e => setArea(e.target.value)} className="h-9 rounded-md border px-2 md:col-span-1">
+        <option value="">居住地</option>
+        {AREAS.map(a => (
           <option key={a} value={a}>{a}</option>
         ))}
       </select>
-      <select value={location} onChange={e => setLocation(e.target.value)} className="h-9 rounded-md border px-2 md:col-span-1">
-        <option value="">居住地</option>
-        {LOCATIONS.map(l => (
-          <option key={l} value={l}>{l}</option>
-        ))}
-      </select>
-      <div className="md:col-span-5 text-right">
+      <div className="md:col-span-3 text-right">
         <Button type="submit">検索</Button>
       </div>
     </form>

--- a/talentify-next-frontend/components/talent-search/TalentSearchPage.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentSearchPage.tsx
@@ -1,27 +1,27 @@
 "use client"
 
 import { useEffect, useState } from 'react'
-import { createClient } from '@/utils/supabase/client' // あなたのSupabaseラッパー
+import { createClient } from '@/utils/supabase/client'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import TalentSearchForm, { SearchFilters } from './TalentSearchForm'
 import TalentList from './TalentList'
 
-type TalentLite = {
-  id: string
-  stage_name: string
+type PublicTalent = {
+  stage_name: string | null
   genre: string | null
-  gender: string | null
-  age_group: string | null
-  location: string | null
-  comment: string | null
+  area: string | null
   avatar_url: string | null
+  rating: number | null
+  rate: number | null
+  bio: string | null
+  display_name?: string | null
 }
 
 const ITEMS_PER_PAGE = 6
 
 export default function TalentSearchPage() {
-  const [talents, setTalents] = useState<TalentLite[]>([])
-  const [results, setResults] = useState<TalentLite[]>([])
+  const [talents, setTalents] = useState<PublicTalent[]>([])
+  const [results, setResults] = useState<PublicTalent[]>([])
   const [page, setPage] = useState(1)
   const [fetchError, setFetchError] = useState(false)
 
@@ -29,10 +29,11 @@ export default function TalentSearchPage() {
     const fetchTalents = async () => {
       const supabase = createClient() as SupabaseClient<any>
       const { data, error } = await supabase
-        .from('talents')
-        .select('id, stage_name, genre, gender, age_group, location, comment, avatar_url')
-        .eq('is_public', true)
-        .returns<TalentLite[]>()
+        .from('public_talent_profiles')
+        .select(
+          'stage_name, genre, area, avatar_url, rating, rate, bio, display_name'
+        )
+        .returns<PublicTalent[]>()
 
       if (error) {
         console.error('タレントの取得に失敗しました:', error)
@@ -53,12 +54,10 @@ export default function TalentSearchPage() {
     const keyword = f.keyword.toLowerCase()
     const filtered = talents.filter(t =>
       (!f.keyword ||
-        t.stage_name.toLowerCase().includes(keyword) ||
-        (t.comment ? t.comment.toLowerCase().includes(keyword) : false)) &&
+        t.stage_name?.toLowerCase().includes(keyword) ||
+        t.bio?.toLowerCase().includes(keyword)) &&
       (!f.genre || t.genre === f.genre) &&
-      (!f.gender || t.gender === f.gender) &&
-      (!f.age || t.age_group === f.age) &&
-      (!f.location || t.location === f.location)
+      (!f.area || t.area === f.area)
     )
     setResults(filtered)
     setPage(1)


### PR DESCRIPTION
## Summary
- query `public_talent_profiles` for public talent search with explicit columns
- simplify search filters to keyword, genre and area using `PublicTalent` type
- streamline TalentCard display without gender or age and show rating, rate and bio

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689aa4b5a190833282fcc8786682cfa2