### PR TITLE
Fix talent search cards navigation and avatar fallback

### DIFF
--- a/talentify-next-frontend/__tests__/talent-card.test.tsx
+++ b/talentify-next-frontend/__tests__/talent-card.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import TalentCard, { PublicTalent } from '@/components/talent-search/TalentCard'
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: any) => React.createElement('img', props),
+}))
+
+describe('TalentCard image handling', () => {
+  const baseTalent: PublicTalent = {
+    id: '1',
+    stage_name: 'Test',
+    genre: null,
+    area: null,
+    avatar_url: null,
+    rating: null,
+    rate: null,
+    bio: null,
+  }
+
+  it('uses placeholder when avatar_url is empty', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(TalentCard, { talent: { ...baseTalent, avatar_url: '' } })
+    )
+    expect(markup).toContain('/avatar-default.svg')
+  })
+
+  it('uses placeholder when avatar_url is invalid', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(TalentCard, {
+        talent: { ...baseTalent, avatar_url: 'invalid-url' },
+      })
+    )
+    expect(markup).toContain('/avatar-default.svg')
+  })
+
+  it('renders provided avatar_url when valid', () => {
+    const url = 'https://example.com/avatar.png'
+    const markup = renderToStaticMarkup(
+      React.createElement(TalentCard, {
+        talent: { ...baseTalent, avatar_url: url },
+      })
+    )
+    expect(markup).toContain(url)
+  })
+})

--- a/talentify-next-frontend/components/talent-search/TalentCard.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentCard.tsx
@@ -1,7 +1,9 @@
 import Image from 'next/image'
+import Link from 'next/link'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 
 export type PublicTalent = {
+  id: string
   stage_name: string | null
   genre: string | null
   area: string | null
@@ -13,38 +15,54 @@ export type PublicTalent = {
 }
 
 export default function TalentCard({ talent }: { talent: PublicTalent }) {
+  const isValidHttpUrl = (url: string) => {
+    try {
+      const parsed = new URL(url)
+      return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+    } catch {
+      return false
+    }
+  }
+
+  const imageSrc = talent.avatar_url && isValidHttpUrl(talent.avatar_url)
+    ? talent.avatar_url
+    : '/avatar-default.svg'
+
   return (
-    <Card className="flex flex-col transition-transform hover:shadow-md hover:scale-[1.02]">
-      <CardHeader className="flex items-center gap-3">
-        <div className="w-16 h-16 rounded-full overflow-hidden bg-gray-100">
-          {talent.avatar_url && (
+    <Link
+      href={`/talents/${talent.id}`}
+      className="block focus:outline-none focus:ring-2 focus:ring-offset-2"
+    >
+      <Card className="flex flex-col transition-transform hover:shadow-md hover:scale-[1.02]">
+        <CardHeader className="flex items-center gap-3">
+          <div className="w-16 h-16 rounded-full overflow-hidden bg-gray-100">
             <Image
-              src={talent.avatar_url}
-              alt={talent.stage_name ?? ''}
+              src={imageSrc}
+              alt={talent.stage_name ?? 'Avatar'}
               width={64}
               height={64}
               className="object-cover w-full h-full"
             />
+          </div>
+          <div className="text-lg font-semibold">{talent.stage_name}</div>
+        </CardHeader>
+        <CardContent className="text-sm space-y-1">
+          {(talent.genre || talent.area) && (
+            <p className="text-gray-600">
+              {talent.genre}
+              {talent.genre && talent.area ? '・' : ''}
+              {talent.area}
+            </p>
           )}
-        </div>
-        <div className="text-lg font-semibold">{talent.stage_name}</div>
-      </CardHeader>
-      <CardContent className="text-sm space-y-1">
-        {(talent.genre || talent.area) && (
-          <p className="text-gray-600">
-            {talent.genre}
-            {talent.genre && talent.area ? '・' : ''}
-            {talent.area}
-          </p>
-        )}
-        {talent.rating != null && (
-          <p className="text-gray-600">評価: {talent.rating}</p>
-        )}
-        {talent.rate != null && (
-          <p className="text-gray-600">料金: {talent.rate}</p>
-        )}
-        {talent.bio && <p className="line-clamp-2">{talent.bio}</p>}
-      </CardContent>
-    </Card>
+          {talent.rating != null && (
+            <p className="text-gray-600">評価: {talent.rating}</p>
+          )}
+          {talent.rate != null && (
+            <p className="text-gray-600">料金: {talent.rate}</p>
+          )}
+          {talent.bio && <p className="line-clamp-2">{talent.bio}</p>}
+        </CardContent>
+      </Card>
+    </Link>
   )
 }

--- a/talentify-next-frontend/components/talent-search/TalentList.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentList.tsx
@@ -13,8 +13,8 @@ export default function TalentList({ talents, error }: { talents: PublicTalent[]
     <>
       <p className="mb-4 text-sm text-gray-700">検索結果：{talents.length}件</p>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {talents.map((t, idx) => (
-          <TalentCard key={t.stage_name ?? idx} talent={t} />
+        {talents.map(t => (
+          <TalentCard key={t.id} talent={t} />
         ))}
       </div>
     </>

--- a/talentify-next-frontend/components/talent-search/TalentSearchPage.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentSearchPage.tsx
@@ -5,17 +5,7 @@ import { createClient } from '@/utils/supabase/client'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import TalentSearchForm, { SearchFilters } from './TalentSearchForm'
 import TalentList from './TalentList'
-
-type PublicTalent = {
-  stage_name: string | null
-  genre: string | null
-  area: string | null
-  avatar_url: string | null
-  rating: number | null
-  rate: number | null
-  bio: string | null
-  display_name?: string | null
-}
+import type { PublicTalent } from './TalentCard'
 
 const ITEMS_PER_PAGE = 6
 
@@ -31,7 +21,7 @@ export default function TalentSearchPage() {
       const { data, error } = await supabase
         .from('public_talent_profiles')
         .select(
-          'stage_name, genre, area, avatar_url, rating, rate, bio, display_name'
+          'id, stage_name, genre, area, avatar_url, rating, rate, bio, display_name'
         )
         .returns<PublicTalent[]>()
 

--- a/talentify-next-frontend/jest.config.js
+++ b/talentify-next-frontend/jest.config.js
@@ -5,5 +5,12 @@ module.exports = {
     '^@/(.*)$': '<rootDir>/$1',
     '^@utils/(.*)$': '<rootDir>/utils/$1',
     '^@types/(.*)$': '<rootDir>/types/$1'
+  },
+  globals: {
+    'ts-jest': {
+      tsconfig: {
+        jsx: 'react-jsx'
+      }
+    }
   }
 };

--- a/talentify-next-frontend/next.config.mjs
+++ b/talentify-next-frontend/next.config.mjs
@@ -1,7 +1,12 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ['example.com'], // ←ここに使用したい画像のドメインを追加
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '**.supabase.co',
+      },
+    ],
   },
 };
 


### PR DESCRIPTION
## Summary
- wrap search result cards with link to talent details
- sanitize talent avatar URLs and add placeholder image
- allow Supabase storage domains for next/image
- add tests for avatar fallback logic

## Testing
- `npm test`
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_689aefaf9a98833293ac095a71631231