### PR TITLE
chore: sync supabase enums

### DIFF
--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -107,7 +107,7 @@ export default function StoreOfferDetailPage() {
         await addNotification({
           user_id: offer.talent_id,
           data: { offer_id: offer.id },
-          type: 'contract_uploaded',
+          type: 'offer_updated',
           title: '契約書がアップロードされました',
         })
       }
@@ -145,7 +145,7 @@ export default function StoreOfferDetailPage() {
         await addNotification({
           user_id: offer.talent_id,
           data: { offer_id: offer.id },
-          type: 'payment_completed',
+          type: 'payment_created',
           title: 'お支払いが完了しました',
         })
       }

--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -105,7 +105,7 @@ export default function TalentOfferDetailPage() {
         await addNotification({
           user_id: offer.user_id,
           data: { offer_id: offer.id },
-          type: 'contract_checked',
+          type: 'offer_updated',
           title: 'タレントが契約書を確認しました'
         })
       }

--- a/talentify-next-frontend/supabase-docs/enums.md
+++ b/talentify-next-frontend/supabase-docs/enums.md
@@ -41,29 +41,27 @@
 
 ### public.invoice_status
 - draft
-- pending
 - submitted
 - approved
 - rejected
+- pending
 
 ### public.notification_type
-- offer
 - offer_created
 - offer_updated
-- offer_accepted
-- schedule_fixed
-- contract_uploaded
-- contract_checked
 - payment_created
 - invoice_submitted
-- payment_completed
 - review_received
 - message
+- offer
+- offer_accepted
+- schedule_fixed
 
 ### public.offer_status
 - pending
-- confirmed
+- accepted
 - rejected
+- confirmed
 
 ### auth.one_time_token_type
 - confirmation_token

--- a/talentify-next-frontend/supabase-docs/schema.md
+++ b/talentify-next-frontend/supabase-docs/schema.md
@@ -96,7 +96,7 @@
 **RLSポリシー** (relrowsecurity = true)
 - offers_insert_by_store: auth.uid() = user_id または stores.user_id = auth.uid() の自店舗 `store_id` で挿入可
 - offers_update_by_store: 自店舗の `store_id` のみ更新可
-- talent_update_own_offer_status: タレントは自分宛のオファーに対して `status` を `pending` / `confirmed` / `rejected` に更新可
+ - talent_update_own_offer_status: タレントは自分宛のオファーに対して `status` を `pending` / `accepted` / `rejected` / `confirmed` に更新可
 - offers_delete_by_store: 自店舗の `store_id` のみ削除可
 旧ポリシー (auth.uid() = store_id などの誤った比較) は削除済み。
 

--- a/talentify-next-frontend/types/notifications.ts
+++ b/talentify-next-frontend/types/notifications.ts
@@ -3,16 +3,13 @@ import type { Database } from '@/types/supabase'
 export type NotificationType = Database['public']['Tables']['notifications']['Row']['type']
 
 export const NOTIFICATION_TYPES: NotificationType[] = [
-  'offer',
   'offer_created',
   'offer_updated',
-  'offer_accepted',
-  'schedule_fixed',
-  'contract_uploaded',
-  'contract_checked',
   'payment_created',
   'invoice_submitted',
-  'payment_completed',
   'review_received',
   'message',
+  'offer',
+  'offer_accepted',
+  'schedule_fixed',
 ]

--- a/talentify-next-frontend/types/supabase.ts
+++ b/talentify-next-frontend/types/supabase.ts
@@ -382,18 +382,15 @@ export type Database = {
           user_id: string
           data: Json | null
           type:
-              | 'offer'
-              | 'offer_created'
-              | 'offer_updated'
-              | 'offer_accepted'
-              | 'schedule_fixed'
-              | 'contract_uploaded'
-              | 'contract_checked'
-              | 'payment_created'
-              | 'invoice_submitted'
-              | 'payment_completed'
-              | 'review_received'
-              | 'message'
+            | 'offer_created'
+            | 'offer_updated'
+            | 'payment_created'
+            | 'invoice_submitted'
+            | 'review_received'
+            | 'message'
+            | 'offer'
+            | 'offer_accepted'
+            | 'schedule_fixed'
           title: string
           body: string | null
           is_read: boolean
@@ -405,18 +402,15 @@ export type Database = {
           user_id: string
           data?: Json | null
           type:
-              | 'offer'
-              | 'offer_created'
-              | 'offer_updated'
-              | 'offer_accepted'
-              | 'schedule_fixed'
-              | 'contract_uploaded'
-              | 'contract_checked'
-              | 'payment_created'
-              | 'invoice_submitted'
-              | 'payment_completed'
-              | 'review_received'
-              | 'message'
+            | 'offer_created'
+            | 'offer_updated'
+            | 'payment_created'
+            | 'invoice_submitted'
+            | 'review_received'
+            | 'message'
+            | 'offer'
+            | 'offer_accepted'
+            | 'schedule_fixed'
           title: string
           body?: string | null
           is_read?: boolean
@@ -428,18 +422,15 @@ export type Database = {
           user_id?: string
           data?: Json | null
           type?:
-            | 'offer'
             | 'offer_created'
             | 'offer_updated'
-            | 'offer_accepted'
-            | 'schedule_fixed'
-            | 'contract_uploaded'
-            | 'contract_checked'
             | 'payment_created'
             | 'invoice_submitted'
-            | 'payment_completed'
             | 'review_received'
             | 'message'
+            | 'offer'
+            | 'offer_accepted'
+            | 'schedule_fixed'
           title?: string
           body?: string | null
           is_read?: boolean
@@ -575,23 +566,27 @@ export type Database = {
       }
     }
     Enums: {
-      invoice_status: 'draft' | 'pending' | 'submitted' | 'approved' | 'rejected'
+      invoice_status: 'draft' | 'submitted' | 'approved' | 'rejected' | 'pending'
       notification_type:
-        | 'offer'
         | 'offer_created'
         | 'offer_updated'
-        | 'offer_accepted'
-        | 'schedule_fixed'
-        | 'contract_uploaded'
-        | 'contract_checked'
         | 'payment_created'
         | 'invoice_submitted'
-        | 'payment_completed'
         | 'review_received'
         | 'message'
-      offer_status: 'pending' | 'confirmed' | 'rejected'
+        | 'offer'
+        | 'offer_accepted'
+        | 'schedule_fixed'
+      offer_status: 'pending' | 'accepted' | 'rejected' | 'confirmed'
       payment_status: 'pending' | 'paid' | 'cancelled'
-      status_type: 'draft' | 'pending' | 'approved' | 'rejected' | 'completed'
+      status_type:
+        | 'draft'
+        | 'pending'
+        | 'approved'
+        | 'rejected'
+        | 'completed'
+        | 'offer_created'
+        | 'confirmed'
       visit_status: 'scheduled' | 'confirmed' | 'visited'
     }
     CompositeTypes: {
@@ -708,24 +703,21 @@ export type CompositeTypes<
 export const Constants = {
   public: {
     Enums: {
-      invoice_status: ['draft', 'pending', 'submitted', 'approved', 'rejected'],
+      invoice_status: ['draft', 'submitted', 'approved', 'rejected', 'pending'],
       notification_type: [
-        'offer',
         'offer_created',
         'offer_updated',
-        'offer_accepted',
-        'schedule_fixed',
-        'contract_uploaded',
-        'contract_checked',
         'payment_created',
         'invoice_submitted',
-        'payment_completed',
         'review_received',
-        'message'
+        'message',
+        'offer',
+        'offer_accepted',
+        'schedule_fixed'
       ],
-      offer_status: ['pending', 'confirmed', 'rejected'],
+      offer_status: ['pending', 'accepted', 'rejected', 'confirmed'],
       payment_status: ['pending', 'paid', 'cancelled'],
-      status_type: ['draft', 'pending', 'approved', 'rejected', 'completed'],
+      status_type: ['draft', 'pending', 'approved', 'rejected', 'completed', 'offer_created', 'confirmed'],
       visit_status: ['scheduled', 'confirmed', 'visited']
     },
   },


### PR DESCRIPTION
## Summary
- sync Supabase enum documentation and generated types with current schema
- replace deprecated notification types with supported values
- document accepted offer status in RLS policy

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d402990148332baa96aceff2c2df8