### PR TITLE
Fix talent profile id mapping and image fallback

### DIFF
--- a/talentify-next-frontend/app/talents/[id]/TalentDetailPageClient.tsx
+++ b/talentify-next-frontend/app/talents/[id]/TalentDetailPageClient.tsx
@@ -54,6 +54,20 @@ export default function TalentDetailPageClient({ id, initialTalent }: Props) {
   const [isAgreed, setIsAgreed] = useState(false)
   const [submitted, setSubmitted] = useState(false)
 
+  const isValidHttpUrl = (url: string) => {
+    try {
+      const parsed = new URL(url)
+      return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+    } catch {
+      return false
+    }
+  }
+
+  const imageSrc =
+    talent?.avatar_url && isValidHttpUrl(talent.avatar_url)
+      ? talent.avatar_url
+      : '/avatar-default.svg'
+
   useEffect(() => {
     const fetchData = async () => {
       if (!initialTalent) {
@@ -143,9 +157,9 @@ export default function TalentDetailPageClient({ id, initialTalent }: Props) {
       <Card>
         <CardContent className="flex flex-col sm:flex-row gap-4 items-start">
           <div className="w-full sm:w-48 h-48 rounded-lg overflow-hidden bg-gray-100 flex-shrink-0">
-            {talent.avatar_url && (
+            {talent && (
               <Image
-                src={talent.avatar_url}
+                src={imageSrc}
                 alt={talent.stage_name}
                 width={192}
                 height={192}

--- a/talentify-next-frontend/components/talent-search/TalentSearchPage.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentSearchPage.tsx
@@ -21,7 +21,7 @@ export default function TalentSearchPage() {
       const { data, error } = await supabase
         .from('public_talent_profiles')
         .select(
-          'id:talent_id, stage_name, genre, area, avatar_url, rating, rate, bio, display_name'
+          'id:id, stage_name, genre, area, avatar_url, rating, rate, bio, display_name'
         )
         .returns<PublicTalent[]>()
 

--- a/talentify-next-frontend/supabase-docs/schema.md
+++ b/talentify-next-frontend/supabase-docs/schema.md
@@ -106,6 +106,7 @@
 status が 'completed' の場合に支払い完了とみなし、その日時を `paid_at` に保存する。
 
 ### public_talent_profiles
+- id: uuid (talents.id)
 - display_name: text
 - stage_name: text
 - genre: text


### PR DESCRIPTION
## Summary
- fix search query to use existing id column
- document id column in `public_talent_profiles`
- add safe avatar fallback on talent detail page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689afa0aba988332a7fd5f31d9729d86