### PR TITLE
fix: unify talent photo storage bucket

### DIFF
--- a/talentify-next-frontend/app/store/edit/EditClient.tsx
+++ b/talentify-next-frontend/app/store/edit/EditClient.tsx
@@ -10,7 +10,7 @@ import { toast } from 'sonner'
 
 const ALLOWED_TYPES = ['image/png', 'image/jpeg', 'image/webp'] as const
 const MAX_FILE_SIZE = 5 * 1024 * 1024
-const AVATAR_BUCKET = 'talent_photos'
+const AVATAR_BUCKET = 'talent-photos'
 
 const supabase = createClient()
 

--- a/talentify-next-frontend/app/talent/edit/EditClient.tsx
+++ b/talentify-next-frontend/app/talent/edit/EditClient.tsx
@@ -17,7 +17,7 @@ const minHourOptions = ['1時間','2時間','3時間以上']
 
 const ALLOWED_TYPES = ['image/png', 'image/jpeg', 'image/webp'] as const
 const MAX_FILE_SIZE = 5 * 1024 * 1024
-const AVATAR_BUCKET = 'talent_photos'
+const AVATAR_BUCKET = 'talent-photos'
 
 const supabase = createClient()
 
@@ -257,6 +257,10 @@ export default function TalentProfileEditPageClient({ code }: { code?: string | 
       let avatarUrl = profile.avatar_url
       if (avatarFile) {
         avatarUrl = await uploadImage(avatarFile, userId, 'avatar')
+        await supabase
+          .from('talents' as any)
+          .update({ avatar_url: avatarUrl })
+          .eq('user_id', userId);
         setProfile((p) => ({ ...p, avatar_url: avatarUrl }))
       }
 
@@ -301,7 +305,6 @@ export default function TalentProfileEditPageClient({ code }: { code?: string | 
         ...(profile.notes && { notes: profile.notes }),
         ...(profile.achievements && { media_appearance: profile.achievements }),
         ...(profile.video_url && { video_url: profile.video_url }),
-        ...(avatarUrl && { avatar_url: avatarUrl }),
         ...(photoUrls.length > 0 && { photos: photoUrls }),
         ...(profile.twitterUrl && { twitter_url: profile.twitterUrl }),
         ...(profile.instagramUrl && { instagram_url: profile.instagramUrl }),


### PR DESCRIPTION
## Summary
- use `talent-photos` storage bucket for avatar uploads
- persist uploaded avatar URLs to `talents.avatar_url`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ae9c5d3b48332ad27b9b0400495a7