### PR TITLE
Centralize notification creation via server API

### DIFF
--- a/talentify-next-frontend/.env.example
+++ b/talentify-next-frontend/.env.example
@@ -6,3 +6,4 @@ NEXT_PUBLIC_API_BASE=
 # so that API calls like `/api/csrf-token` do not trigger CORS errors.
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 NOTIFICATION_WEBHOOK_URL=https://example.com/webhook
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key

--- a/talentify-next-frontend/.env.local.example
+++ b/talentify-next-frontend/.env.local.example
@@ -6,3 +6,4 @@ NEXT_PUBLIC_API_BASE=
 # so that API calls like `/api/csrf-token` do not trigger CORS errors.
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 NOTIFICATION_WEBHOOK_URL=https://example.com/webhook
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key

--- a/talentify-next-frontend/app/api/messages/route.ts
+++ b/talentify-next-frontend/app/api/messages/route.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@/lib/supabase/server'
 import { NextRequest, NextResponse } from 'next/server'
+import { API_BASE } from '@/lib/api'
 
 export async function GET() {
   const supabase = await createClient()
@@ -49,12 +50,19 @@ export async function POST(req: NextRequest) {
   }
 
   if (topic) {
-    await supabase.from('notifications').insert({
-      user_id: topic,
-      type: 'message',
-      title: '新着メッセージがあります',
-      body: content ?? null
+    const res = await fetch(`${API_BASE}/api/notifications`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        user_id: topic,
+        type: 'message',
+        title: '新着メッセージがあります',
+        body: content ?? null,
+      }),
     })
+    if (!res.ok) {
+      console.error('failed to create notification', await res.text())
+    }
   }
 
   return NextResponse.json(data, { status: 201 })

--- a/talentify-next-frontend/app/api/notifications/route.ts
+++ b/talentify-next-frontend/app/api/notifications/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/supabase/service'
+import { NOTIFICATION_TYPES, NotificationType } from '@/types/notifications'
+
+export const runtime = 'nodejs'
+
+export async function POST(req: NextRequest) {
+  try {
+    const { user_id, type, payload, title, body } = await req.json()
+
+    if (!user_id || !type || !title || !NOTIFICATION_TYPES.includes(type as NotificationType)) {
+      return NextResponse.json({ error: 'invalid request' }, { status: 400 })
+    }
+
+    const supabase = createServiceClient()
+    const { data, error } = await supabase
+      .from('notifications')
+      .insert({
+        user_id,
+        type,
+        title,
+        body: body ?? null,
+        data: payload ?? null,
+      })
+      .select()
+      .single()
+
+    if (error) {
+      console.error('failed to insert notification', { user_id, type, error })
+      return NextResponse.json({ error: error.message }, { status: 400 })
+    }
+
+    return NextResponse.json({ data })
+  } catch (error) {
+    console.error('failed to insert notification', error)
+    return NextResponse.json({ error: 'invalid request' }, { status: 400 })
+  }
+}

--- a/talentify-next-frontend/lib/supabase/service.ts
+++ b/talentify-next-frontend/lib/supabase/service.ts
@@ -5,7 +5,7 @@ import type { Database } from '@/types/supabase'
 
 export function createServiceClient() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const serviceKey = process.env.SUPABASE_SERVICE_KEY
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
 
   if (!url || !serviceKey) {
     throw new Error('Supabase environment variables are not set')

--- a/talentify-next-frontend/types/notifications.ts
+++ b/talentify-next-frontend/types/notifications.ts
@@ -1,0 +1,18 @@
+import type { Database } from '@/types/supabase'
+
+export type NotificationType = Database['public']['Tables']['notifications']['Row']['type']
+
+export const NOTIFICATION_TYPES: NotificationType[] = [
+  'offer',
+  'offer_created',
+  'offer_updated',
+  'offer_accepted',
+  'schedule_fixed',
+  'contract_uploaded',
+  'contract_checked',
+  'payment_created',
+  'invoice_submitted',
+  'payment_completed',
+  'review_received',
+  'message',
+]

--- a/talentify-next-frontend/types/ui.ts
+++ b/talentify-next-frontend/types/ui.ts
@@ -1,12 +1,6 @@
-export type NotificationType =
-  | 'offer_created'
-  | 'review_received'
-  | 'payment_completed'
-  | 'schedule_confirmed'
-  | 'message'
-  | 'offer'
-  | 'schedule'
-  | 'system'
+import type { NotificationType } from './notifications'
+
+export type { NotificationType }
 
 export type TaskType = 'respond_offer' | 'update_profile' | 'check_message'
 


### PR DESCRIPTION
## Summary
- add `/api/notifications` endpoint that creates notifications using Supabase service role
- restrict notification types with a shared union and validate requests
- replace client-side inserts with API calls and document `SUPABASE_SERVICE_ROLE_KEY`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b080a92608332bd0b805fdcd1e060