### PR TITLE
feat: add mobile drawer header

### DIFF
--- a/talentify-next-frontend/app/search/layout.tsx
+++ b/talentify-next-frontend/app/search/layout.tsx
@@ -27,8 +27,12 @@ export default async function SearchLayout({
           <Header sidebarRole="store" />
           <div className="flex h-[calc(100vh-64px)] pt-16">
             <SidebarProvider>
-              <Sidebar role="store" collapsible />
-              <SidebarToggle />
+              <div className="hidden md:block">
+                <Sidebar role="store" collapsible />
+              </div>
+              <div className="hidden md:block">
+                <SidebarToggle />
+              </div>
               <main className="flex-1 overflow-y-auto p-6 transition-[margin,width]">{children}</main>
             </SidebarProvider>
           </div>

--- a/talentify-next-frontend/app/store/layout.tsx
+++ b/talentify-next-frontend/app/store/layout.tsx
@@ -27,8 +27,12 @@ export default async function StoreLayout({
           <Header sidebarRole="store" />
           <div className="flex h-[calc(100vh-64px)] pt-16">
             <SidebarProvider>
-              <Sidebar role="store" collapsible />
-              <SidebarToggle />
+              <div className="hidden md:block">
+                <Sidebar role="store" collapsible />
+              </div>
+              <div className="hidden md:block">
+                <SidebarToggle />
+              </div>
               <main className="flex-1 overflow-y-auto p-6 transition-[margin,width]">{children}</main>
             </SidebarProvider>
           </div>

--- a/talentify-next-frontend/app/talent/layout.tsx
+++ b/talentify-next-frontend/app/talent/layout.tsx
@@ -30,8 +30,12 @@ export default async function TalentLayout({
           {/* ヘッダー高さ分の余白を考慮して下部を分割 */}
           <div className="flex h-[calc(100vh-64px)] pt-16">
             <SidebarProvider>
-              <Sidebar role="talent" collapsible />
-              <SidebarToggle />
+              <div className="hidden md:block">
+                <Sidebar role="talent" collapsible />
+              </div>
+              <div className="hidden md:block">
+                <SidebarToggle />
+              </div>
               {/* メインコンテンツ */}
               <main className="flex-1 overflow-y-auto p-6 transition-[margin,width]">{children}</main>
             </SidebarProvider>

--- a/talentify-next-frontend/app/talents/layout.tsx
+++ b/talentify-next-frontend/app/talents/layout.tsx
@@ -27,8 +27,12 @@ export default async function TalentsLayout({
           <Header sidebarRole="store" />
           <div className="flex h-[calc(100vh-64px)] pt-16">
             <SidebarProvider>
-              <Sidebar role="store" collapsible />
-              <SidebarToggle />
+              <div className="hidden md:block">
+                <Sidebar role="store" collapsible />
+              </div>
+              <div className="hidden md:block">
+                <SidebarToggle />
+              </div>
               <main className="flex-1 overflow-y-auto p-6 transition-[margin,width]">{children}</main>
             </SidebarProvider>
           </div>

--- a/talentify-next-frontend/components/Header.tsx
+++ b/talentify-next-frontend/components/Header.tsx
@@ -2,8 +2,10 @@
 
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
+import { usePathname } from 'next/navigation'
 import { Menu, Search } from 'lucide-react'
 import Sidebar from './Sidebar'
+import { SidebarProvider } from './SidebarProvider'
 import { Sheet, SheetTrigger, SheetContent } from './ui/sheet'
 import { Button } from './ui/button'
 import {
@@ -21,6 +23,8 @@ const supabase = createClient()
 export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'store' }) {
   const [userName, setUserName] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(true)
+  const [open, setOpen] = useState(false)
+  const pathname = usePathname()
 
   useEffect(() => {
     const fetchSessionAndProfile = async () => {
@@ -69,6 +73,10 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
     }
   }, [])
 
+  useEffect(() => {
+    setOpen(false)
+  }, [pathname])
+
   const isLoggedIn = !!userName
 
   return (
@@ -76,14 +84,27 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
       <div className="mx-auto flex h-full max-w-5xl items-center justify-between p-4">
         <div className="flex items-center gap-2">
           {sidebarRole && (
-            <Sheet>
+            <Sheet open={open} onOpenChange={setOpen}>
               <SheetTrigger asChild>
-                <button className="md:hidden text-gray-800">
+                <button
+                  className="md:hidden text-gray-800"
+                  aria-label="メニュー"
+                  aria-controls="mobile-menu"
+                  aria-expanded={open}
+                >
                   <Menu size={24} />
                 </button>
               </SheetTrigger>
-              <SheetContent side="left" className="p-4">
-                <Sidebar role={sidebarRole} collapsible />
+              <SheetContent
+                id="mobile-menu"
+                side="left"
+                className="p-4 overflow-y-auto"
+                role="dialog"
+                aria-modal="true"
+              >
+                <SidebarProvider>
+                  <Sidebar role={sidebarRole} collapsible />
+                </SidebarProvider>
               </SheetContent>
             </Sheet>
           )}
@@ -91,35 +112,49 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
             Talentify
           </Link>
         </div>
-        {!isLoading && !isLoggedIn && (
-          <Button
-            asChild
-            variant="outline"
-            size="sm"
-            className="ml-auto md:hidden hover:bg-muted"
-          >
-            <Link href="/login">ログイン</Link>
-          </Button>
-        )}
-        {!isLoading && isLoggedIn && (
-          <div className="ml-auto flex items-center gap-2 md:hidden">
-            <HeaderBellLink />
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button className="text-sm font-semibold focus:outline-none">
-                  {userName}
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem asChild>
-                  <Link href="/terms">利用規約</Link>
-                </DropdownMenuItem>
-                <DropdownMenuItem asChild>
-                  <Link href="/privacy">プライバシーポリシー</Link>
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
+        {!isLoading && (
+          <>
+            {sidebarRole ? (
+              isLoggedIn && (
+                <div className="ml-auto md:hidden">
+                  <HeaderBellLink />
+                </div>
+              )
+            ) : (
+              <>
+                {!isLoggedIn && (
+                  <Button
+                    asChild
+                    variant="outline"
+                    size="sm"
+                    className="ml-auto md:hidden hover:bg-muted"
+                  >
+                    <Link href="/login">ログイン</Link>
+                  </Button>
+                )}
+                {isLoggedIn && (
+                  <div className="ml-auto flex items-center gap-2 md:hidden">
+                    <HeaderBellLink />
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <button className="text-sm font-semibold focus:outline-none">
+                          {userName}
+                        </button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem asChild>
+                          <Link href="/terms">利用規約</Link>
+                        </DropdownMenuItem>
+                        <DropdownMenuItem asChild>
+                          <Link href="/privacy">プライバシーポリシー</Link>
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
+                )}
+              </>
+            )}
+          </>
         )}
         {!isLoading && (
           <nav className="hidden md:flex justify-between items-center w-full text-sm">


### PR DESCRIPTION
## Summary
- make mobile header a minimal hamburger + logo + notification bell
- hide sidebar and toggle on small screens
- auto-close drawer on navigation and add a11y attributes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac05b61b4483329f06394753d2ac85