### PR TITLE
feat: redesign notification and settings pages

### DIFF
--- a/talentify-next-frontend/__tests__/formatJaDateTimeWithWeekday.test.ts
+++ b/talentify-next-frontend/__tests__/formatJaDateTimeWithWeekday.test.ts
@@ -1,0 +1,13 @@
+import { formatJaDateTimeWithWeekday } from '../utils/formatJaDateTimeWithWeekday'
+
+describe('formatJaDateTimeWithWeekday', () => {
+  test('formats date correctly', () => {
+    const d = new Date(2025, 7, 14, 9, 30)
+    expect(formatJaDateTimeWithWeekday(d)).toBe('2025年8月14日(木) 09:30')
+  })
+
+  test('returns empty string for invalid date', () => {
+    // @ts-expect-error invalid
+    expect(formatJaDateTimeWithWeekday('invalid')).toBe('')
+  })
+})

--- a/talentify-next-frontend/app/talent/notifications/page.tsx
+++ b/talentify-next-frontend/app/talent/notifications/page.tsx
@@ -2,10 +2,26 @@
 
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
-import { getNotifications, markNotificationRead, NotificationRow } from '@/utils/notifications'
+import {
+  getNotifications,
+  markNotificationRead,
+  markNotificationUnread,
+  markAllNotificationsRead,
+  NotificationRow,
+} from '@/utils/notifications'
+import { formatJaDateTimeWithWeekday } from '@/utils/formatJaDateTimeWithWeekday'
+import { Button } from '@/components/ui/button'
+
+const typeMap: Record<string, 'offer' | 'payment' | 'schedule' | 'other'> = {
+  offer_created: 'offer',
+  review_received: 'other',
+  payment_status: 'payment',
+  schedule_changed: 'schedule',
+}
 
 export default function TalentNotificationsPage() {
   const [items, setItems] = useState<NotificationRow[]>([])
+  const [filter, setFilter] = useState<'all' | 'offer' | 'payment' | 'schedule'>('all')
 
   useEffect(() => {
     getNotifications().then(setItems)
@@ -25,18 +41,77 @@ export default function TalentNotificationsPage() {
     return offerId ? `/talent/offers/${offerId}` : '#'
   }
 
+  const handleToggleRead = async (n: NotificationRow) => {
+    if (n.is_read) {
+      await markNotificationUnread(n.id)
+    } else {
+      await markNotificationRead(n.id)
+    }
+    setItems((prev) => prev.map((m) => (m.id === n.id ? { ...m, is_read: !n.is_read } : m)))
+  }
+
+  const handleMarkAll = async () => {
+    const unreadIds = items.filter((i) => !i.is_read).map((i) => i.id)
+    await markAllNotificationsRead(unreadIds)
+    setItems((prev) => prev.map((m) => ({ ...m, is_read: true })))
+  }
+
+  const filtered = items.filter((n) => {
+    if (filter === 'all') return true
+    return typeMap[n.type] === filter
+  })
+
   return (
-    <div className='max-w-screen-md mx-auto py-8 space-y-4'>
-      <h1 className='text-2xl font-bold'>通知一覧</h1>
-      <ul className='space-y-2'>
-        {items.map((n) => (
-          <li key={n.id} className={`p-3 border rounded hover:bg-gray-50 cursor-pointer ${!n.is_read ? 'font-semibold' : ''}`}
-              onClick={() => handleClick(n, linkFor(n))}>
-            <span>[{n.title}]（{n.created_at.slice(0,10)}）→</span>
+    <div className="max-w-screen-md mx-auto py-8 space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">通知</h1>
+        <Button variant="outline" size="sm" onClick={handleMarkAll} disabled={!items.some((i) => !i.is_read)}>
+          すべて既読
+        </Button>
+      </div>
+      <div className="flex gap-2">
+        {['all', 'offer', 'payment', 'schedule'].map((t) => (
+          <Button
+            key={t}
+            variant={filter === t ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setFilter(t as any)}
+          >
+            {t === 'all' ? 'すべて' : t === 'offer' ? 'オファー' : t === 'payment' ? '支払い' : 'スケジュール'}
+          </Button>
+        ))}
+      </div>
+      <ul className="space-y-2">
+        {filtered.map((n) => (
+          <li
+            key={n.id}
+            className={`relative p-3 border rounded hover:bg-gray-50 cursor-pointer group`}
+            onClick={() => handleClick(n, linkFor(n))}
+          >
+            {!n.is_read && <span className="absolute left-2 top-1/2 -translate-y-1/2 h-2 w-2 rounded-full bg-blue-500" />}
+            <div className="flex justify-between items-center pl-4">
+              <div>
+                <p className="font-medium">{n.title}</p>
+                <p className="text-sm text-muted-foreground line-clamp-1">{n.body || '—'}</p>
+              </div>
+              <span className="text-xs text-muted-foreground ml-2 whitespace-nowrap">
+                {formatJaDateTimeWithWeekday(n.created_at)}
+              </span>
+            </div>
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                handleToggleRead(n)
+              }}
+              className="absolute right-3 top-3 text-xs text-blue-600 opacity-0 group-hover:opacity-100"
+            >
+              {n.is_read ? '未読にする' : '既読にする'}
+            </button>
           </li>
         ))}
       </ul>
-      {items.length === 0 && <p className='text-sm text-muted-foreground'>通知はありません</p>}
+      {items.length === 0 && <p className="text-sm text-muted-foreground">通知はありません</p>}
     </div>
   )
 }
+

--- a/talentify-next-frontend/app/talent/settings/page.tsx
+++ b/talentify-next-frontend/app/talent/settings/page.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+import { useState } from 'react'
+import { SectionCard } from '@/components/settings/SectionCard'
+import { ToggleRow } from '@/components/settings/ToggleRow'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
+import { toast } from 'sonner'
+
+export default function TalentSettingsPage() {
+  const [email, setEmail] = useState('')
+  const [notifications, setNotifications] = useState({
+    offer: true,
+    schedule: true,
+    payment: true,
+  })
+  const [bank, setBank] = useState({
+    bankName: '',
+    branch: '',
+    type: '',
+    number: '',
+    holder: '',
+  })
+  const [saving, setSaving] = useState(false)
+
+  const handleSave = async () => {
+    setSaving(true)
+    try {
+      // TODO: API未接続
+      toast.success('保存しました')
+    } catch (e) {
+      toast.error('保存に失敗しました')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <main className="max-w-screen-md mx-auto p-4 space-y-6">
+      <h1 className="text-2xl font-bold">設定</h1>
+
+      <SectionCard title="アカウント設定">
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="email">ログインメール</Label>
+            <Input id="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+            <p className="text-xs text-muted-foreground">ログインに使用されます</p>
+          </div>
+          <Button type="button" variant="outline">
+            パスワード変更
+          </Button>
+          <Button type="button" variant="outline">
+            2段階認証（未対応）
+          </Button>
+        </div>
+      </SectionCard>
+
+      <SectionCard title="通知設定">
+        <div className="divide-y">
+          <ToggleRow
+            id="offer"
+            label="オファー受信通知"
+            checked={notifications.offer}
+            onCheckedChange={(v) => setNotifications({ ...notifications, offer: v })}
+          />
+          <ToggleRow
+            id="schedule"
+            label="スケジュール変更通知"
+            checked={notifications.schedule}
+            onCheckedChange={(v) => setNotifications({ ...notifications, schedule: v })}
+          />
+          <ToggleRow
+            id="payment"
+            label="支払いステータス通知"
+            checked={notifications.payment}
+            onCheckedChange={(v) => setNotifications({ ...notifications, payment: v })}
+          />
+        </div>
+      </SectionCard>
+
+      <SectionCard title="受取口座" description="現在は保存されません">
+        <div className="space-y-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="bankName">銀行名</Label>
+              <Input
+                id="bankName"
+                value={bank.bankName}
+                onChange={(e) => setBank({ ...bank, bankName: e.target.value })}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="branch">支店名</Label>
+              <Input id="branch" value={bank.branch} onChange={(e) => setBank({ ...bank, branch: e.target.value })} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="type">口座種別</Label>
+              <Input id="type" value={bank.type} onChange={(e) => setBank({ ...bank, type: e.target.value })} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="number">口座番号</Label>
+              <Input
+                id="number"
+                value={bank.number}
+                onChange={(e) =>
+                  setBank({ ...bank, number: e.target.value.replace(/[^0-9]/g, '') })
+                }
+              />
+            </div>
+            <div className="space-y-2 sm:col-span-2">
+              <Label htmlFor="holder">口座名義</Label>
+              <Input id="holder" value={bank.holder} onChange={(e) => setBank({ ...bank, holder: e.target.value })} />
+            </div>
+          </div>
+        </div>
+      </SectionCard>
+
+      <div className="flex justify-end">
+        <Button onClick={handleSave} disabled={saving}>
+          {saving ? '保存中...' : '保存'}
+        </Button>
+      </div>
+    </main>
+  )
+}
+

--- a/talentify-next-frontend/components/settings/LogoUploader.tsx
+++ b/talentify-next-frontend/components/settings/LogoUploader.tsx
@@ -1,0 +1,55 @@
+'use client'
+import { useRef, useState } from 'react'
+import { Button } from '@/components/ui/button'
+
+interface Props {
+  value?: string | null
+  onChange?: (file: File | null, preview: string | null) => void
+}
+
+export function LogoUploader({ value, onChange }: Props) {
+  const [preview, setPreview] = useState<string | null>(value ?? null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const handleSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    if (!file.type.startsWith('image/')) {
+      // TODO: show error
+      return
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      // TODO: show error
+      return
+    }
+    const url = URL.createObjectURL(file)
+    setPreview(url)
+    onChange?.(file, url)
+  }
+
+  const handleRemove = () => {
+    setPreview(null)
+    if (inputRef.current) inputRef.current.value = ''
+    onChange?.(null, null)
+  }
+
+  return (
+    <div className="space-y-2">
+      {preview && (
+        <div className="w-32 h-32">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={preview} alt="logo" className="object-contain w-full h-full rounded" />
+        </div>
+      )}
+      <div className="flex gap-2">
+        <input ref={inputRef} id="logo" type="file" accept="image/*" className="hidden" onChange={handleSelect} />
+        <Button type="button" onClick={() => inputRef.current?.click()}>アップロード</Button>
+        {preview && (
+          <Button type="button" variant="outline" onClick={handleRemove}>
+            削除
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/talentify-next-frontend/components/settings/NotificationList.tsx
+++ b/talentify-next-frontend/components/settings/NotificationList.tsx
@@ -1,0 +1,44 @@
+import { NotificationRow } from '@/utils/notifications'
+import { formatJaDateTimeWithWeekday } from '@/utils/formatJaDateTimeWithWeekday'
+
+interface Props {
+  items: NotificationRow[]
+  onItemClick?: (n: NotificationRow) => void
+  onToggleRead?: (n: NotificationRow) => void
+}
+
+export function NotificationList({ items, onItemClick, onToggleRead }: Props) {
+  return (
+    <ul className="space-y-2">
+      {items.map((n) => (
+        <li
+          key={n.id}
+          className={`relative p-3 border rounded hover:bg-gray-50 cursor-pointer group`}
+          onClick={() => onItemClick?.(n)}
+        >
+          {!n.is_read && <span className="absolute left-2 top-1/2 -translate-y-1/2 h-2 w-2 rounded-full bg-blue-500" />}
+          <div className="flex justify-between items-center pl-4">
+            <div>
+              <p className="font-medium">{n.title}</p>
+              <p className="text-sm text-muted-foreground line-clamp-1">{n.body || '—'}</p>
+            </div>
+            <span className="text-xs text-muted-foreground ml-2 whitespace-nowrap">
+              {formatJaDateTimeWithWeekday(n.created_at)}
+            </span>
+          </div>
+          {onToggleRead && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onToggleRead(n)
+              }}
+              className="absolute right-3 top-3 text-xs text-blue-600 opacity-0 group-hover:opacity-100"
+            >
+              {n.is_read ? '未読にする' : '既読にする'}
+            </button>
+          )}
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/talentify-next-frontend/components/settings/SectionCard.tsx
+++ b/talentify-next-frontend/components/settings/SectionCard.tsx
@@ -1,0 +1,18 @@
+import { PropsWithChildren } from 'react'
+
+interface SectionCardProps {
+  title: string
+  description?: string
+}
+
+export function SectionCard({ title, description, children }: PropsWithChildren<SectionCardProps>) {
+  return (
+    <section className="border rounded-md p-4 space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold">{title}</h2>
+        {description && <p className="text-sm text-muted-foreground">{description}</p>}
+      </div>
+      <div>{children}</div>
+    </section>
+  )
+}

--- a/talentify-next-frontend/components/settings/SettingsTabs.tsx
+++ b/talentify-next-frontend/components/settings/SettingsTabs.tsx
@@ -1,0 +1,49 @@
+'use client'
+import Link from 'next/link'
+
+interface Tab {
+  href: string
+  label: string
+}
+
+interface Props {
+  tabs: Tab[]
+  current: string
+}
+
+export function SettingsTabs({ tabs, current }: Props) {
+  return (
+    <div className="mb-4">
+      <div className="hidden sm:block border-b">
+        <nav className="-mb-px flex space-x-4">
+          {tabs.map((t) => (
+            <Link
+              key={t.href}
+              href={t.href}
+              className={`px-3 py-2 text-sm font-medium border-b-2 transition-colors ${
+                current === t.href ? 'border-primary' : 'border-transparent text-muted-foreground'
+              }`}
+            >
+              {t.label}
+            </Link>
+          ))}
+        </nav>
+      </div>
+      <div className="sm:hidden">
+        <select
+          className="w-full border rounded p-2"
+          value={current}
+          onChange={(e) => {
+            window.location.href = e.target.value
+          }}
+        >
+          {tabs.map((t) => (
+            <option key={t.href} value={t.href}>
+              {t.label}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  )
+}

--- a/talentify-next-frontend/components/settings/ToggleRow.tsx
+++ b/talentify-next-frontend/components/settings/ToggleRow.tsx
@@ -1,0 +1,22 @@
+import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
+
+interface ToggleRowProps {
+  id: string
+  label: string
+  description?: string
+  checked: boolean
+  onCheckedChange?: (checked: boolean) => void
+}
+
+export function ToggleRow({ id, label, description, checked, onCheckedChange }: ToggleRowProps) {
+  return (
+    <div className="flex items-center justify-between py-2">
+      <div className="space-y-1">
+        <Label htmlFor={id}>{label}</Label>
+        {description && <p className="text-xs text-muted-foreground">{description}</p>}
+      </div>
+      <Switch id={id} checked={checked} onCheckedChange={onCheckedChange} />
+    </div>
+  )
+}

--- a/talentify-next-frontend/utils/formatJaDateTimeWithWeekday.ts
+++ b/talentify-next-frontend/utils/formatJaDateTimeWithWeekday.ts
@@ -1,0 +1,15 @@
+import { format } from 'date-fns'
+import { ja } from 'date-fns/locale'
+
+/**
+ * Format date time in Japanese with weekday.
+ * Example: 2025年8月14日(木) 09:30
+ *
+ * @param d string or Date
+ * @returns formatted string or empty string if invalid
+ */
+export function formatJaDateTimeWithWeekday(d: string | Date): string {
+  const date = typeof d === 'string' ? new Date(d) : d
+  if (isNaN(date.getTime())) return ''
+  return format(date, "yyyy年M月d日(E) HH:mm", { locale: ja })
+}

--- a/talentify-next-frontend/utils/notifications.ts
+++ b/talentify-next-frontend/utils/notifications.ts
@@ -47,6 +47,21 @@ export async function markNotificationRead(id: string) {
     .eq('id', id)
 }
 
+export async function markNotificationUnread(id: string) {
+  await supabase
+    .from('notifications')
+    .update({ is_read: false, read_at: null })
+    .eq('id', id)
+}
+
+export async function markAllNotificationsRead(ids: string[]) {
+  if (ids.length === 0) return
+  await supabase
+    .from('notifications')
+    .update({ is_read: true, read_at: new Date().toISOString() })
+    .in('id', ids)
+}
+
 export async function addNotification(payload: AddNotificationPayload) {
   try {
     const res = await fetch(`${API_BASE}/api/notifications`, {


### PR DESCRIPTION
## Summary
- add formatJaDateTimeWithWeekday utility
- enhance talent notifications with filters, unread marker and mass read
- introduce talent settings page and reusable settings components

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ea14fa2808332a0e6a1c0fda470ac