### PR TITLE
fix: include store name in talent reviews

### DIFF
--- a/talentify-next-frontend/utils/getReviewsForTalent.ts
+++ b/talentify-next-frontend/utils/getReviewsForTalent.ts
@@ -30,7 +30,9 @@ export async function getReviewsForTalent() {
 
   const { data, error } = await supabase
     .from('reviews' as any)
-    .select('id, rating, category_ratings, comment, created_at, store:store_id(store_name), offers(date)')
+    .select(
+      'id, rating, category_ratings, comment, created_at, store:stores(store_name), offers(date)'
+    )
     .eq('talent_id', talent.id)
     .order('created_at', { ascending: false })
 


### PR DESCRIPTION
## Summary
- join stores table to fetch store_name in talent review list

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5579c01588332b7761c6a750a5f72