### PR TITLE
Handle store dashboard load failures

### DIFF
--- a/talentify-next-frontend/app/store/dashboard/error.tsx
+++ b/talentify-next-frontend/app/store/dashboard/error.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  console.error(error)
+  return (
+    <div className="space-y-4 p-4">
+      <p className="text-sm text-red-600">データの取得に失敗しました。</p>
+      <Button onClick={() => reset()}>再試行</Button>
+    </div>
+  )
+}

--- a/talentify-next-frontend/app/store/dashboard/loading.tsx
+++ b/talentify-next-frontend/app/store/dashboard/loading.tsx
@@ -1,0 +1,15 @@
+import { CardSkeleton } from '@/components/ui/skeleton'
+
+export default function Loading() {
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 sm:grid-cols-2">
+        <CardSkeleton className="sm:col-span-2" />
+        <CardSkeleton />
+        <CardSkeleton />
+        <CardSkeleton className="sm:col-span-2" />
+        <CardSkeleton className="sm:col-span-2" />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add error handling when fetching store dashboard data
- show skeleton cards while dashboard data loads
- display a retryable error message if the dashboard fails to render

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ed9b78a44833285d4fdc0cda56cbb