### PR TITLE
feat: implement skeleton settings pages

### DIFF
--- a/talentify-next-frontend/app/store/settings/page.tsx
+++ b/talentify-next-frontend/app/store/settings/page.tsx
@@ -1,9 +1,13 @@
 'use client'
 
 import { useEffect, useState, useMemo } from 'react'
+import { usePathname, useSearchParams } from 'next/navigation'
 import { createClient } from '@/utils/supabase/client'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
+import { SettingsTabs } from '@/components/settings/SettingsTabs'
+import { SectionCard } from '@/components/settings/SectionCard'
+import { ToggleRow } from '@/components/settings/ToggleRow'
 import { toast } from 'sonner'
 
 interface Settings {
@@ -11,6 +15,97 @@ interface Settings {
   contact_person: string
   email: string
   phone: string
+}
+
+function AccountSection() {
+  const [saving, setSaving] = useState(false)
+
+  const handleSave = async () => {
+    setSaving(true)
+    await new Promise((r) => setTimeout(r, 500))
+    toast('（PR-1では）設定は未保存です/TODO')
+    setSaving(false)
+  }
+
+  const handleTodo = () => toast('TODO: ダイアログ未実装')
+
+  return (
+    <SectionCard
+      title="アカウント設定"
+      description="メールやパスワードの変更は今後対応予定です。"
+    >
+      <div className="space-y-4">
+        <div className="flex items-center justify-between py-2">
+          <div>
+            <p className="text-sm">メール変更</p>
+            <p className="text-xs text-muted-foreground">
+              この項目は今後有効になります（準備中）
+            </p>
+          </div>
+          <Button variant="outline" onClick={handleTodo}>
+            変更
+          </Button>
+        </div>
+        <div className="flex items-center justify-between py-2">
+          <div>
+            <p className="text-sm">パスワード変更</p>
+            <p className="text-xs text-muted-foreground">
+              この項目は今後有効になります（準備中）
+            </p>
+          </div>
+          <Button variant="outline" onClick={handleTodo}>
+            変更
+          </Button>
+        </div>
+        <div className="flex justify-end pt-2">
+          <Button onClick={handleSave} disabled={saving}>
+            {saving ? '保存中...' : '保存'}
+          </Button>
+        </div>
+      </div>
+    </SectionCard>
+  )
+}
+
+function NotificationsSection() {
+  const [saving, setSaving] = useState(false)
+  const [toggles, setToggles] = useState({ email: false, sms: false })
+
+  const handleSave = async () => {
+    setSaving(true)
+    await new Promise((r) => setTimeout(r, 500))
+    toast('（PR-1では）設定は未保存です/TODO')
+    setSaving(false)
+  }
+
+  return (
+    <SectionCard
+      title="通知設定"
+      description="通知のON/OFFは現在準備中です。"
+    >
+      <div className="divide-y">
+        <ToggleRow
+          id="store-notif-email"
+          label="メール通知"
+          description="この項目は今後有効になります（準備中）"
+          checked={toggles.email}
+          onCheckedChange={(v) => setToggles({ ...toggles, email: v })}
+        />
+        <ToggleRow
+          id="store-notif-sms"
+          label="SMS通知"
+          description="この項目は今後有効になります（準備中）"
+          checked={toggles.sms}
+          onCheckedChange={(v) => setToggles({ ...toggles, sms: v })}
+        />
+      </div>
+      <div className="flex justify-end pt-4">
+        <Button onClick={handleSave} disabled={saving}>
+          {saving ? '保存中...' : '保存'}
+        </Button>
+      </div>
+    </SectionCard>
+  )
 }
 
 export default function StoreSettingsPage() {
@@ -23,10 +118,23 @@ export default function StoreSettingsPage() {
     phone: '',
   })
 
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const tab = searchParams.get('tab') ?? 'store'
+
+  const tabs = [
+    { href: `${pathname}?tab=store`, label: '店舗情報' },
+    { href: `${pathname}?tab=account`, label: 'アカウント設定' },
+    { href: `${pathname}?tab=notifications`, label: '通知設定' },
+  ]
+
   useEffect(() => {
     const load = async () => {
       const { data: { user } } = await supabase.auth.getUser()
-      if (!user) { setLoading(false); return }
+      if (!user) {
+        setLoading(false)
+        return
+      }
 
       const { data } = await supabase
         .from('stores')
@@ -80,34 +188,70 @@ export default function StoreSettingsPage() {
     }
   }
 
-  if (loading) return <p className="p-4">読み込み中...</p>
+  const storeContent = (
+    <SectionCard title="店舗情報">
+      <div className="space-y-4">
+        <div>
+          <label className="block font-medium" htmlFor="store_name">
+            店舗名
+          </label>
+          <Input
+            id="store_name"
+            name="store_name"
+            value={settings.store_name}
+            onChange={handleChange}
+          />
+        </div>
+        <div>
+          <label className="block font-medium" htmlFor="contact_person">
+            担当者名
+          </label>
+          <Input
+            id="contact_person"
+            name="contact_person"
+            value={settings.contact_person}
+            onChange={handleChange}
+          />
+        </div>
+        <div>
+          <label className="block font-medium" htmlFor="email">
+            メールアドレス
+          </label>
+          <Input
+            id="email"
+            name="email"
+            type="email"
+            value={settings.email}
+            onChange={handleChange}
+          />
+        </div>
+        <div>
+          <label className="block font-medium" htmlFor="phone">
+            電話番号
+          </label>
+          <Input id="phone" name="phone" value={settings.phone} onChange={handleChange} />
+        </div>
+        <div className="flex justify-end">
+          <Button onClick={handleSave}>保存</Button>
+        </div>
+      </div>
+    </SectionCard>
+  )
+
+  let content: JSX.Element
+  if (tab === 'account') {
+    content = <AccountSection />
+  } else if (tab === 'notifications') {
+    content = <NotificationsSection />
+  } else {
+    content = loading ? <p className="p-4">読み込み中...</p> : storeContent
+  }
 
   return (
     <main className="max-w-2xl mx-auto p-6 space-y-6">
-      <h1 className="text-2xl font-bold">店舗設定</h1>
-
-      <div className="space-y-4">
-        <div>
-          <label className="block font-medium">店舗名</label>
-          <Input name="store_name" value={settings.store_name} onChange={handleChange} />
-        </div>
-        <div>
-          <label className="block font-medium">担当者名</label>
-          <Input name="contact_person" value={settings.contact_person} onChange={handleChange} />
-        </div>
-        <div>
-          <label className="block font-medium">メールアドレス</label>
-          <Input name="email" type="email" value={settings.email} onChange={handleChange} />
-        </div>
-        <div>
-          <label className="block font-medium">電話番号</label>
-          <Input name="phone" value={settings.phone} onChange={handleChange} />
-        </div>
-        <Button onClick={handleSave} className="mt-2">保存</Button>
-      </div>
-
-      {/* Toasts are handled globally */}
+      <h1 className="text-2xl font-bold">設定</h1>
+      <SettingsTabs tabs={tabs} current={`${pathname}?tab=${tab}`} />
+      {content}
     </main>
   )
 }
-

--- a/talentify-next-frontend/app/store/settings/page.tsx
+++ b/talentify-next-frontend/app/store/settings/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState, useMemo } from 'react'
+import { useEffect, useState, useMemo, type ReactNode } from 'react'
 import { usePathname, useSearchParams } from 'next/navigation'
 import { createClient } from '@/utils/supabase/client'
 import { Input } from '@/components/ui/input'
@@ -238,7 +238,7 @@ export default function StoreSettingsPage() {
     </SectionCard>
   )
 
-  let content: JSX.Element
+  let content: ReactNode
   if (tab === 'account') {
     content = <AccountSection />
   } else if (tab === 'notifications') {

--- a/talentify-next-frontend/app/talent/settings/page.tsx
+++ b/talentify-next-frontend/app/talent/settings/page.tsx
@@ -3,116 +3,75 @@
 import { useState } from 'react'
 import { SectionCard } from '@/components/settings/SectionCard'
 import { ToggleRow } from '@/components/settings/ToggleRow'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
 import { toast } from 'sonner'
 
 export default function TalentSettingsPage() {
-  const [email, setEmail] = useState('')
-  const [notifications, setNotifications] = useState({
-    offer: true,
-    schedule: true,
-    payment: true,
-  })
-  const [bank, setBank] = useState({
-    bankName: '',
-    branch: '',
-    type: '',
-    number: '',
-    holder: '',
-  })
   const [saving, setSaving] = useState(false)
+  const [notifications, setNotifications] = useState({ offer: false, message: false })
 
   const handleSave = async () => {
     setSaving(true)
-    try {
-      // TODO: API未接続
-      toast.success('保存しました')
-    } catch (e) {
-      toast.error('保存に失敗しました')
-    } finally {
-      setSaving(false)
-    }
+    await new Promise((r) => setTimeout(r, 500))
+    toast('（PR-1では）設定は未保存です/TODO')
+    setSaving(false)
   }
+
+  const handleTodo = () => toast('TODO: ダイアログ未実装')
 
   return (
     <main className="max-w-screen-md mx-auto p-4 space-y-6">
       <h1 className="text-2xl font-bold">設定</h1>
 
-      <SectionCard title="アカウント設定">
+      <SectionCard
+        title="アカウント設定"
+        description="メールやパスワードの変更は現在準備中です。"
+      >
         <div className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="email">ログインメール</Label>
-            <Input id="email" value={email} onChange={(e) => setEmail(e.target.value)} />
-            <p className="text-xs text-muted-foreground">ログインに使用されます</p>
+          <div className="flex items-center justify-between py-2">
+            <div>
+              <p className="text-sm">メール変更</p>
+              <p className="text-xs text-muted-foreground">
+                この項目は今後有効になります（準備中）
+              </p>
+            </div>
+            <Button variant="outline" onClick={handleTodo}>
+              変更
+            </Button>
           </div>
-          <Button type="button" variant="outline">
-            パスワード変更
-          </Button>
-          <Button type="button" variant="outline">
-            2段階認証（未対応）
-          </Button>
+          <div className="flex items-center justify-between py-2">
+            <div>
+              <p className="text-sm">パスワード変更</p>
+              <p className="text-xs text-muted-foreground">
+                この項目は今後有効になります（準備中）
+              </p>
+            </div>
+            <Button variant="outline" onClick={handleTodo}>
+              変更
+            </Button>
+          </div>
         </div>
       </SectionCard>
 
-      <SectionCard title="通知設定">
+      <SectionCard
+        title="通知設定"
+        description="通知のON/OFFは現在準備中です。"
+      >
         <div className="divide-y">
           <ToggleRow
-            id="offer"
-            label="オファー受信通知"
+            id="talent-notif-offer"
+            label="オファー通知"
+            description="この項目は今後有効になります（準備中）"
             checked={notifications.offer}
             onCheckedChange={(v) => setNotifications({ ...notifications, offer: v })}
           />
           <ToggleRow
-            id="schedule"
-            label="スケジュール変更通知"
-            checked={notifications.schedule}
-            onCheckedChange={(v) => setNotifications({ ...notifications, schedule: v })}
+            id="talent-notif-message"
+            label="メッセージ通知"
+            description="この項目は今後有効になります（準備中）"
+            checked={notifications.message}
+            onCheckedChange={(v) => setNotifications({ ...notifications, message: v })}
           />
-          <ToggleRow
-            id="payment"
-            label="支払いステータス通知"
-            checked={notifications.payment}
-            onCheckedChange={(v) => setNotifications({ ...notifications, payment: v })}
-          />
-        </div>
-      </SectionCard>
-
-      <SectionCard title="受取口座" description="現在は保存されません">
-        <div className="space-y-4">
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label htmlFor="bankName">銀行名</Label>
-              <Input
-                id="bankName"
-                value={bank.bankName}
-                onChange={(e) => setBank({ ...bank, bankName: e.target.value })}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="branch">支店名</Label>
-              <Input id="branch" value={bank.branch} onChange={(e) => setBank({ ...bank, branch: e.target.value })} />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="type">口座種別</Label>
-              <Input id="type" value={bank.type} onChange={(e) => setBank({ ...bank, type: e.target.value })} />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="number">口座番号</Label>
-              <Input
-                id="number"
-                value={bank.number}
-                onChange={(e) =>
-                  setBank({ ...bank, number: e.target.value.replace(/[^0-9]/g, '') })
-                }
-              />
-            </div>
-            <div className="space-y-2 sm:col-span-2">
-              <Label htmlFor="holder">口座名義</Label>
-              <Input id="holder" value={bank.holder} onChange={(e) => setBank({ ...bank, holder: e.target.value })} />
-            </div>
-          </div>
         </div>
       </SectionCard>
 
@@ -124,4 +83,3 @@ export default function TalentSettingsPage() {
     </main>
   )
 }
-


### PR DESCRIPTION
## Summary
- add tabbed store settings with placeholder sections for account and notifications
- create skeleton talent settings page with account and notification placeholders

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ea9c7d5c0833294c60dfcbb929a5e