### PR TITLE
docs: document new supabase views

### DIFF
--- a/talentify-next-frontend/supabase-docs/schema.md
+++ b/talentify-next-frontend/supabase-docs/schema.md
@@ -221,3 +221,69 @@ status が 'completed' の場合に支払い完了とみなし、その日時を
 - created_at: timestamp without time zone, DEFAULT now()
 - updated_at: timestamp without time zone, DEFAULT now()
 - status: USER-DEFINED
+
+### pg_stat_statements (extensions schema)
+- userid: oid
+- dbid: oid
+- toplevel: boolean
+- queryid: bigint
+- query: text
+- plans: bigint
+- total_plan_time: double precision
+- min_plan_time: double precision
+- max_plan_time: double precision
+- mean_plan_time: double precision
+- stddev_plan_time: double precision
+- calls: bigint
+- total_exec_time: double precision
+- min_exec_time: double precision
+- max_exec_time: double precision
+- mean_exec_time: double precision
+- stddev_exec_time: double precision
+- rows: bigint
+- shared_blks_hit: bigint
+- shared_blks_read: bigint
+- shared_blks_dirtied: bigint
+- shared_blks_written: bigint
+- local_blks_hit: bigint
+- local_blks_read: bigint
+- local_blks_dirtied: bigint
+- local_blks_written: bigint
+- temp_blks_read: bigint
+- temp_blks_written: bigint
+- shared_blk_read_time: double precision
+- shared_blk_write_time: double precision
+- local_blk_read_time: double precision
+- local_blk_write_time: double precision
+- temp_blk_read_time: double precision
+- temp_blk_write_time: double precision
+- wal_records: bigint
+- wal_fpi: bigint
+- wal_bytes: numeric
+- jit_functions: bigint
+- jit_generation_time: double precision
+- jit_inlining_count: bigint
+- jit_inlining_time: double precision
+- jit_optimization_count: bigint
+- jit_optimization_time: double precision
+- jit_emission_count: bigint
+- jit_emission_time: double precision
+- jit_deform_count: bigint
+- jit_deform_time: double precision
+- stats_since: timestamp with time zone
+- minmax_stats_since: timestamp with time zone
+
+### pg_stat_statements_info (extensions schema)
+- dealloc: bigint
+- stats_reset: timestamp with time zone
+
+### decrypted_secrets (vault schema)
+- id: uuid
+- name: text
+- description: text
+- secret: text
+- decrypted_secret: text
+- key_id: uuid
+- nonce: bytea
+- created_at: timestamp with time zone
+- updated_at: timestamp with time zone


### PR DESCRIPTION
## Summary
- document `pg_stat_statements` and `pg_stat_statements_info` extension views
- add Supabase Vault `decrypted_secrets` view to schema doc

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d411db1748332aca5050f3fafbb17