### PR TITLE
Fix sidebar toggle clipping and accessibility

### DIFF
--- a/talentify-next-frontend/app/search/layout.tsx
+++ b/talentify-next-frontend/app/search/layout.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import Header from '@/components/Header'
 import Sidebar from '@/components/Sidebar'
+import { SidebarProvider } from '@/components/SidebarProvider'
+import SidebarToggle from '@/components/SidebarToggle'
 import { createClient } from '@/lib/supabase/server'
 import { SupabaseProvider } from '@/lib/supabase/provider'
 
@@ -24,8 +26,11 @@ export default async function SearchLayout({
         <SupabaseProvider session={session}>
           <Header sidebarRole="store" />
           <div className="flex h-[calc(100vh-64px)] pt-16">
-            <Sidebar role="store" collapsible />
-            <main className="flex-1 overflow-y-auto p-6 transition-[margin,width]">{children}</main>
+            <SidebarProvider>
+              <Sidebar role="store" collapsible />
+              <SidebarToggle />
+              <main className="flex-1 overflow-y-auto p-6 transition-[margin,width]">{children}</main>
+            </SidebarProvider>
           </div>
         </SupabaseProvider>
       </body>

--- a/talentify-next-frontend/app/store/layout.tsx
+++ b/talentify-next-frontend/app/store/layout.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import Header from "@/components/Header";
 import Sidebar from "@/components/Sidebar";
+import { SidebarProvider } from "@/components/SidebarProvider";
+import SidebarToggle from "@/components/SidebarToggle";
 import { createClient } from "@/lib/supabase/server";
 import { SupabaseProvider } from "@/lib/supabase/provider";
 
@@ -24,8 +26,11 @@ export default async function StoreLayout({
         <SupabaseProvider session={session}>
           <Header sidebarRole="store" />
           <div className="flex h-[calc(100vh-64px)] pt-16">
-            <Sidebar role="store" collapsible />
-            <main className="flex-1 overflow-y-auto p-6 transition-[margin,width]">{children}</main>
+            <SidebarProvider>
+              <Sidebar role="store" collapsible />
+              <SidebarToggle />
+              <main className="flex-1 overflow-y-auto p-6 transition-[margin,width]">{children}</main>
+            </SidebarProvider>
           </div>
         </SupabaseProvider>
       </body>

--- a/talentify-next-frontend/app/talent/layout.tsx
+++ b/talentify-next-frontend/app/talent/layout.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import Header from "@/components/Header";
 import Sidebar from "@/components/Sidebar";
+import { SidebarProvider } from "@/components/SidebarProvider";
+import SidebarToggle from "@/components/SidebarToggle";
 import { createClient } from "@/lib/supabase/server";
 import { SupabaseProvider } from "@/lib/supabase/provider";
 
@@ -27,10 +29,12 @@ export default async function TalentLayout({
 
           {/* ヘッダー高さ分の余白を考慮して下部を分割 */}
           <div className="flex h-[calc(100vh-64px)] pt-16">
-            <Sidebar role="talent" collapsible />
-
-            {/* メインコンテンツ */}
-            <main className="flex-1 overflow-y-auto p-6 transition-[margin,width]">{children}</main>
+            <SidebarProvider>
+              <Sidebar role="talent" collapsible />
+              <SidebarToggle />
+              {/* メインコンテンツ */}
+              <main className="flex-1 overflow-y-auto p-6 transition-[margin,width]">{children}</main>
+            </SidebarProvider>
           </div>
         </SupabaseProvider>
       </body>

--- a/talentify-next-frontend/app/talents/layout.tsx
+++ b/talentify-next-frontend/app/talents/layout.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import Header from '@/components/Header'
 import Sidebar from '@/components/Sidebar'
+import { SidebarProvider } from '@/components/SidebarProvider'
+import SidebarToggle from '@/components/SidebarToggle'
 import { createClient } from '@/lib/supabase/server'
 import { SupabaseProvider } from '@/lib/supabase/provider'
 
@@ -24,8 +26,11 @@ export default async function TalentsLayout({
         <SupabaseProvider session={session}>
           <Header sidebarRole="store" />
           <div className="flex h-[calc(100vh-64px)] pt-16">
-            <Sidebar role="store" collapsible />
-            <main className="flex-1 overflow-y-auto p-6 transition-[margin,width]">{children}</main>
+            <SidebarProvider>
+              <Sidebar role="store" collapsible />
+              <SidebarToggle />
+              <main className="flex-1 overflow-y-auto p-6 transition-[margin,width]">{children}</main>
+            </SidebarProvider>
           </div>
         </SupabaseProvider>
       </body>

--- a/talentify-next-frontend/components/Sidebar.tsx
+++ b/talentify-next-frontend/components/Sidebar.tsx
@@ -23,9 +23,8 @@ import {
   Settings,
   Search,
   LogOut,
-  ChevronLeft,
-  ChevronRight,
 } from "lucide-react";
+import { useSidebar } from "@/components/SidebarProvider";
 
 const navItems = {
   talent: [
@@ -67,18 +66,8 @@ export default function Sidebar({
   const pathname = usePathname();
   const router = useRouter();
   const supabase = useMemo(() => createClient(), []);
-  const [collapsed, setCollapsed] = useState(false);
+  const { collapsed } = useSidebar();
   const [loggedIn, setLoggedIn] = useState(false);
-
-  const STORAGE_KEY = "sidebar:collapsed";
-
-  useEffect(() => {
-    try {
-      const saved =
-        typeof window !== "undefined" ? localStorage.getItem(STORAGE_KEY) : null;
-      if (saved != null) setCollapsed(saved === "true");
-    } catch {}
-  }, []);
 
   useEffect(() => {
     const checkSession = async () => {
@@ -104,16 +93,6 @@ export default function Sidebar({
   const handleLogout = async () => {
     await supabase.auth.signOut();
     router.push("/login");
-  };
-
-  const handleToggle = () => {
-    setCollapsed((v) => {
-      const next = !v;
-      try {
-        localStorage.setItem(STORAGE_KEY, String(next));
-      } catch {}
-      return next;
-    });
   };
 
   const items = role === "store" ? navItems.store : navItems.talent;
@@ -186,18 +165,6 @@ export default function Sidebar({
             </Button>
           )}
         </div>
-      )}
-      {collapsible && (
-        <button
-          onClick={handleToggle}
-          className="absolute z-50 -right-3 top-2 flex h-6 w-6 items-center justify-center rounded-full border bg-background shadow md:flex"
-        >
-          {collapsed ? (
-            <ChevronRight className="h-4 w-4" />
-          ) : (
-            <ChevronLeft className="h-4 w-4" />
-          )}
-        </button>
       )}
     </div>
   );

--- a/talentify-next-frontend/components/SidebarProvider.tsx
+++ b/talentify-next-frontend/components/SidebarProvider.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState, ReactNode } from "react";
+
+interface SidebarContextValue {
+  collapsed: boolean;
+  toggle: () => void;
+}
+
+const SidebarContext = createContext<SidebarContextValue | undefined>(undefined);
+
+export function SidebarProvider({ children }: { children: ReactNode }) {
+  const STORAGE_KEY = "sidebar:collapsed";
+  const [collapsed, setCollapsed] = useState(false);
+
+  useEffect(() => {
+    try {
+      const saved =
+        typeof window !== "undefined" ? localStorage.getItem(STORAGE_KEY) : null;
+      if (saved != null) setCollapsed(saved === "true");
+    } catch {}
+  }, []);
+
+  const toggle = () =>
+    setCollapsed((v) => {
+      const next = !v;
+      try {
+        localStorage.setItem(STORAGE_KEY, String(next));
+      } catch {}
+      return next;
+    });
+
+  return (
+    <SidebarContext.Provider value={{ collapsed, toggle }}>
+      {children}
+    </SidebarContext.Provider>
+  );
+}
+
+export function useSidebar() {
+  const ctx = useContext(SidebarContext);
+  if (!ctx) throw new Error("useSidebar must be used within SidebarProvider");
+  return ctx;
+}
+

--- a/talentify-next-frontend/components/SidebarToggle.tsx
+++ b/talentify-next-frontend/components/SidebarToggle.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+import { useSidebar } from "@/components/SidebarProvider";
+
+export default function SidebarToggle() {
+  const { collapsed, toggle } = useSidebar();
+  const label = collapsed ? "サイドバーを開く" : "サイドバーを閉じる";
+
+  return (
+    <TooltipProvider delayDuration={0}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            aria-label={label}
+            title={label}
+            onClick={toggle}
+            className="fixed top-[72px] z-[60] flex h-6 w-6 items-center justify-center rounded-full border bg-background shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            style={{
+              left: collapsed
+                ? "calc(12px + env(safe-area-inset-left))"
+                : "calc(238px + env(safe-area-inset-left))",
+            }}
+          >
+            {collapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="right">{label}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+


### PR DESCRIPTION
## Summary
- refactor Sidebar to use shared context for collapsed state
- add floating SidebarToggle with tooltip and keyboard/focus support
- wire SidebarProvider and toggle into app layouts

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abfcdf273883329b84d598c49c351a