### PR TITLE
Fix offer notification trigger to use talent user ID

### DIFF
--- a/supabase/migrations/20250814000000_fix_offer_notification_user_id.sql
+++ b/supabase/migrations/20250814000000_fix_offer_notification_user_id.sql
@@ -1,0 +1,35 @@
+create or replace function public.notify_talent_on_offer_created()
+returns trigger
+language plpgsql
+as $$
+declare
+  _user_id uuid;
+begin
+  select user_id into _user_id from public.talents where id = NEW.talent_id;
+  if _user_id is not null then
+    insert into public.notifications (
+      id,
+      user_id,
+      type,
+      data,
+      is_read,
+      created_at
+    )
+    values (
+      gen_random_uuid(),
+      _user_id,
+      'offer_created',
+      jsonb_build_object(
+        'offer_id', NEW.id,
+        'store_id', NEW.store_id,
+        'event_name', NEW.event_name,
+        'date', NEW.date
+      ),
+      false,
+      now()
+    );
+  end if;
+  return NEW;
+end;
+$$;
+

--- a/talentify-next-frontend/app/api/offers/route.ts
+++ b/talentify-next-frontend/app/api/offers/route.ts
@@ -111,36 +111,6 @@ export async function POST(req: NextRequest) {
     )
   }
 
-  // resolve notification recipient
-  const { data: talent } = await service
-    .from('talents')
-    .select('user_id')
-    .eq('id', body.talent_id)
-    .single()
-  const talentUserId = talent?.user_id
-
-  if (talentUserId) {
-    const payload = {
-      offer_id: offer.id,
-      store_id: body.store_id,
-      talent_id: body.talent_id,
-      date: body.date,
-      time_range: body.time_range,
-      message: body.message ?? '',
-    }
-    try {
-      await service.from('notifications').insert({
-        user_id: talentUserId,
-        type: 'offer_created',
-        title: '新しいオファーが届きました',
-        data: payload,
-      })
-    } catch (e) {
-      console.error('notify insert failed', e)
-    }
-  } else {
-    console.error('notify insert failed', { reason: 'talent user_id not found', talent_id: body.talent_id })
-  }
-
+  // Notification creation is handled by a database trigger
   return NextResponse.json({ ok: true, offer })
 }

--- a/talentify-next-frontend/supabase-docs/functions.sql
+++ b/talentify-next-frontend/supabase-docs/functions.sql
@@ -1,30 +1,34 @@
--- notify_talent_on_offer_created
 CREATE OR REPLACE FUNCTION public.notify_talent_on_offer_created()
  RETURNS trigger
  LANGUAGE plpgsql
 AS $function$
+DECLARE
+  _user_id uuid;
 BEGIN
-  INSERT INTO notifications (
-    id,
-    user_id,
-    type,
-    data,
-    is_read,
-    created_at
-  )
-  VALUES (
-    gen_random_uuid(),
-    NEW.talent_id,
-    'offer_created',
-    jsonb_build_object(
-      'offer_id', NEW.id,
-      'store_id', NEW.store_id,
-      'event_name', NEW.event_name,
-      'date', NEW.date
-    ),
-    false,
-    now()
-  );
+  SELECT user_id INTO _user_id FROM public.talents WHERE id = NEW.talent_id;
+  IF _user_id IS NOT NULL THEN
+    INSERT INTO notifications (
+      id,
+      user_id,
+      type,
+      data,
+      is_read,
+      created_at
+    )
+    VALUES (
+      gen_random_uuid(),
+      _user_id,
+      'offer_created',
+      jsonb_build_object(
+        'offer_id', NEW.id,
+        'store_id', NEW.store_id,
+        'event_name', NEW.event_name,
+        'date', NEW.date
+      ),
+      false,
+      now()
+    );
+  END IF;
 
   RETURN NEW;
 END;


### PR DESCRIPTION
## Summary
- ensure offer notifications use talent user ID in Supabase trigger
- rely on trigger instead of manual API insertion
- add migration for updated trigger

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c471fd94483329ae36b4dc36df616