### PR TITLE
fix offer update auth and document notifications

### DIFF
--- a/docs/audit/250214.md
+++ b/docs/audit/250214.md
@@ -1,0 +1,35 @@
+# Talentify Audit 2025-02-14
+
+## Issue 1: Offer update authorization mismatch
+- **Cause**: `/api/offers/[id]` compared `auth.user.id` with `offers.store_id` and `offers.talent_id` (both are entity IDs, not user IDs), resulting in false negatives.
+- **Reproduction**: Logged-in store owner attempts to update contract URL via `PUT /api/offers/{id}` → receives `403 権限がありません`.
+- **Impact**: Store owners and talents cannot update offers (contract, invoice info) despite having privileges.
+- **Fix**: Fetch related `stores.user_id` and `talents.user_id` then compare with `auth.user.id`.
+- **Checks**: `npm test`, `npm run lint`.
+
+## Issue 2: Notifications cannot be marked as read
+- **Cause**: RLS policies for `notifications` allow only `INSERT` (service role) and `SELECT` (receiver). `utils/notifications.ts::markNotificationRead` performs `UPDATE`, which violates RLS.
+- **Reproduction**: Call `markNotificationRead(id)` as a normal user → `new row violates row-level security policy for table "notifications"`.
+- **Impact**: Users cannot mark notifications as read; notification badges never clear.
+- **Workaround**: Use service role (not recommended).
+- **Proposed SQL**: `supabase-sql-proposals/20250214_notifications_update.sql`.
+
+## RLS Mapping (excerpt)
+| Table | Operation | Code Path | RLS Policy |
+|-------|-----------|-----------|------------|
+| offers | INSERT | `app/api/offers/route.ts` (POST) | `offers_insert_by_store`
+| offers | UPDATE (store) | `app/api/offers/[id]/route.ts` (store block) | `offers_update_by_store`
+| offers | UPDATE (talent) | `app/api/offers/[id]/route.ts` (talent block), `talent_accept_offer` RPC | `talent_update_own_offer_status`
+| notifications | UPDATE | `utils/notifications.ts::markNotificationRead` | **missing** → add `notifications_update_self` |
+
+## Schema / Type mismatches
+| Location | Field | Mismatch |
+|----------|-------|----------|
+| `supabase-docs/schema.md` vs generated types | `notifications.title`, `notifications.body` | Columns exist in DB and code but were missing in docs (docs updated) |
+
+## Confirmation checklist
+1. Store user can create an offer via `POST /api/offers`.
+2. Store user can update status or contract via `PUT /api/offers/{id}`.
+3. Talent user can update invoice fields via `PUT /api/offers/{id}`.
+4. After applying proposed SQL, `markNotificationRead` updates notification without RLS error.
+

--- a/supabase-sql-proposals/20250214_notifications_update.sql
+++ b/supabase-sql-proposals/20250214_notifications_update.sql
@@ -1,0 +1,6 @@
+-- Allow users to mark their own notifications as read
+DROP POLICY IF EXISTS notifications_update_self ON notifications;
+CREATE POLICY notifications_update_self
+ON notifications FOR UPDATE
+USING (auth.uid() = user_id)
+WITH CHECK (auth.uid() = user_id);

--- a/talentify-next-frontend/app/api/offers/[id]/route.ts
+++ b/talentify-next-frontend/app/api/offers/[id]/route.ts
@@ -20,7 +20,7 @@ export async function PUT(
 
     const { data: offer, error: offerError } = await supabase
       .from('offers')
-      .select('store_id, talent_id')
+      .select('store:store_id(user_id), talent:talent_id(user_id)')
       .eq('id', id)
       .single()
     if (offerError || !offer) {
@@ -28,9 +28,11 @@ export async function PUT(
     }
 
     let allowedFields: string[] = []
-    if (user.id === offer.store_id) {
+    const storeUserId = (offer as any).store?.user_id as string | undefined
+    const talentUserId = (offer as any).talent?.user_id as string | undefined
+    if (storeUserId && user.id === storeUserId) {
       allowedFields = ['status', 'contract_url']
-    } else if (user.id === offer.talent_id) {
+    } else if (talentUserId && user.id === talentUserId) {
       allowedFields = [
         'status',
         'agreed',

--- a/talentify-next-frontend/supabase-docs/schema.md
+++ b/talentify-next-frontend/supabase-docs/schema.md
@@ -54,6 +54,8 @@
 - id: uuid, NOT NULL, DEFAULT gen_random_uuid()
 - user_id: uuid, NOT NULL
 - type: USER-DEFINED, NOT NULL
+- title: text
+- body: text
 - data: jsonb
 - is_read: boolean, DEFAULT false
 - created_at: timestamp without time zone, DEFAULT now()


### PR DESCRIPTION
## Summary
- fix permission check in `PUT /api/offers/:id` to compare user IDs via joined store/talent records
- document `title` and `body` columns for notifications table
- add SQL proposal for notifications update RLS
- add audit report for current findings

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d4c44dc5c833299af7613a4cf8a5b