### PR TITLE
feat: add header notification bell link

### DIFF
--- a/talentify-next-frontend/__tests__/notifications.test.ts
+++ b/talentify-next-frontend/__tests__/notifications.test.ts
@@ -67,3 +67,12 @@ test('getUnreadNotificationCount returns unread count', async () => {
   expect(builder.eq).toHaveBeenCalledWith('is_read', false)
   expect(count).toBe(3)
 })
+
+test('formatUnreadCount formats values', () => {
+  const { formatUnreadCount } = require('@/utils/notifications')
+  expect(formatUnreadCount(0)).toBeNull()
+  expect(formatUnreadCount(1)).toBe('1')
+  expect(formatUnreadCount(98)).toBe('98')
+  expect(formatUnreadCount(120)).toBe('99+')
+})
+

--- a/talentify-next-frontend/components/Header.tsx
+++ b/talentify-next-frontend/components/Header.tsx
@@ -14,7 +14,7 @@ import {
 } from './ui/dropdown-menu'
 import { createClient } from '@/utils/supabase/client'
 import { getUserRoleInfo } from '@/lib/getUserRole'
-import NotificationBell from './notifications/NotificationBell'
+import HeaderBellLink from './notifications/HeaderBellLink'
 
 const supabase = createClient()
 
@@ -103,7 +103,7 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
         )}
         {!isLoading && isLoggedIn && (
           <div className="ml-auto flex items-center gap-2 md:hidden">
-            <NotificationBell />
+            <HeaderBellLink />
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <button className="text-sm font-semibold focus:outline-none">
@@ -158,7 +158,7 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
                 </>
               ) : (
                 <>
-                  <NotificationBell />
+                  <HeaderBellLink />
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                       <button className="flex items-baseline font-semibold focus:outline-none">

--- a/talentify-next-frontend/components/notifications/HeaderBellLink.tsx
+++ b/talentify-next-frontend/components/notifications/HeaderBellLink.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import { Bell } from 'lucide-react'
+import { createClient } from '@/utils/supabase/client'
+import { getUnreadNotificationCount, formatUnreadCount } from '@/utils/notifications'
+import { useUserRole } from '@/utils/useRole'
+
+const supabase = createClient()
+
+export default function HeaderBellLink() {
+  const { role } = useUserRole()
+  const [count, setCount] = useState(0)
+
+  const refreshCount = async () => {
+    const c = await getUnreadNotificationCount()
+    setCount(c)
+  }
+
+  useEffect(() => {
+    refreshCount()
+    const channel = supabase
+      .channel('header-bell')
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'notifications' }, () => {
+        refreshCount()
+      })
+      .subscribe()
+    const interval = setInterval(refreshCount, 60000)
+    return () => {
+      supabase.removeChannel(channel)
+      clearInterval(interval)
+    }
+  }, [])
+
+  if (!role) return null
+  const href = `/${role}/notifications`
+  const formatted = formatUnreadCount(count)
+
+  return (
+    <Link
+      href={href}
+      aria-label="通知"
+      className="relative p-2 rounded-full hover:bg-muted focus:outline-none"
+    >
+      <Bell className="h-6 w-6" />
+      {formatted && (
+        <span
+          aria-live="polite"
+          className="absolute -top-1 -right-1 flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-red-500 px-1 text-xs text-white"
+        >
+          {formatted}
+        </span>
+      )}
+    </Link>
+  )
+}
+

--- a/talentify-next-frontend/utils/notifications.ts
+++ b/talentify-next-frontend/utils/notifications.ts
@@ -99,3 +99,9 @@ export async function addNotification(payload: AddNotificationPayload) {
     console.error('failed to add notification', error)
   }
 }
+
+export function formatUnreadCount(count: number): string | null {
+  if (count <= 0) return null
+  return count > 99 ? '99+' : String(count)
+}
+


### PR DESCRIPTION
## Summary
- add `HeaderBellLink` component to show bell icon with unread badge and link to role-specific notifications page
- expose `formatUnreadCount` utility and use it in header bell link
- integrate bell link into global header and test formatting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac022c60cc8332a17dc25c46a706dc