### PR TITLE
Fix talent header and store names display

### DIFF
--- a/supabase-sql-proposals/20250326_talent_select_store.sql
+++ b/supabase-sql-proposals/20250326_talent_select_store.sql
@@ -1,0 +1,25 @@
+-- Allow talents to read related store names via offers
+create policy "talent_can_select_related_store_via_offers" on public.stores
+for select to authenticated
+using (
+  exists (
+    select 1
+    from public.talents t
+    join public.offers o on o.talent_id = t.id
+    where t.user_id = auth.uid()
+      and o.store_id = stores.id
+  )
+);
+
+-- Allow talents to read related store names via reviews
+create policy "talent_can_select_related_store_via_reviews" on public.stores
+for select to authenticated
+using (
+  exists (
+    select 1
+    from public.talents t
+    join public.reviews r on r.talent_id = t.id
+    where t.user_id = auth.uid()
+      and r.store_id = stores.id
+  )
+);

--- a/talentify-next-frontend/app/store/layout.tsx
+++ b/talentify-next-frontend/app/store/layout.tsx
@@ -3,6 +3,7 @@ import Header from "@/components/Header";
 import Sidebar from "@/components/Sidebar";
 import { createClient } from "@/lib/supabase/server";
 import { SupabaseProvider } from "@/lib/supabase/provider";
+import { getDisplayName } from "@/lib/getDisplayName";
 
 export const metadata = {
   title: "Talentify | 店舗",
@@ -17,12 +18,13 @@ export default async function StoreLayout({
   const {
     data: { session },
   } = await supabase.auth.getSession();
+  const displayName = await getDisplayName("store");
 
   return (
     <html lang="ja">
       <body className="font-sans antialiased bg-white text-black">
         <SupabaseProvider session={session}>
-          <Header sidebarRole="store" />
+          <Header sidebarRole="store" displayName={displayName} />
           <div className="flex h-[calc(100vh-64px)] pt-16">
             <Sidebar role="store" collapsible />
             <main className="flex-1 overflow-y-auto p-6 transition-[margin,width]">{children}</main>

--- a/talentify-next-frontend/app/talent/layout.tsx
+++ b/talentify-next-frontend/app/talent/layout.tsx
@@ -3,6 +3,7 @@ import Header from "@/components/Header";
 import Sidebar from "@/components/Sidebar";
 import { createClient } from "@/lib/supabase/server";
 import { SupabaseProvider } from "@/lib/supabase/provider";
+import { getDisplayName } from "@/lib/getDisplayName";
 
 export const metadata = {
   title: "Talentify | タレント",
@@ -17,13 +18,14 @@ export default async function TalentLayout({
   const {
     data: { session },
   } = await supabase.auth.getSession();
+  const displayName = await getDisplayName("talent");
 
   return (
     <html lang="ja">
       <body className="font-sans antialiased bg-white text-black">
         <SupabaseProvider session={session}>
           {/* 上部固定ヘッダー */}
-          <Header sidebarRole="talent" />
+          <Header sidebarRole="talent" displayName={displayName} />
 
           {/* ヘッダー高さ分の余白を考慮して下部を分割 */}
           <div className="flex h-[calc(100vh-64px)] pt-16">

--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -290,7 +290,7 @@ export default function TalentOfferDetailPage() {
               />
             </div>
           )}
-          {offer.store_name && <div className="text-lg font-bold">{offer.store_name}</div>}
+          <div className="text-lg font-bold">{offer.store_name ?? '店舗名不明'}</div>
           {offer.store_address && (
             <div className="text-sm text-muted-foreground">{offer.store_address}</div>
           )}

--- a/talentify-next-frontend/app/talent/offers/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/page.tsx
@@ -104,7 +104,7 @@ export default function TalentOffersPage() {
               <TableBody>
                 {sorted.map(o => (
                   <TableRow key={o.id} className="h-10">
-                    <TableCell className="truncate" title={o.store_name ?? ''}>{o.store_name ?? '-'}</TableCell>
+                    <TableCell className="truncate" title={o.store_name ?? ''}>{o.store_name ?? '店舗不明'}</TableCell>
                     <TableCell>{formatJaDateTimeWithWeekday(o.created_at ?? '')}</TableCell>
                     <TableCell>{o.date ? formatJaDateTimeWithWeekday(o.date) : '未定'}</TableCell>
                     <TableCell>{o.paid ? '済' : '未'}</TableCell>
@@ -128,7 +128,7 @@ export default function TalentOffersPage() {
             {sorted.map(o => (
               <div key={o.id} className="border rounded p-2 space-y-1">
                 <div className="flex justify-between items-center">
-                  <span className="font-medium truncate" title={o.store_name ?? ''}>{o.store_name ?? '-'}</span>
+                  <span className="font-medium truncate" title={o.store_name ?? ''}>{o.store_name ?? '店舗不明'}</span>
                   <Badge variant={statusVariants[o.status ?? 'pending']}>
                     {statusLabels[o.status ?? 'pending']}
                   </Badge>

--- a/talentify-next-frontend/components/Header.tsx
+++ b/talentify-next-frontend/components/Header.tsx
@@ -1,53 +1,19 @@
 'use client'
 
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
-import { Menu, Search } from 'lucide-react'
+import { Menu } from 'lucide-react'
 import Sidebar from './Sidebar'
 import { Sheet, SheetTrigger, SheetContent } from './ui/sheet'
 import { Button } from './ui/button'
-import { createClient } from '@/utils/supabase/client'
-import { getUserRoleInfo } from '@/lib/getUserRole'
 
-const supabase = createClient()
-
-export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'store' }) {
-  const [userName, setUserName] = useState<string | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
-
-  useEffect(() => {
-    const fetchSessionAndProfile = async () => {
-      const {
-        data: { session },
-      } = await supabase.auth.getSession()
-      const user = session?.user
-      if (!user) {
-        setIsLoading(false)
-        return
-      }
-
-      const { name } = await getUserRoleInfo(supabase, user.id)
-      setUserName(name ?? 'ユーザー')
-      setIsLoading(false)
-    }
-
-    fetchSessionAndProfile()
-
-    // リアルタイムで反映させる
-    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
-      if (session?.user) fetchSessionAndProfile()
-      else {
-        setUserName(null)
-        setIsLoading(false)
-      }
-    })
-
-    return () => {
-      listener.subscription.unsubscribe()
-    }
-  }, [])
-
-  const isLoggedIn = !!userName
+export default function Header({
+  sidebarRole,
+  displayName,
+}: {
+  sidebarRole?: 'talent' | 'store'
+  displayName?: string | null
+}) {
+  const isLoggedIn = !!displayName
 
   return (
     <header className="fixed top-0 w-full h-16 bg-white shadow-sm z-[var(--z-header)]">
@@ -69,7 +35,7 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
             Talentify
           </Link>
         </div>
-        {!isLoading && !isLoggedIn && (
+        {!isLoggedIn && (
           <Button
             asChild
             variant="outline"
@@ -79,8 +45,7 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
             <Link href="/login">ログイン</Link>
           </Button>
         )}
-        {!isLoading && (
-          <nav className="hidden md:flex justify-between items-center w-full text-sm">
+        <nav className="hidden md:flex justify-between items-center w-full text-sm">
             {/* 左メニュー */}
             <div className="flex space-x-6 ml-6">
               <Link href="/about" className="hover:underline">Talentifyについて</Link>
@@ -117,14 +82,13 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
               ) : (
                 <>
                   <span className="flex items-baseline font-semibold">
-                    <span className="text-base">{userName}</span>
+                    <span className="text-base">{displayName}</span>
                     <span className="ml-1 text-sm text-muted-foreground align-top">様</span>
                   </span>
                 </>
               )}
             </div>
-          </nav>
-        )}
+        </nav>
       </div>
     </header>
   )

--- a/talentify-next-frontend/lib/getDisplayName.ts
+++ b/talentify-next-frontend/lib/getDisplayName.ts
@@ -1,0 +1,37 @@
+import { createClient } from '@/lib/supabase/server'
+
+export async function getDisplayName(role: 'talent' | 'store') {
+  const supabase = await createClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  const user = session?.user
+  if (!user) return null
+
+  if (role === 'talent') {
+    const { data: talent } = await supabase
+      .from('talents' as any)
+      .select('stage_name')
+      .eq('user_id', user.id)
+      .maybeSingle()
+    if (talent?.stage_name) return talent.stage_name as string
+  } else if (role === 'store') {
+    const { data: store } = await supabase
+      .from('stores' as any)
+      .select('store_name')
+      .eq('user_id', user.id)
+      .maybeSingle()
+    if (store?.store_name) return store.store_name as string
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles' as any)
+    .select('display_name')
+    .eq('id', user.id)
+    .maybeSingle()
+
+  if (profile?.display_name) return profile.display_name as string
+  return user.email
+}
+
+export default getDisplayName

--- a/talentify-next-frontend/lib/getDisplayName.ts
+++ b/talentify-next-frontend/lib/getDisplayName.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@/lib/supabase/server'
 
 export async function getDisplayName(role: 'talent' | 'store') {
-  const supabase = await createClient()
+  const supabase = createClient()
   const {
     data: { session },
   } = await supabase.auth.getSession()
@@ -10,27 +10,27 @@ export async function getDisplayName(role: 'talent' | 'store') {
 
   if (role === 'talent') {
     const { data: talent } = await supabase
-      .from('talents' as any)
+      .from('talents')
       .select('stage_name')
       .eq('user_id', user.id)
-      .maybeSingle()
-    if (talent?.stage_name) return talent.stage_name as string
+      .maybeSingle<{ stage_name: string | null }>()
+    if (talent?.stage_name) return talent.stage_name
   } else if (role === 'store') {
     const { data: store } = await supabase
-      .from('stores' as any)
+      .from('stores')
       .select('store_name')
       .eq('user_id', user.id)
-      .maybeSingle()
-    if (store?.store_name) return store.store_name as string
+      .maybeSingle<{ store_name: string | null }>()
+    if (store?.store_name) return store.store_name
   }
 
   const { data: profile } = await supabase
     .from('profiles' as any)
     .select('display_name')
     .eq('id', user.id)
-    .maybeSingle()
+    .maybeSingle<{ display_name: string | null }>()
 
-  if (profile?.display_name) return profile.display_name as string
+  if (profile?.display_name) return profile.display_name
   return user.email
 }
 

--- a/talentify-next-frontend/lib/queries/dashboard.ts
+++ b/talentify-next-frontend/lib/queries/dashboard.ts
@@ -37,7 +37,7 @@ export async function getTalentDashboardData() {
   const { data: scheduleData } = talentId
     ? await supabase
         .from('offers')
-        .select('id, date, time_range, stores(store_name)')
+        .select('id, date, time_range, store:store_id(store_name)')
         .eq('talent_id', talentId)
         .eq('status', 'confirmed')
         .order('date', { ascending: true })
@@ -45,7 +45,7 @@ export async function getTalentDashboardData() {
 
   const schedule: ScheduleItem[] = (scheduleData ?? []).map((d: any) => ({
     date: d.date,
-    performer: d.stores?.store_name ?? '',
+    performer: d.store?.store_name ?? '',
     status: 'confirmed',
     href: `/talent/offers/${d.id}`,
   }))

--- a/talentify-next-frontend/supabase-docs/rls.md
+++ b/talentify-next-frontend/supabase-docs/rls.md
@@ -92,6 +92,35 @@ WITH CHECK (
 - ストアオーナーのみ閲覧可能 (`SELECT`): USING `(auth.uid() = user_id)`
 - ストアオーナーのみ更新可能 (`UPDATE`): USING `(auth.uid() = user_id)`, CHECK `(auth.uid() = user_id)`
 
+- タレントは自身に紐づくオファー経由で店舗名を閲覧可能 (`SELECT`):
+  ```sql
+  create policy "talent_can_select_related_store_via_offers" on public.stores
+  for select to authenticated
+  using (
+    exists (
+      select 1
+      from public.talents t
+      join public.offers o on o.talent_id = t.id
+      where t.user_id = auth.uid()
+        and o.store_id = stores.id
+    )
+  );
+  ```
+- タレントは自身のレビュー先の店舗名を閲覧可能 (`SELECT`):
+  ```sql
+  create policy "talent_can_select_related_store_via_reviews" on public.stores
+  for select to authenticated
+  using (
+    exists (
+      select 1
+      from public.talents t
+      join public.reviews r on r.talent_id = t.id
+      where t.user_id = auth.uid()
+        and r.store_id = stores.id
+    )
+  );
+  ```
+
 ### talents
 - タレント本人のみ登録可能 (`INSERT`): CHECK `(auth.uid() = user_id)`
 - ストアは公開済みでプロフィールが完成したタレントを閲覧可能 (`SELECT`): USING `(is_profile_complete = true)`

--- a/talentify-next-frontend/utils/getOffersForTalent.ts
+++ b/talentify-next-frontend/utils/getOffersForTalent.ts
@@ -29,7 +29,7 @@ export async function getOffersForTalent() {
 
   const { data, error } = await supabase
     .from('offers')
-    .select('id, store_id, created_at, date, status, payments(status,paid_at), stores(store_name)')
+    .select('id, store_id, created_at, date, status, payments(status,paid_at), store:store_id(store_name)')
     .eq('talent_id', talent.id)
     .order('created_at', { ascending: false })
 
@@ -41,7 +41,7 @@ export async function getOffersForTalent() {
   return (data ?? []).map((o: any) => ({
     id: o.id,
     store_id: o.store_id,
-    store_name: o.stores?.store_name ?? null,
+    store_name: o.store?.store_name ?? null,
     created_at: o.created_at,
     date: o.date,
     status: o.status,

--- a/talentify-next-frontend/utils/getTalentSchedule.ts
+++ b/talentify-next-frontend/utils/getTalentSchedule.ts
@@ -31,7 +31,7 @@ export async function getTalentSchedule(): Promise<TalentSchedule[]> {
 
   const { data, error } = await supabase
     .from('offers')
-    .select('id, date, time_range, stores(store_name)')
+    .select('id, date, time_range, store:store_id(store_name)')
     .eq('talent_id', talent.id)
     .eq('status', 'confirmed')
     .order('date', { ascending: true })
@@ -47,6 +47,6 @@ export async function getTalentSchedule(): Promise<TalentSchedule[]> {
     id: o.id,
     date: o.date,
     time_range: o.time_range,
-    store_name: o.stores?.store_name ?? null,
+    store_name: o.store?.store_name ?? null,
   }))
 }


### PR DESCRIPTION
## Summary
- show stage/store name in header using server-side display name lookup
- join stores for talent offers and reviews and remove placeholder names
- document and propose RLS policies allowing talents to read related store names

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ec15213c083329256e29945a102f9