### PR TITLE
feat: add offer status RPC

### DIFF
--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -72,12 +72,11 @@ export default function TalentOfferDetailPage() {
 
   const handleStatusChange = async (status: 'confirmed' | 'rejected') => {
     if (!offer) return
-    const res = await fetch(`/api/offers/${offer.id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ status }),
-    })
-    if (res.ok) {
+    const { error } =
+      status === 'confirmed'
+        ? await supabase.rpc('talent_accept_offer', { p_offer_id: offer.id })
+        : await supabase.rpc('talent_reject_offer', { p_offer_id: offer.id, p_message: null })
+    if (!error) {
       setOffer({ ...offer, status })
       if (status === 'confirmed' && offer.user_id) {
         await addNotification({

--- a/talentify-next-frontend/types/supabase.ts
+++ b/talentify-next-frontend/types/supabase.ts
@@ -552,7 +552,27 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
-      [_ in never]: never
+      talent_update_offer_status: {
+        Args: {
+          p_offer_id: string
+          p_status: string
+          p_message?: string | null
+        }
+        Returns: Database['public']['Tables']['offers']['Row']
+      }
+      talent_accept_offer: {
+        Args: {
+          p_offer_id: string
+        }
+        Returns: Database['public']['Tables']['offers']['Row']
+      }
+      talent_reject_offer: {
+        Args: {
+          p_offer_id: string
+          p_message?: string | null
+        }
+        Returns: Database['public']['Tables']['offers']['Row']
+      }
     }
     Enums: {
       invoice_status: 'draft' | 'pending' | 'submitted' | 'approved' | 'rejected'


### PR DESCRIPTION
## Summary
- add SQL RPC `talent_update_offer_status` and wrappers for accepting or rejecting offers
- use new RPCs from talent offer detail page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c51d387b883328a5bc3394ecd03e7