### PR TITLE
feat(schedule): add completed toggle and visit notes

### DIFF
--- a/talentify-next-frontend/supabase-docs/20250315_add_note_to_visits.sql
+++ b/talentify-next-frontend/supabase-docs/20250315_add_note_to_visits.sql
@@ -1,0 +1,3 @@
+-- Add note column to visits for storing completion memos
+alter table public.visits
+  add column if not exists note text;

--- a/talentify-next-frontend/supabase-docs/README.md
+++ b/talentify-next-frontend/supabase-docs/README.md
@@ -24,3 +24,9 @@ Codexはコード生成や修正時にこれらを参照してください。
 - 通知は service role (`createServiceClient`) でのみ作成します。
 - 通知の宛先は関連するタレントの `talents.user_id` を `notifications.user_id` にそのままセットします。
 - `talents.user_id` を取得できない場合は通知を作成せず、理由をサーバーログに記録します。
+
+## API仕様: スケジュール取得
+
+`GET /api/store/schedule?from=&to=&statuses=&includeCompleted=`
+
+- `includeCompleted` (boolean, default: `true`): `false` の場合、完了済みの予定を除外

--- a/talentify-next-frontend/supabase-docs/schema.md
+++ b/talentify-next-frontend/supabase-docs/schema.md
@@ -225,6 +225,7 @@ status が 'completed' の場合に支払い完了とみなし、その日時を
 - created_at: timestamp without time zone, DEFAULT now()
 - updated_at: timestamp without time zone, DEFAULT now()
 - status: USER-DEFINED
+- note: text
 
 ### pg_stat_statements (extensions schema)
 - userid: oid


### PR DESCRIPTION
## Summary
- allow store schedule to toggle visibility of completed offers via URL param
- document schedule API includeCompleted param and add visit memo column

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d9c9c71808332a8e38231b1bd0ce3