### PR TITLE
feat: add header notification bell and list page

### DIFF
--- a/talentify-next-frontend/__tests__/notifications.test.ts
+++ b/talentify-next-frontend/__tests__/notifications.test.ts
@@ -1,8 +1,8 @@
-import { createClient } from '@/utils/supabase/client'
+jest.mock('@/utils/supabase/client', () => ({
+  createClient: jest.fn(),
+}))
 
-jest.mock('@/utils/supabase/client')
-
-test('getNotifications fetches review and offer notifications without extra filters', async () => {
+test('getNotifications fetches notifications for user', async () => {
   const mockData = [
     {
       id: '1',
@@ -26,12 +26,11 @@ test('getNotifications fetches review and offer notifications without extra filt
     },
   ]
 
+  const { createClient } = require('@/utils/supabase/client')
   let builder: any
-  const mockIn = jest.fn(() => builder)
   builder = {
     select: jest.fn(() => builder),
     eq: jest.fn(() => builder),
-    in: mockIn,
     order: jest.fn(() => builder),
     limit: jest.fn(() => builder),
     then: (resolve: any) => resolve({ data: mockData, error: null }),
@@ -45,5 +44,26 @@ test('getNotifications fetches review and offer notifications without extra filt
   const { getNotifications } = require('@/utils/notifications')
   const data = await getNotifications()
   expect(data).toHaveLength(2)
-  expect(mockIn).toHaveBeenCalledWith('type', ['offer_created', 'review_received'])
+  expect(builder.eq).toHaveBeenCalledWith('user_id', 'user1')
+})
+
+test('getUnreadNotificationCount returns unread count', async () => {
+  jest.resetModules()
+  const { createClient } = require('@/utils/supabase/client')
+  let builder: any
+  builder = {
+    select: jest.fn(() => builder),
+    eq: jest.fn(() => builder),
+    then: (resolve: any) => resolve({ count: 3, data: null, error: null }),
+  }
+
+  ;(createClient as jest.Mock).mockReturnValue({
+    auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'user1' } } }) },
+    from: jest.fn(() => builder),
+  })
+
+  const { getUnreadNotificationCount } = require('@/utils/notifications')
+  const count = await getUnreadNotificationCount()
+  expect(builder.eq).toHaveBeenCalledWith('is_read', false)
+  expect(count).toBe(3)
 })

--- a/talentify-next-frontend/app/(dashboard)/notifications/page.tsx
+++ b/talentify-next-frontend/app/(dashboard)/notifications/page.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { NotificationRow } from '@/utils/notifications'
+import {
+  getNotifications,
+  markAllNotificationsRead,
+} from '@/utils/notifications'
+import NotificationItem from '@/components/notifications/NotificationItem'
+import { Button } from '@/components/ui/button'
+
+export default function NotificationsPage() {
+  const [items, setItems] = useState<NotificationRow[]>([])
+  const [status, setStatus] = useState<'all' | 'unread' | 'read'>('all')
+  const [type, setType] = useState('all')
+
+  useEffect(() => {
+    getNotifications().then(setItems)
+  }, [])
+
+  const filtered = items.filter((n) => {
+    if (status === 'unread' && n.is_read) return false
+    if (status === 'read' && !n.is_read) return false
+    if (type !== 'all' && !n.type.startsWith(type)) return false
+    return true
+  })
+
+  const handleMarkAll = async () => {
+    const ids = items.filter((i) => !i.is_read).map((i) => i.id)
+    await markAllNotificationsRead(ids)
+    setItems((prev) => prev.map((n) => ({ ...n, is_read: true })))
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto py-8 space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">通知</h1>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleMarkAll}
+          disabled={!items.some((n) => !n.is_read)}
+        >
+          一括既読化
+        </Button>
+      </div>
+      <div className="flex gap-2 items-center">
+        {['all', 'unread', 'read'].map((s) => (
+          <Button
+            key={s}
+            size="sm"
+            variant={status === s ? 'default' : 'outline'}
+            onClick={() => setStatus(s as any)}
+          >
+            {s === 'all' ? 'すべて' : s === 'unread' ? '未読' : '既読'}
+          </Button>
+        ))}
+        <select
+          className="ml-auto border rounded px-2 py-1 text-sm"
+          value={type}
+          onChange={(e) => setType(e.target.value)}
+        >
+          <option value="all">全種類</option>
+          <option value="offer">オファー</option>
+          <option value="schedule">スケジュール</option>
+          <option value="invoice">請求</option>
+          <option value="payment">支払い</option>
+          <option value="system">システム</option>
+        </select>
+      </div>
+      <div className="space-y-2">
+        {filtered.map((n) => (
+          <NotificationItem
+            key={n.id}
+            notification={n}
+            onRead={(id) =>
+              setItems((prev) =>
+                prev.map((m) => (m.id === id ? { ...m, is_read: true } : m))
+              )
+            }
+          />
+        ))}
+        {filtered.length === 0 && (
+          <p className="text-sm text-muted-foreground">通知はありません</p>
+        )}
+      </div>
+    </div>
+  )
+}
+

--- a/talentify-next-frontend/components/Header.tsx
+++ b/talentify-next-frontend/components/Header.tsx
@@ -14,6 +14,7 @@ import {
 } from './ui/dropdown-menu'
 import { createClient } from '@/utils/supabase/client'
 import { getUserRoleInfo } from '@/lib/getUserRole'
+import NotificationBell from './notifications/NotificationBell'
 
 const supabase = createClient()
 
@@ -101,21 +102,24 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
           </Button>
         )}
         {!isLoading && isLoggedIn && (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button className="ml-auto md:hidden text-sm font-semibold focus:outline-none">
-                {userName}
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem asChild>
-                <Link href="/terms">利用規約</Link>
-              </DropdownMenuItem>
-              <DropdownMenuItem asChild>
-                <Link href="/privacy">プライバシーポリシー</Link>
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <div className="ml-auto flex items-center gap-2 md:hidden">
+            <NotificationBell />
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button className="text-sm font-semibold focus:outline-none">
+                  {userName}
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem asChild>
+                  <Link href="/terms">利用規約</Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild>
+                  <Link href="/privacy">プライバシーポリシー</Link>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         )}
         {!isLoading && (
           <nav className="hidden md:flex justify-between items-center w-full text-sm">
@@ -153,22 +157,25 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
                   </Link>
                 </>
               ) : (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <button className="flex items-baseline font-semibold focus:outline-none">
-                      <span className="text-base">{userName}</span>
-                      <span className="ml-1 text-sm text-muted-foreground align-top">様</span>
-                    </button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem asChild>
-                      <Link href="/terms">利用規約</Link>
-                    </DropdownMenuItem>
-                    <DropdownMenuItem asChild>
-                      <Link href="/privacy">プライバシーポリシー</Link>
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                <>
+                  <NotificationBell />
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <button className="flex items-baseline font-semibold focus:outline-none">
+                        <span className="text-base">{userName}</span>
+                        <span className="ml-1 text-sm text-muted-foreground align-top">様</span>
+                      </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem asChild>
+                        <Link href="/terms">利用規約</Link>
+                      </DropdownMenuItem>
+                      <DropdownMenuItem asChild>
+                        <Link href="/privacy">プライバシーポリシー</Link>
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </>
               )}
             </div>
           </nav>

--- a/talentify-next-frontend/components/notifications/NotificationBell.tsx
+++ b/talentify-next-frontend/components/notifications/NotificationBell.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { Bell } from 'lucide-react'
+import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent } from '@/components/ui/dropdown-menu'
+import NotificationItem from './NotificationItem'
+import type { NotificationRow } from '@/utils/notifications'
+import {
+  getNotifications,
+  getUnreadNotificationCount,
+} from '@/utils/notifications'
+import { createClient } from '@/utils/supabase/client'
+
+const supabase = createClient()
+
+export default function NotificationBell() {
+  const [count, setCount] = useState(0)
+  const [items, setItems] = useState<NotificationRow[]>([])
+
+  const refreshCount = async () => {
+    const c = await getUnreadNotificationCount()
+    setCount(c)
+  }
+
+  const refreshItems = async () => {
+    const list = await getNotifications(5)
+    setItems(list)
+  }
+
+  useEffect(() => {
+    refreshCount()
+    const channel = supabase
+      .channel('notifications-bell')
+      .on(
+        'postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'notifications' },
+        () => {
+          refreshCount()
+          refreshItems()
+        }
+      )
+      .subscribe()
+
+    const interval = setInterval(refreshCount, 60000)
+    return () => {
+      supabase.removeChannel(channel)
+      clearInterval(interval)
+    }
+  }, [])
+
+  const handleOpenChange = (open: boolean) => {
+    if (open) refreshItems()
+  }
+
+  const handleItemRead = (id: string) => {
+    setCount((c) => Math.max(0, c - 1))
+    setItems((prev) => prev.map((n) => (n.id === id ? { ...n, is_read: true } : n)))
+  }
+
+  return (
+    <DropdownMenu onOpenChange={handleOpenChange}>
+      <DropdownMenuTrigger asChild>
+        <button
+          aria-label="通知"
+          className="relative p-2 rounded-full hover:bg-muted focus:outline-none"
+        >
+          <Bell className="h-6 w-6" />
+          {count > 0 && (
+            <span
+              aria-live="polite"
+              className="absolute -top-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full bg-red-500 px-1 text-xs text-white"
+            >
+              {count > 99 ? '99+' : count}
+            </span>
+          )}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-80 p-0">
+        <div className="max-h-80 overflow-y-auto p-2">
+          {items.length === 0 && (
+            <p className="text-sm text-muted-foreground px-2 py-4">通知はありません</p>
+          )}
+          {items.map((n) => (
+            <NotificationItem key={n.id} notification={n} onRead={handleItemRead} />
+          ))}
+        </div>
+        <div className="border-t">
+          <Link
+            href="/notifications"
+            className="block px-3 py-2 text-center text-sm text-blue-600 hover:underline"
+          >
+            すべて見る
+          </Link>
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+

--- a/talentify-next-frontend/components/notifications/NotificationItem.tsx
+++ b/talentify-next-frontend/components/notifications/NotificationItem.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+import { Bell, Calendar, FileText, CreditCard, Info } from 'lucide-react'
+import type { NotificationRow } from '@/utils/notifications'
+import { markNotificationRead } from '@/utils/notifications'
+import { cn } from '@/lib/utils'
+import { formatDistanceToNow } from 'date-fns'
+import { ja } from 'date-fns/locale'
+
+interface Props {
+  notification: NotificationRow
+  onRead?: (id: string) => void
+  className?: string
+}
+
+const typeIcon: Record<string, React.ComponentType<{ className?: string }>> = {
+  offer: Bell,
+  schedule: Calendar,
+  invoice: FileText,
+  payment: CreditCard,
+  system: Info,
+}
+
+function resolveIcon(type: string) {
+  const prefix = type.split('_')[0]
+  return typeIcon[prefix] || Info
+}
+
+function resolveLink(n: NotificationRow): string {
+  const data = (n.data as any) || {}
+  if (data.url) return data.url as string
+  const id = data.offer_id || data.schedule_id || data.invoice_id || data.payment_id
+  const prefix = n.type.split('_')[0]
+  switch (prefix) {
+    case 'offer':
+      return id ? `/offers/${id}` : '/offers'
+    case 'schedule':
+      return '/schedule'
+    case 'invoice':
+      return id ? `/invoices/${id}` : '/invoices'
+    case 'payment':
+      return id ? `/payments/${id}` : '/payments'
+    case 'system':
+      return id ? `/notifications/${id}` : '/notifications'
+    default:
+      return '/'
+  }
+}
+
+export default function NotificationItem({ notification, onRead, className }: Props) {
+  const router = useRouter()
+  const Icon = resolveIcon(notification.type)
+
+  const handleClick = useCallback(async () => {
+    if (!notification.is_read) {
+      markNotificationRead(notification.id)
+      onRead?.(notification.id)
+    }
+    const href = resolveLink(notification)
+    router.push(href)
+  }, [notification, router, onRead])
+
+  return (
+    <button
+      onClick={handleClick}
+      className={cn(
+        'flex w-full items-start gap-3 rounded-md p-2 text-left hover:bg-accent focus:outline-none',
+        !notification.is_read && 'bg-muted/50',
+        className
+      )}
+    >
+      <Icon className="h-4 w-4 mt-0.5" />
+      <div className="flex-1 text-sm">
+        <p className="font-medium leading-snug">{notification.title}</p>
+        {notification.body && (
+          <p className="text-xs text-muted-foreground line-clamp-2">{notification.body}</p>
+        )}
+        <p className="text-xs text-muted-foreground">
+          {formatDistanceToNow(new Date(notification.created_at), { addSuffix: true, locale: ja })}
+        </p>
+      </div>
+    </button>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add notification bell with unread badge and realtime updates
- integrate bell into header and link to new notifications page
- support unread count utility and tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abfe7491408332b295c2ff8667d85e