### PR TITLE
docs: update Supabase functions

### DIFF
--- a/talentify-next-frontend/supabase-docs/functions.sql
+++ b/talentify-next-frontend/supabase-docs/functions.sql
@@ -1,21 +1,22 @@
+-- notify_talent_on_offer_created
 CREATE OR REPLACE FUNCTION public.notify_talent_on_offer_created()
  RETURNS trigger
  LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
 AS $function$
-DECLARE
+declare
   _user_id uuid;
-BEGIN
-  SELECT user_id INTO _user_id FROM public.talents WHERE id = NEW.talent_id;
-  IF _user_id IS NOT NULL THEN
-    INSERT INTO notifications (
-      id,
-      user_id,
-      type,
-      data,
-      is_read,
-      created_at
+begin
+  select t.user_id into _user_id
+  from public.talents t
+  where t.id = NEW.talent_id;
+
+  if _user_id is not null then
+    insert into public.notifications (
+      id, user_id, type, data, is_read, created_at
     )
-    VALUES (
+    values (
       gen_random_uuid(),
       _user_id,
       'offer_created',
@@ -28,10 +29,10 @@ BEGIN
       false,
       now()
     );
-  END IF;
+  end if;
 
-  RETURN NEW;
-END;
+  return NEW;
+end;
 $function$;
 
 -- notify_talent_on_payment_created
@@ -72,10 +73,12 @@ CREATE OR REPLACE FUNCTION public.update_updated_at_column()
  RETURNS trigger
  LANGUAGE plpgsql
 AS $function$
-BEGIN
-  NEW.updated_at = now();
-  RETURN NEW;
-END;
+begin
+  if to_jsonb(NEW) ? 'updated_at' then
+    NEW.updated_at = now();
+  end if;
+  return NEW;
+end;
 $function$;
 
 -- handle_review_insert
@@ -84,12 +87,54 @@ CREATE OR REPLACE FUNCTION public.handle_review_insert()
  LANGUAGE plpgsql
 AS $function$
 BEGIN
-  UPDATE offers
-  SET status = 'completed'
+  -- レビューに紐づくオファーの status を 'completed' に更新し、updated_at も更新
+  UPDATE public.offers
+  SET status = 'completed',
+      updated_at = now()
   WHERE id = NEW.offer_id;
-
   RETURN NEW;
 END;
+$function$;
+
+-- notify_review_received
+CREATE OR REPLACE FUNCTION public.notify_review_received()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+declare
+  v_talent_user_id uuid;
+begin
+  -- 対象オファーのタレント user_id を取得
+  select t.user_id
+    into v_talent_user_id
+  from public.offers o
+  join public.talents t on t.id = o.talent_id
+  where o.id = NEW.offer_id;
+
+  if v_talent_user_id is null then
+    return null; -- 念のため
+  end if;
+
+  -- 通知を挿入（notifications は service_role しか許可していないが、
+  -- security definer なのでこの関数経由なら作成できる）
+  insert into public.notifications (user_id, type, data)
+  values (
+    v_talent_user_id,
+    'review_received',
+    jsonb_build_object(
+      'review_id', NEW.id,
+      'offer_id', NEW.offer_id,
+      'store_id', NEW.store_id,
+      'talent_id', NEW.talent_id,
+      'rating', NEW.rating,
+      'is_public', NEW.is_public
+    )
+  );
+
+  return null; -- AFTERトリガーなので戻り値は未使用
+end;
 $function$;
 
 -- notify_talent_on_review_created
@@ -98,7 +143,7 @@ CREATE OR REPLACE FUNCTION public.notify_talent_on_review_created()
  LANGUAGE plpgsql
 AS $function$
 BEGIN
-  INSERT INTO notifications (
+  INSERT INTO public.notifications (
     id,
     user_id,
     type,
@@ -108,105 +153,138 @@ BEGIN
   )
   VALUES (
     gen_random_uuid(),
-    NEW.talent_id,
-    'review_received',
+    NEW.talent_id,      -- 通知対象はレビューされたタレント
+    'review_received',  -- enums.md に定義済み:contentReference[oaicite:0]{index=0}
     jsonb_build_object(
       'review_id', NEW.id,
-      'offer_id', NEW.offer_id
+      'offer_id', NEW.offer_id,
+      'store_id', NEW.store_id,
+      'rating', NEW.rating,
+      'comment', NEW.comment
     ),
     false,
     now()
   );
-
   RETURN NEW;
 END;
 $function$;
 
--- trigger to update offer status on review creation
-DROP TRIGGER IF EXISTS trigger_set_offer_completed_on_review ON reviews;
-CREATE TRIGGER trigger_set_offer_completed_on_review
-AFTER INSERT ON reviews
-FOR EACH ROW
-EXECUTE FUNCTION public.handle_review_insert();
-
--- trigger to notify talent when review is created
-DROP TRIGGER IF EXISTS trigger_notify_talent_on_review_created ON reviews;
-CREATE TRIGGER trigger_notify_talent_on_review_created
-AFTER INSERT ON reviews
-FOR EACH ROW
-EXECUTE FUNCTION public.notify_talent_on_review_created();
--- talent_update_offer_status
-CREATE OR REPLACE FUNCTION public.talent_update_offer_status(
-    p_offer_id uuid,
-    p_status text,
-    p_message text DEFAULT NULL
-)
-RETURNS offers
-LANGUAGE plpgsql
-SECURITY DEFINER
+-- reviews_fill_and_validate
+CREATE OR REPLACE FUNCTION public.reviews_fill_and_validate()
+ RETURNS trigger
+ LANGUAGE plpgsql
 AS $function$
-DECLARE
-  _talent_id uuid;
-  _updated offers;
-BEGIN
-  SELECT id INTO _talent_id FROM public.talents WHERE user_id = auth.uid();
-  IF _talent_id IS NULL THEN
-    RAISE EXCEPTION 'not authorized';
-  END IF;
+declare
+  o record;
+begin
+  -- オファー取得
+  select id, store_id, talent_id into o
+  from public.offers
+  where id = new.offer_id;
 
-  IF p_status NOT IN ('confirmed', 'rejected') THEN
-    RAISE EXCEPTION 'invalid status %', p_status;
-  END IF;
+  if o.id is null then
+    raise exception 'Invalid offer_id: %', new.offer_id using errcode = '23503';
+  end if;
 
-  UPDATE public.offers
-  SET status = p_status,
-      message = CASE WHEN p_status = 'rejected' THEN p_message ELSE message END,
-      accepted_at = CASE WHEN p_status = 'confirmed' THEN now() ELSE accepted_at END,
-      updated_at = now()
-  WHERE id = p_offer_id
-    AND talent_id = _talent_id
-  RETURNING * INTO _updated;
+  -- store_id / talent_id が無い or 不一致なら上書き
+  if new.store_id is null or new.store_id <> o.store_id then
+    new.store_id := o.store_id;
+  end if;
+  if new.talent_id is null or new.talent_id <> o.talent_id then
+    new.talent_id := o.talent_id;
+  end if;
 
-  IF NOT FOUND THEN
-    RAISE EXCEPTION 'offer not found';
-  END IF;
+  -- rating の簡易チェック（NULLは許容のまま）
+  if new.rating is not null and (new.rating < 1 or new.rating > 5) then
+    raise exception 'rating must be between 1 and 5 (got %)', new.rating using errcode = '22023';
+  end if;
 
-  RETURN _updated;
-END;
+  -- category_ratings 未指定なら {}
+  if new.category_ratings is null then
+    new.category_ratings := '{}'::jsonb;
+  end if;
+
+  return new;
+end;
 $function$;
 
-ALTER FUNCTION public.talent_update_offer_status(uuid, text, text) OWNER TO postgres;
-GRANT EXECUTE ON FUNCTION public.talent_update_offer_status(uuid, text, text) TO authenticated;
+-- set_review_store_id
+CREATE OR REPLACE FUNCTION public.set_review_store_id()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+begin
+  if new.store_id is null then
+    select o.store_id into new.store_id
+    from public.offers o
+    where o.id = new.offer_id;
+  end if;
+  return new;
+end;
+$function$;
 
 -- talent_accept_offer
-CREATE OR REPLACE FUNCTION public.talent_accept_offer(
-    p_offer_id uuid
-)
-RETURNS offers
-LANGUAGE plpgsql
-SECURITY DEFINER
+CREATE OR REPLACE FUNCTION public.talent_accept_offer(p_offer_id uuid)
+ RETURNS offers
+ LANGUAGE sql
+ SECURITY DEFINER
+ SET search_path TO 'public'
 AS $function$
-BEGIN
-  RETURN public.talent_update_offer_status(p_offer_id, 'confirmed', NULL);
-END;
+  select public.talent_update_offer_status(p_offer_id, 'confirmed', null);
 $function$;
-
-ALTER FUNCTION public.talent_accept_offer(uuid) OWNER TO postgres;
-GRANT EXECUTE ON FUNCTION public.talent_accept_offer(uuid) TO authenticated;
 
 -- talent_reject_offer
-CREATE OR REPLACE FUNCTION public.talent_reject_offer(
-    p_offer_id uuid,
-    p_message text DEFAULT NULL
-)
-RETURNS offers
-LANGUAGE plpgsql
-SECURITY DEFINER
+CREATE OR REPLACE FUNCTION public.talent_reject_offer(p_offer_id uuid, p_message text DEFAULT NULL::text)
+ RETURNS offers
+ LANGUAGE sql
+ SECURITY DEFINER
+ SET search_path TO 'public'
 AS $function$
-BEGIN
-  RETURN public.talent_update_offer_status(p_offer_id, 'rejected', p_message);
-END;
+  select public.talent_update_offer_status(p_offer_id, 'rejected', p_message);
 $function$;
 
-ALTER FUNCTION public.talent_reject_offer(uuid, text) OWNER TO postgres;
-GRANT EXECUTE ON FUNCTION public.talent_reject_offer(uuid, text) TO authenticated;
+-- talent_update_offer_status
+CREATE OR REPLACE FUNCTION public.talent_update_offer_status(p_offer_id uuid, p_next_status text, p_message text DEFAULT NULL::text)
+ RETURNS offers
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+declare
+  v_offer public.offers;
+  v_talent_user_id uuid;
+begin
+  -- 対象オファー取得
+  select * into v_offer from public.offers where id = p_offer_id;
+  if not found then
+    raise exception 'offer not found';
+  end if;
+
+  -- このオファーのタレントの user_id を取得
+  select t.user_id into v_talent_user_id
+  from public.talents t
+  where t.id = v_offer.talent_id;
+
+  -- 呼び出しユーザーが当該タレント本人か検証
+  if v_talent_user_id is null or v_talent_user_id <> auth.uid() then
+    raise exception 'forbidden';
+  end if;
+
+  -- 許可する遷移のみ
+  if p_next_status not in ('confirmed','rejected') then
+    raise exception 'invalid status %', p_next_status;
+  end if;
+
+  -- 許可カラムのみ更新
+  update public.offers
+  set
+    status      = p_next_status,
+    message     = coalesce(p_message, message),
+    accepted_at = case when p_next_status = 'confirmed' then now() else accepted_at end,
+    updated_at  = now()
+  where id = p_offer_id
+  returning * into v_offer;
+
+  return v_offer;
+end;
+$function$;


### PR DESCRIPTION
## Summary
- document secure offer notification trigger
- add review validation and notification helpers
- clarify offer status updates for talents

## Testing
- `cd talentify-next-frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d40f1a2408332a7c91052c07c677b