### PR TITLE
docs: document database sequences

### DIFF
--- a/talentify-next-frontend/supabase-docs/README.md
+++ b/talentify-next-frontend/supabase-docs/README.md
@@ -10,6 +10,7 @@ Codexはコード生成や修正時にこれらを参照してください。
 - [enums.md](./enums.md): ENUM型一覧
 - [rls.md](./rls.md): Row Level Securityポリシー
 - [triggers.md](./triggers.md): トリガー定義
+- [sequences.md](./sequences.md): シーケンス定義
 - [functions.sql](./functions.sql): PL/pgSQL関数定義
 
 ## プロビジョニングフロー

--- a/talentify-next-frontend/supabase-docs/sequences.md
+++ b/talentify-next-frontend/supabase-docs/sequences.md
@@ -1,0 +1,4 @@
+## シーケンス
+
+- auth.refresh_tokens_id_seq: bigint, START 1, INCREMENT 1
+- graphql.seq_schema_version: integer, START 1, INCREMENT 1


### PR DESCRIPTION
## Summary
- document auth.refresh_tokens_id_seq and graphql.seq_schema_version sequences
- reference the new sequences doc from Supabase docs README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d413beb788332b293f1beef0d9531