### PR TITLE
fix: show talent name in header

### DIFF
--- a/talentify-next-frontend/components/Header.tsx
+++ b/talentify-next-frontend/components/Header.tsx
@@ -27,7 +27,22 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
       }
 
       const { name } = await getUserRoleInfo(supabase, user.id)
-      setUserName(name ?? 'ユーザー')
+      let displayName = name
+
+      if (!displayName) {
+        const { data: profile } = await supabase
+          .from('profiles' as any)
+          .select('display_name')
+          .eq('id', user.id)
+          .maybeSingle()
+        displayName = (profile as any)?.display_name ?? null
+      }
+
+      if (!displayName) {
+        displayName = user.email?.split('@')[0] ?? 'ユーザー'
+      }
+
+      setUserName(displayName)
       setIsLoading(false)
     }
 

--- a/talentify-next-frontend/lib/getUserRole.ts
+++ b/talentify-next-frontend/lib/getUserRole.ts
@@ -20,7 +20,7 @@ export async function getUserRoleInfo(
     supabase
       .from('talents' as any)
       .select('stage_name, is_setup_complete')
-      .eq('id', userId)
+      .eq('user_id', userId)
       .maybeSingle(),
     supabase
       .from('companies' as any)
@@ -40,7 +40,7 @@ export async function getUserRoleInfo(
   if (talent) {
     return {
       role: 'talent',
-      name: (talent as any).stage_name ?? 'タレント',
+      name: (talent as any).stage_name ?? null,
       isSetupComplete: (talent as any).is_setup_complete ?? false,
     }
   }


### PR DESCRIPTION
## Summary
- display logged-in talent name in header using stage_name -> profile -> email
- query talents by user_id for accurate name

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a54efb45588332bfe37177ea012dd6