### PR TITLE
fix: format store review dates

### DIFF
--- a/talentify-next-frontend/app/store/reviews/page.tsx
+++ b/talentify-next-frontend/app/store/reviews/page.tsx
@@ -37,7 +37,13 @@ export default function StoreReviewsPage() {
           <TableBody>
             {offers.map(o => (
               <TableRow key={o.id}>
-                <TableCell>{o.date}</TableCell>
+                <TableCell>
+                  {new Date(o.date).toLocaleDateString('ja-JP', {
+                    year: 'numeric',
+                    month: '2-digit',
+                    day: '2-digit',
+                  })}
+                </TableCell>
                 <TableCell>{o.talent_name || o.talent_id}</TableCell>
                 <TableCell>
                   {o.reviewed ? (


### PR DESCRIPTION
## Summary
- format review dates in store dashboard using locale date string

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a53746e67483329b68e757f52987d7