### PR TITLE
Fix talent search ID alias and improve error handling

### DIFF
--- a/talentify-next-frontend/components/talent-search/TalentList.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentList.tsx
@@ -1,23 +1,19 @@
 import TalentCard from './TalentCard'
 import type { PublicTalent } from '@/types/talent'
 
-export default function TalentList({ talents, error }: { talents: PublicTalent[]; error?: boolean }) {
-  if (error) {
-    return <p className="p-4">取得に失敗しました</p>
-  }
-
-  if (talents.length === 0) {
-    return <p className="p-4">検索条件に一致するキャストがいません</p>
-  }
-
+export default function TalentList({ talents }: { talents: PublicTalent[] }) {
   return (
     <>
       <p className="mb-4 text-sm text-gray-700">検索結果：{talents.length}件</p>
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {talents.map(t => (
-          <TalentCard key={t.id} talent={t} />
-        ))}
-      </div>
+      {talents.length === 0 ? (
+        <p className="p-4">検索条件に一致するキャストがいません</p>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {talents.map(t => (
+            <TalentCard key={t.id} talent={t} />
+          ))}
+        </div>
+      )}
     </>
   )
 }

--- a/talentify-next-frontend/components/talent-search/TalentSearchPage.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentSearchPage.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { createClient } from '@/utils/supabase/client'
 import type { SupabaseClient } from '@supabase/supabase-js'
+import { toast } from 'sonner'
 import TalentSearchForm, { SearchFilters } from './TalentSearchForm'
 import TalentList from './TalentList'
 import type { PublicTalent } from '@/types/talent'
@@ -13,7 +14,6 @@ export default function TalentSearchPage() {
   const [talents, setTalents] = useState<PublicTalent[]>([])
   const [results, setResults] = useState<PublicTalent[]>([])
   const [page, setPage] = useState(1)
-  const [fetchError, setFetchError] = useState(false)
 
   useEffect(() => {
     const fetchTalents = async () => {
@@ -21,13 +21,13 @@ export default function TalentSearchPage() {
       const { data, error } = await supabase
         .from('public_talent_profiles')
         .select(
-          'id, stage_name, genre, area, avatar_url, rating, rate, bio, display_name'
+          'id:talent_id, stage_name, genre, area, avatar_url, rating, rate, bio, display_name'
         )
         .returns<PublicTalent[]>()
 
       if (error) {
         console.error('タレントの取得に失敗しました:', error)
-        setFetchError(true)
+        toast.error('タレントの取得に失敗しました')
         setTalents([])
         setResults([])
         return
@@ -59,7 +59,7 @@ export default function TalentSearchPage() {
   return (
     <main className="max-w-5xl mx-auto p-4 space-y-6">
       <TalentSearchForm onSearch={handleSearch} />
-      <TalentList talents={paginated} error={fetchError} />
+      <TalentList talents={paginated} />
       {totalPages > 1 && (
         <div className="flex justify-center mt-6">
           <nav className="flex space-x-2">


### PR DESCRIPTION
## Summary
- alias `talent_id` to `id` when fetching from `public_talent_profiles`
- show a toast and keep results empty on fetch failure
- update talent list to always show result count and handle empty lists gracefully

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689af6a73aa883329fa2003b2dc6f7fc