### PR TITLE
feat: enhance schedule UI with filtering and color legend

### DIFF
--- a/talentify-next-frontend/__tests__/storeSchedule.test.ts
+++ b/talentify-next-frontend/__tests__/storeSchedule.test.ts
@@ -1,0 +1,52 @@
+import {
+  mapOfferStatus,
+  parseStatusesParam,
+  stringifyStatuses,
+  filterEvents,
+  DEFAULT_STATUSES,
+  type StoreScheduleEvent,
+} from '../utils/storeSchedule'
+
+describe('store schedule utils', () => {
+  test('mapOfferStatus maps raw statuses to display statuses', () => {
+    expect(mapOfferStatus('confirmed')).toBe('scheduled')
+    expect(mapOfferStatus('completed')).toBe('completed')
+    expect(mapOfferStatus('cancelled')).toBe('cancelled')
+    expect(mapOfferStatus('no_show')).toBe('no_show')
+    expect(mapOfferStatus('unknown')).toBe('scheduled')
+  })
+
+  test('parse and stringify statuses round trip', () => {
+    const s: typeof DEFAULT_STATUSES = ['scheduled', 'completed']
+    const str = stringifyStatuses(s)
+    expect(str).toBe('scheduled,completed')
+    expect(parseStatusesParam(str)).toEqual(s)
+    expect(stringifyStatuses(DEFAULT_STATUSES)).toBeNull()
+  })
+
+  test('filterEvents filters by status and query', () => {
+    const events: StoreScheduleEvent[] = [
+      {
+        title: 'A',
+        start: new Date(),
+        end: new Date(),
+        talentId: '1',
+        offerId: '1',
+        talentName: 'Alice',
+        status: 'scheduled',
+      },
+      {
+        title: 'B',
+        start: new Date(),
+        end: new Date(),
+        talentId: '2',
+        offerId: '2',
+        talentName: 'Bob',
+        status: 'completed',
+      },
+    ]
+
+    expect(filterEvents(events, ['scheduled'], '')).toHaveLength(1)
+    expect(filterEvents(events, DEFAULT_STATUSES, 'bo')).toHaveLength(1)
+  })
+})

--- a/talentify-next-frontend/components/ui/badge.tsx
+++ b/talentify-next-frontend/components/ui/badge.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { cn } from '@/lib/utils'
 
-type BadgeVariant = 'default' | 'secondary' | 'destructive' | 'outline'
+type BadgeVariant =
+  | 'default'
+  | 'secondary'
+  | 'destructive'
+  | 'outline'
+  | 'success'
 
 interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
   className?: string
@@ -15,6 +20,7 @@ export function Badge({ className, variant = 'default', ...props }: BadgeProps) 
     secondary: 'bg-gray-100 text-gray-800',
     destructive: 'bg-red-600 text-white',
     outline: 'border border-gray-300 text-gray-700',
+    success: 'bg-green-600 text-white',
   }
 
   return <span className={cn(base, variants[variant], className)} {...props} />

--- a/talentify-next-frontend/utils/storeSchedule.ts
+++ b/talentify-next-frontend/utils/storeSchedule.ts
@@ -1,0 +1,60 @@
+import type { Event as BigCalendarEvent } from 'react-big-calendar'
+
+export type DisplayStatus =
+  | 'scheduled'
+  | 'completed'
+  | 'cancelled'
+  | 'no_show'
+
+export interface StoreScheduleEvent extends BigCalendarEvent {
+  talentId: string
+  offerId: string
+  talentName: string
+  status: DisplayStatus
+  startTime?: string | null
+  notes?: string | null
+}
+
+export const DEFAULT_STATUSES: DisplayStatus[] = [
+  'scheduled',
+  'completed',
+  'cancelled',
+  'no_show',
+]
+
+const RAW_STATUS_MAP: Record<string, DisplayStatus> = {
+  confirmed: 'scheduled',
+  pending: 'scheduled',
+  completed: 'completed',
+  cancelled: 'cancelled',
+  no_show: 'no_show',
+}
+
+export function mapOfferStatus(status: string | null | undefined): DisplayStatus {
+  if (!status) return 'scheduled'
+  return RAW_STATUS_MAP[status] ?? 'scheduled'
+}
+
+export function parseStatusesParam(param: string | null): DisplayStatus[] {
+  if (!param) return DEFAULT_STATUSES
+  const parts = param.split(',')
+  return DEFAULT_STATUSES.filter((s) => parts.includes(s))
+}
+
+export function stringifyStatuses(statuses: DisplayStatus[]): string | null {
+  if (statuses.length === DEFAULT_STATUSES.length) return null
+  return statuses.join(',')
+}
+
+export function filterEvents(
+  events: StoreScheduleEvent[],
+  statuses: DisplayStatus[],
+  q: string
+): StoreScheduleEvent[] {
+  const qLower = q.toLowerCase()
+  return events.filter(
+    (e) =>
+      statuses.includes(e.status) &&
+      (!qLower || e.talentName.toLowerCase().includes(qLower))
+  )
+}


### PR DESCRIPTION
## Summary
- add success badge variant for status chips
- rework store schedule page with toolbar, filters, and color-coded legend
- add utilities and tests for schedule status mapping and URL filter sync

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d9f3451d48332902a9148bed6478e