### PR TITLE
fix: prevent calendar bottom cut off

### DIFF
--- a/talentify-next-frontend/app/store/schedule/page.tsx
+++ b/talentify-next-frontend/app/store/schedule/page.tsx
@@ -324,7 +324,7 @@ export default function StoreSchedulePage() {
           </div>
         ))}
       </div>
-      <div className="overflow-hidden">
+      <div className="h-[430px]">
         <BigCalendar
           culture="ja"
           toolbar={false}


### PR DESCRIPTION
## Summary
- ensure full calendar is visible by giving its container fixed height

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abe84e12708332aa17684574c6e5a8