### PR TITLE
feat: compute profile completeness

### DIFF
--- a/talentify-next-frontend/__tests__/isProfileComplete.test.ts
+++ b/talentify-next-frontend/__tests__/isProfileComplete.test.ts
@@ -1,0 +1,40 @@
+import { isProfileComplete } from '../utils/isProfileComplete'
+
+describe('isProfileComplete', () => {
+  test('returns true when all MVP conditions are met', () => {
+    const profile = {
+      stage_name: 'Test',
+      genre: 'Rock',
+      area: ['Tokyo'],
+      rate: 5000,
+      profile: 'This is a sufficiently long profile text.',
+      avatar_url: 'http://example.com/avatar.png',
+    }
+    expect(isProfileComplete(profile)).toBe(true)
+  })
+
+  test('returns false when required fields are missing', () => {
+    const profile = {
+      stage_name: 'Test',
+      genre: 'Rock',
+      area: [],
+      rate: 0,
+      profile: 'short',
+      avatar_url: '',
+    }
+    expect(isProfileComplete(profile)).toBe(false)
+  })
+
+  test('uses bio when profile is short', () => {
+    const profile = {
+      stage_name: 'Test',
+      genre: 'Rock',
+      area: ['Tokyo'],
+      rate: 5000,
+      bio: 'This bio is long enough to satisfy the condition.',
+      profile: 'short',
+      avatar_url: 'http://example.com/avatar.png',
+    }
+    expect(isProfileComplete(profile)).toBe(true)
+  })
+})

--- a/talentify-next-frontend/app/api/talents/[id]/route.ts
+++ b/talentify-next-frontend/app/api/talents/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { isProfileComplete } from '@/utils/isProfileComplete'
 
 export async function GET(
   req: NextRequest,
@@ -79,7 +80,20 @@ export async function PUT(
     location,
     rate,
     availability,
+    stage_name,
+    genre,
+    bio,
   } = body
+
+  const isComplete = isProfileComplete({
+    stage_name,
+    genre,
+    area,
+    rate,
+    bio,
+    profile,
+    avatar_url,
+  })
 
   const { error } = await supabase
     .from('talents')
@@ -95,6 +109,10 @@ export async function PUT(
       location,
       rate,
       availability,
+      stage_name,
+      genre,
+      bio,
+      is_profile_complete: isComplete,
     })
     .eq('id', id)
 

--- a/talentify-next-frontend/app/api/talents/route.ts
+++ b/talentify-next-frontend/app/api/talents/route.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@/lib/supabase/server'
+import { isProfileComplete } from '@/utils/isProfileComplete'
 
 export async function GET() {
   const supabase = await createClient()
@@ -35,7 +36,20 @@ export async function POST(req: Request) {
     location = '',
     rate = 0,
     availability = '',
+    stage_name,
+    genre,
+    bio = '',
   } = body
+
+  const isComplete = isProfileComplete({
+    stage_name,
+    genre,
+    area,
+    rate,
+    bio,
+    profile,
+    avatar_url,
+  })
 
   const { data, error } = await supabase
     .from('talents')
@@ -51,6 +65,10 @@ export async function POST(req: Request) {
         location,
         rate,
         availability,
+        stage_name,
+        genre,
+        bio,
+        is_profile_complete: isComplete,
       },
     ])
     .select()

--- a/talentify-next-frontend/app/talent/edit/EditClient.tsx
+++ b/talentify-next-frontend/app/talent/edit/EditClient.tsx
@@ -4,6 +4,7 @@
 import { useEffect, useState, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import { createClient } from '@/utils/supabase/client'
+import { isProfileComplete } from '@/utils/isProfileComplete'
 
 const prefectures = [
   '北海道','青森県','岩手県','宮城県','秋田県','山形県','福島県','茨城県','栃木県','群馬県','埼玉県','千葉県','東京都','神奈川県','新潟県','富山県','石川県','福井県','山梨県','長野県','岐阜県','静岡県','愛知県','三重県','滋賀県','京都府','大阪府','兵庫県','奈良県','和歌山県','鳥取県','島根県','岡山県','広島県','山口県','徳島県','香川県','愛媛県','高知県','福岡県','佐賀県','長崎県','熊本県','大分県','宮崎県','鹿児島県','沖縄県'
@@ -162,6 +163,15 @@ export default function TalentProfileEditPageClient({ code }: { code?: string | 
       return
     }
 
+    const isComplete = isProfileComplete({
+      stage_name: profile.stage_name,
+      genre: profile.genre,
+      area: profile.area,
+      rate: profile.rate === '' ? 0 : Number(profile.rate),
+      profile: profile.description,
+      avatar_url: profile.avatar_url,
+    })
+
     const updateData = {
       name: profile.name,
       stage_name: profile.stage_name,
@@ -182,6 +192,7 @@ export default function TalentProfileEditPageClient({ code }: { code?: string | 
       ...(profile.instagramUrl && { instagram_url: profile.instagramUrl }),
       ...(profile.youtubeUrl && { youtube_url: profile.youtubeUrl }),
       is_setup_complete: true,
+      is_profile_complete: isComplete,
     }
 
     // Debug log before sending

--- a/talentify-next-frontend/utils/isProfileComplete.ts
+++ b/talentify-next-frontend/utils/isProfileComplete.ts
@@ -1,0 +1,29 @@
+export interface TalentProfile {
+  stage_name?: string | null
+  genre?: string | null
+  area?: string[] | string | null
+  rate?: number | null
+  bio?: string | null
+  profile?: string | null
+  avatar_url?: string | null
+}
+
+export function isProfileComplete(profile: TalentProfile): boolean {
+  const hasStageName = !!profile.stage_name && profile.stage_name.trim().length > 0
+  const hasGenre = !!profile.genre && profile.genre.trim().length > 0
+
+  const area = profile.area
+  const hasArea = Array.isArray(area)
+    ? area.length > 0
+    : !!area && area.trim().length > 0 && area !== '[]'
+
+  const hasRate = typeof profile.rate === 'number' && profile.rate > 0
+
+  const bioLen = profile.bio ? profile.bio.trim().length : 0
+  const profileLen = profile.profile ? profile.profile.trim().length : 0
+  const hasBioOrProfile = bioLen >= 20 || profileLen >= 20
+
+  const hasAvatar = !!profile.avatar_url && profile.avatar_url.trim().length > 0
+
+  return hasStageName && hasGenre && hasArea && hasRate && hasBioOrProfile && hasAvatar
+}


### PR DESCRIPTION
## Summary
- compute profile completeness and set `is_profile_complete` on talent updates
- add server and client hooks to use completeness check
- cover profile completeness rules with Jest tests

## Testing
- `cd talentify-next-frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689aa9e8a4d08332888b81bdcd666566