### PR TITLE
Fix talent data queries to use talent ID

### DIFF
--- a/talentify-next-frontend/utils/getInvoicesForTalent.ts
+++ b/talentify-next-frontend/utils/getInvoicesForTalent.ts
@@ -10,10 +10,21 @@ export async function getInvoicesForTalent() {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return [] as Invoice[]
 
+  const { data: talent, error: talentError } = await supabase
+    .from('talents')
+    .select('id')
+    .eq('user_id', user.id)
+    .single()
+
+  if (talentError || !talent) {
+    console.error('failed to fetch talent', talentError)
+    return [] as Invoice[]
+  }
+
   const { data, error } = await supabase
     .from('invoices')
     .select('*')
-    .eq('talent_id', user.id)
+    .eq('talent_id', talent.id)
     .order('created_at', { ascending: false })
 
   if (error) {

--- a/talentify-next-frontend/utils/getReviewsForTalent.ts
+++ b/talentify-next-frontend/utils/getReviewsForTalent.ts
@@ -17,10 +17,21 @@ export async function getReviewsForTalent() {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return [] as TalentReview[]
 
+  const { data: talent, error: talentError } = await supabase
+    .from('talents')
+    .select('id')
+    .eq('user_id', user.id)
+    .single()
+
+  if (talentError || !talent) {
+    console.error('failed to fetch talent:', talentError)
+    return [] as TalentReview[]
+  }
+
   const { data, error } = await supabase
     .from('reviews' as any)
     .select('id, rating, category_ratings, comment, created_at, store:store_id(store_name), offers(date)')
-    .eq('talent_id', user.id)
+    .eq('talent_id', talent.id)
     .order('created_at', { ascending: false })
 
   if (error) {

--- a/talentify-next-frontend/utils/getTalentSchedule.ts
+++ b/talentify-next-frontend/utils/getTalentSchedule.ts
@@ -18,10 +18,21 @@ export async function getTalentSchedule(): Promise<TalentSchedule[]> {
 
   if (!user) return []
 
+  const { data: talent, error: talentError } = await supabase
+    .from('talents')
+    .select('id')
+    .eq('user_id', user.id)
+    .single()
+
+  if (talentError || !talent) {
+    console.error('failed to fetch talent', talentError)
+    return []
+  }
+
   const { data, error } = await supabase
     .from('offers')
     .select('id, date, time_range, stores(store_name)')
-    .eq('talent_id', user.id)
+    .eq('talent_id', talent.id)
     .eq('status', 'confirmed')
     .order('date', { ascending: true })
 


### PR DESCRIPTION
## Summary
- Fetch talent ID from `talents` table before querying talent-specific data
- Use talent ID to load reviews, schedule entries, and invoices for performers

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689d9818bbf48332b150b866deb62483