### PR TITLE
fix: handle store dashboard errors and document RLS

### DIFF
--- a/supabase-sql-proposals/20250219_store_rls.sql
+++ b/supabase-sql-proposals/20250219_store_rls.sql
@@ -1,0 +1,19 @@
+-- Grant store owners access to their own stores and related profiles
+create policy if not exists "store owners can read own stores"
+  on public.stores for select using (auth.uid() = user_id);
+
+create policy if not exists "store owners can maintain own store profiles"
+  on public.store_profiles for select using (
+    exists (
+      select 1 from public.stores s
+      where s.id = store_profiles.store_id
+        and s.user_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1 from public.stores s
+      where s.id = store_profiles.store_id
+        and s.user_id = auth.uid()
+    )
+  );

--- a/talentify-next-frontend/app/store/dashboard/error.tsx
+++ b/talentify-next-frontend/app/store/dashboard/error.tsx
@@ -6,7 +6,7 @@ export default function Error({ error, reset }: { error: Error; reset: () => voi
   console.error(error)
   return (
     <div className="space-y-4 p-4">
-      <p className="text-sm text-red-600">データの取得に失敗しました。</p>
+      <p className="text-sm text-red-600">店舗情報を取得できませんでした。</p>
       <Button onClick={() => reset()}>再試行</Button>
     </div>
   )

--- a/talentify-next-frontend/lib/queries/dashboard.ts
+++ b/talentify-next-frontend/lib/queries/dashboard.ts
@@ -60,61 +60,76 @@ export async function getTalentDashboardData() {
 export async function getStoreDashboardData() {
   const supabase = createClient()
 
-  try {
-    const {
-      data: { user },
-    } = await supabase.auth.getUser()
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
 
-    if (!user) {
-      return { offerStats: {} as Record<string, number>, schedule: [] as ScheduleItem[], unreadCount: 0 }
-    }
-
-    const { data: store } = await supabase
-      .from('stores')
-      .select('id')
-      .eq('user_id', user.id)
-      .single()
-
-    const storeId = store?.id
-
-    const { data: offers } = storeId
-      ? await supabase.from('offers').select('status').eq('store_id', storeId)
-      : { data: [] }
-
-    const offerStats = (offers ?? []).reduce((acc: Record<string, number>, o: any) => {
-      const status = o.status ?? 'unknown'
-      acc[status] = (acc[status] ?? 0) + 1
-      return acc
-    }, {} as Record<string, number>)
-
-    const { data: scheduleData } = storeId
-      ? await supabase
-          .from('offers')
-          .select('id, date, talents(stage_name)')
-          .eq('store_id', storeId)
-          .eq('status', 'confirmed')
-          .gte('date', new Date().toISOString().slice(0, 10))
-          .order('date', { ascending: true })
-          .limit(5)
-      : { data: [] }
-
-    const schedule: ScheduleItem[] = (scheduleData ?? []).map((d: any) => ({
-      date: d.date,
-      performer: d.talents?.stage_name ?? '',
-      status: 'confirmed',
-      href: `/store/offers/${d.id}`,
-    }))
-
-    const { count: unreadCount } = await supabase
-      .from('notifications')
-      .select('*', { count: 'exact', head: true })
-      .eq('user_id', user.id)
-      .eq('type', 'message')
-      .eq('is_read', false)
-
-    return { offerStats, schedule, unreadCount: unreadCount ?? 0 }
-  } catch (error) {
-    console.error('failed to fetch store dashboard data', error)
-    return { offerStats: {} as Record<string, number>, schedule: [] as ScheduleItem[], unreadCount: 0 }
+  if (userError || !user) {
+    throw new Error('failed to fetch user session')
   }
+
+  const {
+    data: store,
+    error: storeError,
+  } = await supabase
+    .from('stores')
+    .select('id')
+    .eq('user_id', user.id)
+    .single()
+
+  if (storeError || !store) {
+    throw new Error(storeError?.message ?? 'store not found')
+  }
+
+  const {
+    data: offers,
+    error: offersError,
+  } = await supabase.from('offers').select('status').eq('store_id', store.id)
+
+  if (offersError) {
+    throw new Error(offersError.message)
+  }
+
+  const offerStats = (offers ?? []).reduce((acc: Record<string, number>, o: any) => {
+    const status = o.status ?? 'unknown'
+    acc[status] = (acc[status] ?? 0) + 1
+    return acc
+  }, {} as Record<string, number>)
+
+  const {
+    data: scheduleData,
+    error: scheduleError,
+  } = await supabase
+    .from('offers')
+    .select('id, date, talents(stage_name)')
+    .eq('store_id', store.id)
+    .eq('status', 'confirmed')
+    .gte('date', new Date().toISOString().slice(0, 10))
+    .order('date', { ascending: true })
+    .limit(5)
+
+  if (scheduleError) {
+    throw new Error(scheduleError.message)
+  }
+
+  const schedule: ScheduleItem[] = (scheduleData ?? []).map((d: any) => ({
+    date: d.date,
+    performer: d.talents?.stage_name ?? '',
+    status: 'confirmed',
+    href: `/store/offers/${d.id}`,
+  }))
+
+  const { count: unreadCount, error: unreadError } = await supabase
+    .from('notifications')
+    .select('*', { count: 'exact', head: true })
+    .eq('user_id', user.id)
+    .eq('type', 'message')
+    .eq('is_read', false)
+
+  if (unreadError) {
+    throw new Error(unreadError.message)
+  }
+
+  return { offerStats, schedule, unreadCount: unreadCount ?? 0 }
 }

--- a/talentify-next-frontend/supabase-docs/rls.md
+++ b/talentify-next-frontend/supabase-docs/rls.md
@@ -92,6 +92,11 @@ WITH CHECK (
 - ストアオーナーのみ閲覧可能 (`SELECT`): USING `(auth.uid() = user_id)`
 - ストアオーナーのみ更新可能 (`UPDATE`): USING `(auth.uid() = user_id)`, CHECK `(auth.uid() = user_id)`
 
+### store_profiles
+- ストアオーナーのみ登録可能 (`INSERT`): CHECK `EXISTS (SELECT 1 FROM stores s WHERE s.id = store_id AND s.user_id = auth.uid())`
+- ストアオーナーのみ閲覧可能 (`SELECT`): USING `EXISTS (SELECT 1 FROM stores s WHERE s.id = store_profiles.store_id AND s.user_id = auth.uid())`
+- ストアオーナーのみ更新可能 (`UPDATE`): USING `EXISTS (SELECT 1 FROM stores s WHERE s.id = store_profiles.store_id AND s.user_id = auth.uid())`, CHECK `EXISTS (SELECT 1 FROM stores s WHERE s.id = store_profiles.store_id AND s.user_id = auth.uid())`
+
 ### talents
 - タレント本人のみ登録可能 (`INSERT`): CHECK `(auth.uid() = user_id)`
 - ストアは公開済みでプロフィールが完成したタレントを閲覧可能 (`SELECT`): USING `(is_profile_complete = true)`


### PR DESCRIPTION
## Summary
- surface errors when fetching store dashboard data instead of silently returning empty objects
- show clear message on store dashboard failures
- document RLS policies for stores and store_profiles and add SQL proposal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689edd4ab06083329d364e88b403b730