### PR TITLE
feat: redesign talent search grid cards

### DIFF
--- a/talentify-next-frontend/components/talent-search/TalentCard.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentCard.tsx
@@ -1,7 +1,8 @@
 import Image from 'next/image'
 import Link from 'next/link'
-import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
 import type { PublicTalent } from '@/types/talent'
+import { ZoomIn } from 'lucide-react'
 
 export default function TalentCard({ talent }: { talent: PublicTalent }) {
   const isValidHttpUrl = (url: string) => {
@@ -16,42 +17,38 @@ export default function TalentCard({ talent }: { talent: PublicTalent }) {
   const imageSrc = talent.avatar_url && isValidHttpUrl(talent.avatar_url)
     ? talent.avatar_url
     : '/avatar-default.svg'
+  const subInfo =
+    talent.rate != null
+      ? `料金: ${talent.rate}`
+      : talent.genre || talent.area || ''
 
   return (
     <Link
       href={`/talents/${talent.id}`}
-      className="block focus:outline-none focus:ring-2 focus:ring-offset-2"
+      className="block group focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 rounded-2xl"
     >
-      <Card className="flex flex-col transition-transform hover:shadow-md hover:scale-[1.02]">
-        <CardHeader className="flex items-center gap-3">
-          <div className="w-16 h-16 rounded-full overflow-hidden bg-gray-100">
-            <Image
-              src={imageSrc}
-              alt={talent.stage_name ?? 'Avatar'}
-              width={64}
-              height={64}
-              className="object-cover w-full h-full"
-            />
+      <div className="overflow-hidden rounded-2xl border bg-white transition hover:translate-y-[-2px] hover:shadow-lg">
+        <div className="relative aspect-[4/5] bg-gray-100">
+          <Image
+            src={imageSrc}
+            alt={talent.stage_name ?? 'Avatar'}
+            fill
+            className="object-cover"
+            loading="lazy"
+            sizes="(min-width: 1024px) 20vw, (min-width: 768px) 30vw, 45vw"
+          />
+          <div className="absolute inset-0 bg-black/0 group-hover:bg-black/10 flex items-end justify-end p-2 transition">
+            <ZoomIn className="h-5 w-5 text-white opacity-0 group-hover:opacity-100" />
           </div>
-          <div className="text-lg font-semibold">{talent.stage_name}</div>
-        </CardHeader>
-        <CardContent className="text-sm space-y-1">
-          {(talent.genre || talent.area) && (
-            <p className="text-gray-600">
-              {talent.genre}
-              {talent.genre && talent.area ? '・' : ''}
-              {talent.area}
-            </p>
+        </div>
+        <div className="p-3 space-y-1">
+          <p className="text-base font-semibold line-clamp-2">{talent.stage_name}</p>
+          {subInfo && (
+            <p className="text-sm text-muted-foreground line-clamp-1">{subInfo}</p>
           )}
-          {talent.rating != null && (
-            <p className="text-gray-600">評価: {talent.rating}</p>
-          )}
-          {talent.rate != null && (
-            <p className="text-gray-600">料金: {talent.rate}</p>
-          )}
-          {talent.bio && <p className="line-clamp-2">{talent.bio}</p>}
-        </CardContent>
-      </Card>
+          {talent.genre && <Badge className="mt-1">{talent.genre}</Badge>}
+        </div>
+      </div>
     </Link>
   )
 }

--- a/talentify-next-frontend/components/talent-search/TalentCardSkeleton.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentCardSkeleton.tsx
@@ -1,0 +1,12 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+export default function TalentCardSkeleton() {
+  return (
+    <div className="rounded-2xl border bg-white p-3 shadow-md space-y-3">
+      <Skeleton className="w-full aspect-[4/5] rounded-2xl" />
+      <Skeleton className="h-4 w-3/4" />
+      <Skeleton className="h-3 w-1/2" />
+    </div>
+  )
+}
+

--- a/talentify-next-frontend/components/talent-search/TalentList.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentList.tsx
@@ -1,19 +1,28 @@
 import TalentCard from './TalentCard'
 import type { PublicTalent } from '@/types/talent'
+import { EmptyState } from '@/components/ui/empty-state'
+import { SearchX } from 'lucide-react'
 
 export default function TalentList({ talents }: { talents: PublicTalent[] }) {
+  if (talents.length === 0) {
+    return (
+      <EmptyState
+        illustration={<SearchX className="h-12 w-12 text-muted-foreground" />}
+        title="条件に合う演者が見つかりません"
+        actionHref="/search/talents"
+        actionLabel="条件をリセット"
+      />
+    )
+  }
+
   return (
     <>
       <p className="mb-4 text-sm text-gray-700">検索結果：{talents.length}件</p>
-      {talents.length === 0 ? (
-        <p className="p-4">検索条件に一致するキャストがいません</p>
-      ) : (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {talents.map(t => (
-            <TalentCard key={t.id} talent={t} />
-          ))}
-        </div>
-      )}
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-5">
+        {talents.map(t => (
+          <TalentCard key={t.id} talent={t} />
+        ))}
+      </div>
     </>
   )
 }

--- a/talentify-next-frontend/components/talent-search/TalentSearchPage.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentSearchPage.tsx
@@ -7,6 +7,9 @@ import { toast } from 'sonner'
 import TalentSearchForm, { SearchFilters } from './TalentSearchForm'
 import TalentList from './TalentList'
 import type { PublicTalent } from '@/types/talent'
+import TalentCardSkeleton from './TalentCardSkeleton'
+import { EmptyState } from '@/components/ui/empty-state'
+import { AlertCircle } from 'lucide-react'
 
 const ITEMS_PER_PAGE = 6
 
@@ -14,9 +17,12 @@ export default function TalentSearchPage() {
   const [talents, setTalents] = useState<PublicTalent[]>([])
   const [results, setResults] = useState<PublicTalent[]>([])
   const [page, setPage] = useState(1)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState(false)
 
   useEffect(() => {
     const fetchTalents = async () => {
+      setIsLoading(true)
       const supabase = createClient() as SupabaseClient<any>
       const { data, error } = await supabase
         .from('public_talent_profiles')
@@ -28,11 +34,15 @@ export default function TalentSearchPage() {
         toast.error('タレントの取得に失敗しました')
         setTalents([])
         setResults([])
+        setError(true)
+        setIsLoading(false)
         return
       }
 
       setTalents(data ?? [])
       setResults(data ?? [])
+      setError(false)
+      setIsLoading(false)
     }
 
     fetchTalents()
@@ -55,10 +65,25 @@ export default function TalentSearchPage() {
   const paginated = results.slice((page - 1) * ITEMS_PER_PAGE, page * ITEMS_PER_PAGE)
 
   return (
-    <main className="max-w-5xl mx-auto p-4 space-y-6">
+    <main className="mx-auto px-6 md:px-8 lg:px-12 space-y-6">
       <TalentSearchForm onSearch={handleSearch} />
-      <TalentList talents={paginated} />
-      {totalPages > 1 && (
+      {isLoading ? (
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-5">
+          {Array.from({ length: ITEMS_PER_PAGE }).map((_, i) => (
+            <TalentCardSkeleton key={i} />
+          ))}
+        </div>
+      ) : error ? (
+        <EmptyState
+          illustration={<AlertCircle className="h-12 w-12 text-muted-foreground" />}
+          title="エラーが発生しました"
+          actionHref="/search/talents"
+          actionLabel="再読み込み"
+        />
+      ) : (
+        <TalentList talents={paginated} />
+      )}
+      {!isLoading && !error && totalPages > 1 && (
         <div className="flex justify-center mt-6">
           <nav className="flex space-x-2">
             {Array.from({ length: totalPages }, (_, i) => i + 1).map(p => (


### PR DESCRIPTION
## Summary
- redesign talent cards to photo-focused layout with hover zoom icon
- show talent results in responsive 2-5 column grid with empty state and skeletons
- add loading and error handling to talent search page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abf9c6b6c88332b026c1c75e26d302