### PR TITLE
feat: hide footer after login and expose legal links

### DIFF
--- a/talentify-next-frontend/app/(auth)/layout.tsx
+++ b/talentify-next-frontend/app/(auth)/layout.tsx
@@ -5,7 +5,6 @@ export const dynamic = "auto";
 import React from "react";
 import "../globals.css";
 import Header from "@/components/Header";
-import Footer from "@/components/Footer";
 import { createClient } from "@/lib/supabase/server";
 import { SupabaseProvider } from "@/lib/supabase/provider";
 
@@ -33,7 +32,6 @@ export default async function AuthLayout({
         <SupabaseProvider session={session}>
           <Header />
           {children}
-          <Footer />
         </SupabaseProvider>
       </body>
     </html>

--- a/talentify-next-frontend/app/layout.tsx
+++ b/talentify-next-frontend/app/layout.tsx
@@ -6,6 +6,8 @@ import Header from "../components/Header";
 import Footer from "../components/Footer";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { createClient } from "@/lib/supabase/server";
+import { SupabaseProvider } from "@/lib/supabase/provider";
 
 export const metadata = {
   title: "Talentify",
@@ -20,15 +22,24 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const supabase = await createClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  const showFooter = !session;
+
   return (
     <html lang="ja">
       <body className="font-sans antialiased bg-white text-black">
-        <TooltipProvider delayDuration={200} disableHoverableContent>
-          <Header />
-          <Toaster />
-          {children}
-          <Footer />
-        </TooltipProvider>
+        <SupabaseProvider session={session}>
+          <TooltipProvider delayDuration={200} disableHoverableContent>
+            <Header />
+            <Toaster />
+            {children}
+            {showFooter && <Footer />}
+          </TooltipProvider>
+        </SupabaseProvider>
       </body>
     </html>
   );

--- a/talentify-next-frontend/components/Header.tsx
+++ b/talentify-next-frontend/components/Header.tsx
@@ -6,6 +6,12 @@ import { Menu, Search } from 'lucide-react'
 import Sidebar from './Sidebar'
 import { Sheet, SheetTrigger, SheetContent } from './ui/sheet'
 import { Button } from './ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem
+} from './ui/dropdown-menu'
 import { createClient } from '@/utils/supabase/client'
 import { getUserRoleInfo } from '@/lib/getUserRole'
 
@@ -94,6 +100,23 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
             <Link href="/login">ログイン</Link>
           </Button>
         )}
+        {!isLoading && isLoggedIn && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button className="ml-auto md:hidden text-sm font-semibold focus:outline-none">
+                {userName}
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem asChild>
+                <Link href="/terms">利用規約</Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <Link href="/privacy">プライバシーポリシー</Link>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
         {!isLoading && (
           <nav className="hidden md:flex justify-between items-center w-full text-sm">
             {/* 左メニュー */}
@@ -130,12 +153,22 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
                   </Link>
                 </>
               ) : (
-                <>
-                  <span className="flex items-baseline font-semibold">
-                    <span className="text-base">{userName}</span>
-                    <span className="ml-1 text-sm text-muted-foreground align-top">様</span>
-                  </span>
-                </>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <button className="flex items-baseline font-semibold focus:outline-none">
+                      <span className="text-base">{userName}</span>
+                      <span className="ml-1 text-sm text-muted-foreground align-top">様</span>
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem asChild>
+                      <Link href="/terms">利用規約</Link>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem asChild>
+                      <Link href="/privacy">プライバシーポリシー</Link>
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
               )}
             </div>
           </nav>


### PR DESCRIPTION
## Summary
- hide footer for authenticated pages
- show footer only on public pages
- add terms/privacy links to header user menu

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abf53d1c8083329c11c6ccfe15839e