### PR TITLE
fix sidebar toggle overlap and styling

### DIFF
--- a/talentify-next-frontend/components/Sidebar.tsx
+++ b/talentify-next-frontend/components/Sidebar.tsx
@@ -105,7 +105,12 @@ export default function Sidebar({
       )}
     >
       <TooltipProvider delayDuration={0}>
-        <nav className="flex-1 space-y-2 px-2 py-4">
+        <nav
+          className={cn(
+            "flex-1 space-y-2 px-2 pb-4 pt-4",
+            collapsed && "pt-14",
+          )}
+        >
           {items.map(({ href, label, icon: Icon }) => {
             const content = (
               <div

--- a/talentify-next-frontend/components/SidebarToggle.tsx
+++ b/talentify-next-frontend/components/SidebarToggle.tsx
@@ -16,14 +16,18 @@ export default function SidebarToggle() {
             aria-label={label}
             title={label}
             onClick={toggle}
-            className="fixed top-[72px] z-[60] flex h-6 w-6 items-center justify-center rounded-full border bg-background shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="fixed top-[72px] z-[60] flex h-10 w-10 items-center justify-center rounded-2xl bg-background text-muted-foreground transition-colors hover:bg-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             style={{
               left: collapsed
                 ? "calc(12px + env(safe-area-inset-left))"
                 : "calc(238px + env(safe-area-inset-left))",
             }}
           >
-            {collapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
+            {collapsed ? (
+              <ChevronRight className="h-5 w-5" />
+            ) : (
+              <ChevronLeft className="h-5 w-5" />
+            )}
           </button>
         </TooltipTrigger>
         <TooltipContent side="right">{label}</TooltipContent>


### PR DESCRIPTION
## Summary
- shift collapsed sidebar nav down to avoid toggle overlap
- restyle sidebar toggle button to match menu icons

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abfffd7498833286b08942d9a18176