### PR TITLE
fix: handle payment completion by id

### DIFF
--- a/talentify-next-frontend/app/api/payments/complete/route.ts
+++ b/talentify-next-frontend/app/api/payments/complete/route.ts
@@ -1,45 +1,70 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createServiceClient } from '@/lib/supabase/service'
+import { createClient } from '@/lib/supabase/server'
 
 export async function POST(req: NextRequest) {
+  const supabase = await createClient()
+  let json: any
   try {
-    const supabase = createServiceClient()
-    const { offer_id } = await req.json()
-    if (!offer_id) {
-      return NextResponse.json({ error: 'offer_id is required' }, { status: 400 })
-    }
+    json = await req.json()
+  } catch (e) {
+    return NextResponse.json(
+      { error: 'invalid json body' },
+      { status: 400 }
+    )
+  }
 
-    let { data: payment } = await supabase
-      .from('payments')
-      .select('*')
-      .eq('offer_id', offer_id)
-      .maybeSingle()
+  const { id, offer_id, paid_at } = json
 
-    if (!payment) {
-      const insertRes = await supabase
+  try {
+    let paymentId = id as string | undefined
+
+    if (!paymentId && offer_id) {
+      const { data, error } = await supabase
         .from('payments')
-        .insert({ offer_id, status: 'pending' })
-        .select()
-        .single()
-      if (insertRes.error) throw insertRes.error
-      payment = insertRes.data
+        .select('id')
+        .eq('offer_id', offer_id)
+
+      if (error) {
+        console.error('[POST /payments/complete] select by offer_id', error)
+        return NextResponse.json({ error: error.message }, { status: 400 })
+      }
+
+      if (!data || data.length === 0) {
+        return NextResponse.json({ error: 'payment not found' }, { status: 400 })
+      }
+
+      if (data.length > 1) {
+        return NextResponse.json({ error: 'multiple payments found' }, { status: 400 })
+      }
+
+      paymentId = data[0].id
     }
 
-    if (payment.status === 'completed') {
-      return NextResponse.json(payment, { status: 200 })
+    if (!paymentId) {
+      return NextResponse.json({ error: 'missing payment id' }, { status: 400 })
     }
 
     const updateRes = await supabase
       .from('payments')
-      .update({ status: 'completed', paid_at: new Date().toISOString() })
-      .eq('id', payment.id)
-      .select()
-      .single()
-    if (updateRes.error) throw updateRes.error
+      .update({
+        status: 'completed',
+        paid_at: paid_at ?? new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', paymentId)
 
-    return NextResponse.json(updateRes.data, { status: 200 })
-  } catch (e) {
+    if (updateRes.error) {
+      const status = updateRes.error.code === '42501' ? 403 : 400
+      console.error('[POST /payments/complete] update failed', updateRes.error)
+      return NextResponse.json(
+        { error: updateRes.error.message },
+        { status }
+      )
+    }
+
+    return NextResponse.json({ ok: true }, { status: 200 })
+  } catch (e: any) {
     console.error('[POST /payments/complete]', e)
-    return new NextResponse('Internal Server Error', { status: 500 })
+    return NextResponse.json({ error: e.message }, { status: 500 })
   }
 }

--- a/talentify-next-frontend/app/manage/page.js
+++ b/talentify-next-frontend/app/manage/page.js
@@ -46,10 +46,15 @@ function usePayments() {
   }, [])
 
   const updateStatus = async (offerId) => {
+    const payment = payments.find(p => p.offer_id === offerId)
     try {
-      const updated = await markPaymentCompleted(offerId)
+      await markPaymentCompleted(payment?.id, offerId)
       setPayments(prev =>
-        prev.map(p => (p.offer_id === offerId ? { ...p, ...updated } : p))
+        prev.map(p =>
+          p.offer_id === offerId
+            ? { ...p, status: 'completed', paid_at: new Date().toISOString() }
+            : p
+        )
       )
     } catch (e) {
       console.error(e)

--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -139,8 +139,7 @@ export default function StoreOfferDetailPage() {
   const handlePaid = async () => {
     if (!offer) return
     try {
-      const updated = await markPaymentCompleted(offer.id)
-      setPayment(updated)
+      await markPaymentCompleted(payment?.id, offer.id)
       if (offer.talent_id) {
         await addNotification({
           user_id: offer.talent_id,

--- a/talentify-next-frontend/lib/payments.ts
+++ b/talentify-next-frontend/lib/payments.ts
@@ -1,10 +1,13 @@
 import { toast } from 'sonner'
 
-export async function markPaymentCompleted(offerId: string) {
+export async function markPaymentCompleted(
+  paymentId?: string,
+  offerId?: string
+) {
   const res = await fetch('/api/payments/complete', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ offer_id: offerId }),
+    body: JSON.stringify({ id: paymentId, offer_id: offerId }),
   })
   const json = await res.json().catch(() => ({ error: 'unknown error' }))
   if (!res.ok || json.error) {

--- a/talentify-next-frontend/supabase-docs/enums.md
+++ b/talentify-next-frontend/supabase-docs/enums.md
@@ -75,6 +75,7 @@
 - pending
 - paid
 - cancelled
+- completed
 
 ### public.status_type
 - draft

--- a/talentify-next-frontend/supabase-docs/schema.md
+++ b/talentify-next-frontend/supabase-docs/schema.md
@@ -108,7 +108,7 @@
 - id: uuid, NOT NULL, DEFAULT gen_random_uuid()
 - offer_id: uuid
 - amount: integer, NOT NULL
-- status: USER-DEFINED, NOT NULL
+ - status: payment_status, NOT NULL
 - created_at: timestamp with time zone, DEFAULT now()
 - updated_at: timestamp with time zone, DEFAULT now()
 - paid_at: timestamp with time zone


### PR DESCRIPTION
## Summary
- send payment `id` when marking a payment as completed
- harden `/api/payments/complete` to update by `id` with offer-based fallback and clear errors
- document `payment_status` enum and API changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d56feaf1c83328d33f290fa6e0097