### PR TITLE
Fix offer status query and mapping for canceled statuses

### DIFF
--- a/talentify-next-frontend/__tests__/storeSchedule.test.ts
+++ b/talentify-next-frontend/__tests__/storeSchedule.test.ts
@@ -12,6 +12,7 @@ describe('store schedule utils', () => {
     expect(mapOfferStatus('confirmed')).toBe('scheduled')
     expect(mapOfferStatus('completed')).toBe('completed')
     expect(mapOfferStatus('cancelled')).toBe('cancelled')
+    expect(mapOfferStatus('canceled')).toBe('cancelled')
     expect(mapOfferStatus('no_show')).toBe('no_show')
     expect(mapOfferStatus('unknown')).toBe('scheduled')
   })

--- a/talentify-next-frontend/app/store/schedule/page.tsx
+++ b/talentify-next-frontend/app/store/schedule/page.tsx
@@ -113,7 +113,7 @@ export default function StoreSchedulePage() {
       } = await supabase.auth.getUser()
       if (!user) return
 
-      const statusesQuery = ['confirmed', 'cancelled', 'no_show']
+      const statusesQuery = ['confirmed', 'canceled', 'no_show']
       if (includeCompleted) statusesQuery.push('completed')
 
       const { data: store } = await supabase

--- a/talentify-next-frontend/utils/storeSchedule.ts
+++ b/talentify-next-frontend/utils/storeSchedule.ts
@@ -27,6 +27,7 @@ const RAW_STATUS_MAP: Record<string, DisplayStatus> = {
   pending: 'scheduled',
   completed: 'completed',
   cancelled: 'cancelled',
+  canceled: 'cancelled',
   no_show: 'no_show',
 }
 


### PR DESCRIPTION
## Summary
- fix store schedule query to use `canceled` status
- map raw `canceled` status to display `cancelled`
- adjust tests for new status mapping

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a57f3cc03483329675a2d1c42b8112