### PR TITLE
refactor: fetch store info via offers join

### DIFF
--- a/talentify-next-frontend/app/talent/offers/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/page.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/components/ui/input'
 import { TableSkeleton } from '@/components/ui/skeleton'
 import { EmptyState } from '@/components/ui/empty-state'
 import { formatJaDateTimeWithWeekday } from '@/utils/formatJaDateTimeWithWeekday'
+import { toast } from 'sonner'
 
 const statusLabels: Record<string, string> = {
   pending: '保留中',
@@ -35,9 +36,15 @@ export default function TalentOffersPage() {
 
   useEffect(() => {
     const load = async () => {
-      const data = await getOffersForTalent()
-      setOffers(data)
-      setLoading(false)
+      try {
+        const data = await getOffersForTalent()
+        setOffers(data)
+      } catch (e) {
+        console.error('failed to load offers', e)
+        toast.error('オファーの取得に失敗しました')
+      } finally {
+        setLoading(false)
+      }
     }
     load()
   }, [])

--- a/talentify-next-frontend/types/supabase.ts
+++ b/talentify-next-frontend/types/supabase.ts
@@ -536,7 +536,14 @@ export type Database = {
           invoice_url?: string | null
           contract_url?: string | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: 'offers_store_id_fkey',
+            columns: ['store_id'],
+            referencedRelation: 'stores',
+            referencedColumns: ['id'],
+          },
+        ]
       }
     }
     Views: {


### PR DESCRIPTION
## Summary
- fetch talent offer store details through `offers` join
- document RLS policy update for `stores`

## Testing
- `npm run lint`
- `npx tsc --noEmit` *(fails: __tests__/formatJaDateTimeWithWeekday.test.ts:10:5: Unused '@ts-expect-error' directive)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689eea0a5210833281f2500954522fd6