### PR TITLE
fix: harden display name lookup

### DIFF
--- a/talentify-next-frontend/app/store/layout.tsx
+++ b/talentify-next-frontend/app/store/layout.tsx
@@ -1,30 +1,37 @@
-import React from "react";
-import Header from "@/components/Header";
-import Sidebar from "@/components/Sidebar";
-import { createClient } from "@/lib/supabase/server";
-import { SupabaseProvider } from "@/lib/supabase/provider";
-import { getDisplayName } from "@/lib/getDisplayName";
+import React from "react"
+import Header from "@/components/Header"
+import Sidebar from "@/components/Sidebar"
+import { createClient } from "@/lib/supabase/server"
+import { SupabaseProvider } from "@/lib/supabase/provider"
+import { getDisplayName } from "@/lib/getDisplayName"
 
 export const metadata = {
   title: "Talentify | 店舗",
-};
+}
 
 export default async function StoreLayout({
   children,
 }: {
-  children: React.ReactNode;
+  children: React.ReactNode
 }) {
-  const supabase = await createClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const displayName = await getDisplayName("store");
+  let session = null
+  try {
+    const supabase = createClient()
+    const {
+      data: { session: s },
+    } = await supabase.auth.getSession()
+    session = s
+  } catch (e) {
+    console.error("StoreLayout session error", e)
+  }
+
+  const displayName = await getDisplayName("store")
 
   return (
     <html lang="ja">
       <body className="font-sans antialiased bg-white text-black">
         <SupabaseProvider session={session}>
-          <Header sidebarRole="store" displayName={displayName} />
+          <Header sidebarRole="store" displayName={displayName || "ユーザー"} />
           <div className="flex h-[calc(100vh-64px)] pt-16">
             <Sidebar role="store" collapsible />
             <main className="flex-1 overflow-y-auto p-6 transition-[margin,width]">{children}</main>
@@ -32,5 +39,5 @@ export default async function StoreLayout({
         </SupabaseProvider>
       </body>
     </html>
-  );
+  )
 }

--- a/talentify-next-frontend/app/talent/layout.tsx
+++ b/talentify-next-frontend/app/talent/layout.tsx
@@ -1,31 +1,38 @@
-import React from "react";
-import Header from "@/components/Header";
-import Sidebar from "@/components/Sidebar";
-import { createClient } from "@/lib/supabase/server";
-import { SupabaseProvider } from "@/lib/supabase/provider";
-import { getDisplayName } from "@/lib/getDisplayName";
+import React from "react"
+import Header from "@/components/Header"
+import Sidebar from "@/components/Sidebar"
+import { createClient } from "@/lib/supabase/server"
+import { SupabaseProvider } from "@/lib/supabase/provider"
+import { getDisplayName } from "@/lib/getDisplayName"
 
 export const metadata = {
   title: "Talentify | タレント",
-};
+}
 
 export default async function TalentLayout({
   children,
 }: {
-  children: React.ReactNode;
+  children: React.ReactNode
 }) {
-  const supabase = await createClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const displayName = await getDisplayName("talent");
+  let session = null
+  try {
+    const supabase = createClient()
+    const {
+      data: { session: s },
+    } = await supabase.auth.getSession()
+    session = s
+  } catch (e) {
+    console.error("TalentLayout session error", e)
+  }
+
+  const displayName = await getDisplayName("talent")
 
   return (
     <html lang="ja">
       <body className="font-sans antialiased bg-white text-black">
         <SupabaseProvider session={session}>
           {/* 上部固定ヘッダー */}
-          <Header sidebarRole="talent" displayName={displayName} />
+          <Header sidebarRole="talent" displayName={displayName || "ユーザー"} />
 
           {/* ヘッダー高さ分の余白を考慮して下部を分割 */}
           <div className="flex h-[calc(100vh-64px)] pt-16">
@@ -37,5 +44,5 @@ export default async function TalentLayout({
         </SupabaseProvider>
       </body>
     </html>
-  );
+  )
 }

--- a/talentify-next-frontend/lib/getDisplayName.ts
+++ b/talentify-next-frontend/lib/getDisplayName.ts
@@ -1,37 +1,52 @@
 import { createClient } from '@/lib/supabase/server'
 
-export async function getDisplayName(role: 'talent' | 'store') {
-  const supabase = createClient()
-  const {
-    data: { session },
-  } = await supabase.auth.getSession()
-  const user = session?.user
-  if (!user) return null
+export async function getDisplayName(role?: 'store' | 'talent') {
+  try {
+    const supabase = createClient()
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser()
+    if (userError) {
+      console.error('getDisplayName getUser error', userError)
+    }
+    if (!user) return 'ゲスト'
 
-  if (role === 'talent') {
-    const { data: talent } = await supabase
-      .from('talents')
-      .select('stage_name')
-      .eq('user_id', user.id)
-      .maybeSingle<{ stage_name: string | null }>()
-    if (talent?.stage_name) return talent.stage_name
-  } else if (role === 'store') {
-    const { data: store } = await supabase
-      .from('stores')
-      .select('store_name')
-      .eq('user_id', user.id)
-      .maybeSingle<{ store_name: string | null }>()
-    if (store?.store_name) return store.store_name
+    if (role === 'talent') {
+      const { data: talent, error: talentError } = await supabase
+        .from('talents')
+        .select('stage_name')
+        .eq('user_id', user.id)
+        .maybeSingle<{ stage_name: string | null }>()
+      if (talentError) {
+        console.error('getDisplayName talent error', talentError)
+      }
+      if (talent?.stage_name) return talent.stage_name
+    } else if (role === 'store') {
+      const { data: store, error: storeError } = await supabase
+        .from('stores')
+        .select('store_name')
+        .eq('user_id', user.id)
+        .maybeSingle<{ store_name: string | null }>()
+      if (storeError) {
+        console.error('getDisplayName store error', storeError)
+      }
+      if (store?.store_name) return store.store_name
+    }
+
+    const { data: profile, error: profileError } = await supabase
+      .from('profiles' as any)
+      .select('display_name')
+      .eq('id', user.id)
+      .maybeSingle<{ display_name: string | null }>()
+    if (profileError) {
+      console.error('getDisplayName profile error', profileError)
+    }
+    return profile?.display_name ?? user.email ?? 'ユーザー'
+  } catch (e) {
+    console.error('getDisplayName failed', e)
+    return 'ユーザー'
   }
-
-  const { data: profile } = await supabase
-    .from('profiles' as any)
-    .select('display_name')
-    .eq('id', user.id)
-    .maybeSingle<{ display_name: string | null }>()
-
-  if (profile?.display_name) return profile.display_name
-  return user.email
 }
 
 export default getDisplayName


### PR DESCRIPTION
## Summary
- prevent `getDisplayName` from throwing and ensure fallback to safe values
- guard store/talent layouts so header renders even when display name lookup fails

## Testing
- `npm test`
- `npm run lint`
- `env CI=1 NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=key npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ec7cc9d7083329523720518c18990