### PR TITLE
feat: provision talent/store profiles on first edit

### DIFF
--- a/talentify-next-frontend/app/api/talents/[id]/route.ts
+++ b/talentify-next-frontend/app/api/talents/[id]/route.ts
@@ -70,9 +70,8 @@ export async function PUT(
 
   const {
     name,
-    email,
     profile,
-    sns_links,
+    social_links,
     area,
     skills,
     experience_years,
@@ -99,10 +98,9 @@ export async function PUT(
     .from('talents')
     .update({
       name,
-      email,
       profile,
-      sns_links,
-    area,
+      social_links,
+      area,
       skills,
       experience_years,
       avatar_url,

--- a/talentify-next-frontend/app/api/talents/route.ts
+++ b/talentify-next-frontend/app/api/talents/route.ts
@@ -28,7 +28,7 @@ export async function POST(req: Request) {
   const {
     name,
     profile,
-    sns_links,
+    social_links = [],
     area,
     skills = [],
     experience_years = 0,
@@ -51,26 +51,36 @@ export async function POST(req: Request) {
     avatar_url,
   })
 
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return new Response(JSON.stringify({ error: 'unauthenticated' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
   const { data, error } = await supabase
     .from('talents')
-    .insert([
-      {
-        name,
-        profile,
-        sns_links,
-        area,
-        skills,
-        experience_years,
-        avatar_url,
-        location,
-        rate,
-        availability,
-        stage_name,
-        genre,
-        bio,
-        is_profile_complete: isComplete,
-      },
-    ])
+    .insert({
+      user_id: user.id,
+      name,
+      profile,
+      social_links,
+      area,
+      skills,
+      experience_years,
+      avatar_url,
+      location,
+      rate,
+      availability,
+      stage_name,
+      genre,
+      bio,
+      is_profile_complete: isComplete,
+    })
     .select()
 
   if (error) {

--- a/talentify-next-frontend/app/store/edit/EditClient.tsx
+++ b/talentify-next-frontend/app/store/edit/EditClient.tsx
@@ -1,0 +1,164 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { createClient } from '@/utils/supabase/client'
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Button } from "@/components/ui/button"
+
+const supabase = createClient()
+
+export default function StoreProfileEditPage() {
+  const router = useRouter()
+  const [loading, setLoading] = useState(true)
+  const [isNew, setIsNew] = useState(false)
+  const [profile, setProfile] = useState({
+    store_name: '',
+    bio: '',
+    avatar_url: ''
+  })
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [showIncomplete, setShowIncomplete] = useState(false)
+
+  useEffect(() => {
+    const loadProfile = async () => {
+      const {
+        data: { user },
+        error: authError,
+      } = await supabase.auth.getUser()
+      if (authError || !user) {
+        console.error('ユーザー取得失敗:', authError)
+        setErrorMessage('ユーザー情報の取得に失敗しました')
+        setLoading(false)
+        return
+      }
+
+      const { data, error } = await supabase
+        .from('stores')
+        .select('store_name, bio, avatar_url, is_setup_complete')
+        .eq('user_id', user.id)
+        .maybeSingle()
+
+      if (error) {
+        console.error('プロフィール読み込みエラー:', {
+          message: error?.message,
+          details: error?.details,
+          hint: error?.hint,
+        })
+        setErrorMessage('プロフィールの取得に失敗しました')
+      }
+
+      if (data) {
+        setProfile({
+          store_name: data.store_name ?? '',
+          bio: data.bio ?? '',
+          avatar_url: data.avatar_url ?? '',
+        })
+        setIsNew(false)
+        setShowIncomplete(!data.is_setup_complete)
+      } else {
+        setIsNew(true)
+        setShowIncomplete(true)
+      }
+      setLoading(false)
+    }
+
+    loadProfile()
+  }, [])
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setProfile({ ...profile, [e.target.name]: e.target.value })
+  }
+
+  const handleSave = async () => {
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+    if (authError || !user) {
+      console.error('ユーザー取得失敗:', authError)
+      setErrorMessage('ユーザー情報の取得に失敗しました')
+      return
+    }
+
+    if (!profile.store_name.trim()) {
+      setErrorMessage('店舗名（表示名）は必須です')
+      return
+    }
+
+    console.log('📝 保存データ（送信前）:', {
+      ...profile,
+      user_id: user.id,
+    })
+
+    const updateData = {
+      store_name: profile.store_name,
+      bio: profile.bio || null,
+      avatar_url: profile.avatar_url || null,
+      user_id: user.id,
+      is_setup_complete: true,
+    }
+
+    const { error } = await supabase
+      .from('stores')
+      .upsert(updateData, { onConflict: 'user_id' })
+
+    if (error) {
+      console.error('🔥 Supabase更新エラー:', {
+        message: error.message,
+        details: error.details,
+        hint: error.hint,
+        code: error.code,
+      })
+      setErrorMessage(`保存に失敗しました: ${error.message}`)
+      if (
+        error.message.toLowerCase().includes('row level security') ||
+        error.message.toLowerCase().includes('permission')
+      ) {
+        console.warn('RLS policy may prevent inserting/updating stores')
+      }
+    } else {
+      console.log('✅ プロフィール保存成功')
+      setShowIncomplete(false)
+      if (isNew) {
+        router.push('/store/edit/complete')
+      } else {
+        router.push('/dashboard?saved=1')
+      }
+    }
+  }
+
+  if (loading) return <p className="p-4">読み込み中...</p>
+
+  return (
+    <main className="max-w-2xl mx-auto p-6 space-y-6">
+      {errorMessage && <p className="text-red-500 text-sm">{errorMessage}</p>}
+      {showIncomplete && !errorMessage && (
+        <div className="rounded bg-yellow-100 p-2 text-yellow-800">
+          プロフィールが未完成です
+        </div>
+      )}
+      <h1 className="text-2xl font-bold">店舗プロフィール編集</h1>
+
+      <div className="space-y-4">
+        <div>
+          <label className="block font-medium">店舗名（表示名）</label>
+          <Input name="store_name" value={profile.store_name} onChange={handleChange} />
+        </div>
+
+        <div>
+          <label className="block font-medium">自己紹介</label>
+          <Textarea name="bio" value={profile.bio} onChange={handleChange} rows={4} />
+        </div>
+
+        <div>
+          <label className="block font-medium">アバター画像URL</label>
+          <Input name="avatar_url" value={profile.avatar_url} onChange={handleChange} type="url" />
+        </div>
+
+        <Button onClick={handleSave} className="mt-4">保存する</Button>
+      </div>
+    </main>
+  )
+}

--- a/talentify-next-frontend/app/store/edit/page.tsx
+++ b/talentify-next-frontend/app/store/edit/page.tsx
@@ -1,146 +1,21 @@
-'use client'
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import EditClient from './EditClient'
+import { ensureStoreProfile } from '@/lib/provision'
 
-import { useEffect, useState } from 'react'
-import { useRouter } from 'next/navigation'
-import { createClient } from '@/utils/supabase/client'
-import { Input } from "@/components/ui/input"
-import { Textarea } from "@/components/ui/textarea"
-import { Button } from "@/components/ui/button"
+export const dynamic = 'auto'
 
-const supabase = createClient()
+export default async function Page() {
+  const supabase = await createClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
 
-export default function StoreProfileEditPage() {
-  const router = useRouter()
-  const [loading, setLoading] = useState(true)
-  const [isNew, setIsNew] = useState(false)
-  const [profile, setProfile] = useState({
-    store_name: '',
-    bio: '',
-    avatar_url: ''
-  })
-
-  useEffect(() => {
-    const loadProfile = async () => {
-      const { data: { user }, error: authError } = await supabase.auth.getUser()
-      if (authError || !user) {
-        console.error("ユーザー取得失敗:", authError)
-        return
-      }
-
-      const { data, error } = await supabase
-        .from('stores')
-        .select('store_name, bio, avatar_url')
-        .eq('user_id', user.id)
-        .maybeSingle()
-
-      if (error) {
-        console.error("プロフィール読み込みエラー:", {
-          message: error?.message,
-          details: error?.details,
-          hint: error?.hint,
-        })
-      }
-
-      if (data) {
-        setProfile({
-          store_name: data.store_name ?? '',
-          bio: data.bio ?? '',
-          avatar_url: data.avatar_url ?? '',
-        })
-        setIsNew(false)
-      } else {
-        setIsNew(true)
-      }
-      setLoading(false)
-    }
-
-    loadProfile()
-  }, [])
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    setProfile({ ...profile, [e.target.name]: e.target.value })
+  if (!session) {
+    redirect('/login')
   }
 
-  const handleSave = async () => {
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) {
-    console.error("ユーザー取得失敗:", authError)
-    alert("ユーザー情報の取得に失敗しました")
-    return
-  }
+  await ensureStoreProfile(supabase, session.user.id)
 
-  if (!profile.store_name.trim()) {
-    alert('店舗名（表示名）は必須です')
-    return
-  }
-
-  // ✅ 保存前のログ
-  console.log("📝 保存データ（送信前）:", {
-    ...profile,
-    user_id: user.id,
-  })
-
-  const updateData = {
-    store_name: profile.store_name,
-    bio: profile.bio || null,
-    avatar_url: profile.avatar_url || null,
-    user_id: user.id,
-    is_setup_complete: true,
-  }
-
-  const { error } = await supabase
-    .from('stores')
-    .upsert(updateData, { onConflict: 'user_id' })
-
-  if (error) {
-    console.error("🔥 Supabase更新エラー:", {
-      message: error.message,
-      details: error.details,
-      hint: error.hint,
-      code: error.code,
-    })
-    alert(`保存に失敗しました: ${error.message}`)
-    if (
-      error.message.toLowerCase().includes('row level security') ||
-      error.message.toLowerCase().includes('permission')
-    ) {
-      console.warn('RLS policy may prevent inserting/updating stores')
-    }
-  } else {
-    // ✅ 成功ログ
-    console.log("✅ プロフィール保存成功")
-    if (isNew) {
-      router.push('/store/edit/complete')
-    } else {
-      router.push('/dashboard?saved=1')
-    }
-  }
-}
-
-  if (loading) return <p className="p-4">読み込み中...</p>
-
-  return (
-    <main className="max-w-2xl mx-auto p-6 space-y-6">
-      <h1 className="text-2xl font-bold">店舗プロフィール編集</h1>
-
-      <div className="space-y-4">
-        <div>
-          <label className="block font-medium">店舗名（表示名）</label>
-          <Input name="store_name" value={profile.store_name} onChange={handleChange} />
-        </div>
-
-        <div>
-          <label className="block font-medium">自己紹介</label>
-          <Textarea name="bio" value={profile.bio} onChange={handleChange} rows={4} />
-        </div>
-
-        <div>
-          <label className="block font-medium">アバター画像URL</label>
-          <Input name="avatar_url" value={profile.avatar_url} onChange={handleChange} type="url" />
-        </div>
-
-        <Button onClick={handleSave} className="mt-4">保存する</Button>
-      </div>
-    </main>
-  )
+  return <EditClient />
 }

--- a/talentify-next-frontend/app/talent/edit/page.tsx
+++ b/talentify-next-frontend/app/talent/edit/page.tsx
@@ -1,36 +1,21 @@
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import EditClient from './EditClient'
+import { ensureTalentProfile } from '@/lib/provision'
 
 export const dynamic = 'auto'
 
-export default async function Page({ searchParams }: { searchParams: { code?: string } }) {
+export default async function Page() {
   const supabase = await createClient()
   const {
     data: { session },
   } = await supabase.auth.getSession()
 
   if (!session) {
-    return <main className="p-4">ログインしてください</main>
+    redirect('/login')
   }
 
-  const code = searchParams.code ?? session.user.id
+  await ensureTalentProfile(supabase, session.user.id)
 
-  if (searchParams.code && searchParams.code !== session.user.id) {
-    redirect(`/talent/edit/${searchParams.code}`)
-  }
-
-  if (code) {
-    const { data, error } = await supabase
-      .from('talents')
-      .select('*')
-      .eq('id', code)
-      .maybeSingle()
-
-    if (error || !data) {
-      return <main className="p-4">このプロフィールは存在しません</main>
-    }
-  }
-
-  return <EditClient code={code} />
+  return <EditClient />
 }

--- a/talentify-next-frontend/lib/provision.ts
+++ b/talentify-next-frontend/lib/provision.ts
@@ -1,0 +1,76 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@/types/supabase'
+
+export async function ensureTalentProfile(
+  supabase: SupabaseClient<Database>,
+  userId: string
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from('talents')
+    .select('id')
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  if (error && error.code !== 'PGRST116') {
+    console.error('failed to load talent profile', error)
+    return null
+  }
+
+  if (!data) {
+    const { data: inserted, error: insertError } = await supabase
+      .from('talents')
+      .insert({ user_id: userId, name: '' })
+      .select('id')
+      .maybeSingle()
+
+    if (insertError && insertError.code !== '23505') {
+      console.error('failed to provision talent profile', insertError)
+      return null
+    }
+
+    if (!insertError) {
+      console.info('provisioned talent profile', { user_id: userId })
+    }
+
+    return inserted?.id ?? null
+  }
+
+  return data.id
+}
+
+export async function ensureStoreProfile(
+  supabase: SupabaseClient<Database>,
+  userId: string
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from('stores')
+    .select('id')
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  if (error && error.code !== 'PGRST116') {
+    console.error('failed to load store profile', error)
+    return null
+  }
+
+  if (!data) {
+    const { data: inserted, error: insertError } = await supabase
+      .from('stores')
+      .insert({ user_id: userId, store_name: '' })
+      .select('id')
+      .maybeSingle()
+
+    if (insertError && insertError.code !== '23505') {
+      console.error('failed to provision store profile', insertError)
+      return null
+    }
+
+    if (!insertError) {
+      console.info('provisioned store profile', { user_id: userId })
+    }
+
+    return inserted?.id ?? null
+  }
+
+  return data.id
+}

--- a/talentify-next-frontend/supabase-docs/README.md
+++ b/talentify-next-frontend/supabase-docs/README.md
@@ -11,3 +11,9 @@ Codexはコード生成や修正時にこれらを参照してください。
 - [rls.md](./rls.md): Row Level Securityポリシー
 - [triggers.md](./triggers.md): トリガー定義
 - [functions.sql](./functions.sql): PL/pgSQL関数定義
+
+## プロビジョニングフロー
+
+- `/talent/edit` と `/store/edit` ではアクセス時に `user_id = auth.uid()` の行を `select … maybeSingle` で確認し、存在しない場合は初期値で `insert` します。
+- 重複によるユニーク制約エラーは無視し、初回のみ `provisioned <role> profile` をログ出力します。
+- 以後の `SELECT/INSERT/UPDATE` は RLS 前提で常に `user_id` 条件を付与してください。

--- a/talentify-next-frontend/supabase-docs/schema.md
+++ b/talentify-next-frontend/supabase-docs/schema.md
@@ -169,7 +169,6 @@ status が 'completed' の場合に支払い完了とみなし、その日時を
 - created_at: timestamp with time zone, DEFAULT now()
 - profile: text
 - area: text
-- sns_links: json
 - video_url: text
 - rating: numeric
 - user_id: uuid

--- a/talentify-next-frontend/types/supabase.ts
+++ b/talentify-next-frontend/types/supabase.ts
@@ -141,13 +141,14 @@ export type Database = {
           photos: string[] | null
           media_appearance: string | null
           id: string
+          user_id: string
           location: string | null
           name: string
           profile: string | null
           rate: number | null
           skills: string[] | null
           social_links: string[] | null
-          is_setup_complete: boolean | null
+          is_profile_complete: boolean | null
         }
         Insert: {
           area?: string | null
@@ -176,13 +177,14 @@ export type Database = {
           photos?: string[] | null
           media_appearance?: string | null
           id?: string
+          user_id: string
           location?: string | null
           name: string
           profile?: string | null
           rate?: number | null
           skills?: string[] | null
           social_links?: string[] | null
-          is_setup_complete?: boolean | null
+          is_profile_complete?: boolean | null
         }
         Update: {
           area?: string | null
@@ -211,13 +213,14 @@ export type Database = {
           photos?: string[] | null
           media_appearance?: string | null
           id?: string
+          user_id?: string
           location?: string | null
           name?: string
           profile?: string | null
           rate?: number | null
           skills?: string[] | null
           social_links?: string[] | null
-          is_setup_complete?: boolean | null
+          is_profile_complete?: boolean | null
         }
         Relationships: []
       },


### PR DESCRIPTION
## Summary
- ensure talent and store profiles are provisioned idempotently on first visit
- redirect unauthenticated users to `/login`
- surface incomplete profile banner and update Supabase types/docs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ad2382dbc8332b4f9075d160f59c8