### PR TITLE
feat: expand mobile drawer nav with labels

### DIFF
--- a/talentify-next-frontend/components/Header.tsx
+++ b/talentify-next-frontend/components/Header.tsx
@@ -3,9 +3,7 @@
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { usePathname } from 'next/navigation'
-import { Menu, Search } from 'lucide-react'
-import Sidebar from './Sidebar'
-import { SidebarProvider } from './SidebarProvider'
+import { Menu } from 'lucide-react'
 import { Sheet, SheetTrigger, SheetContent } from './ui/sheet'
 import { Button } from './ui/button'
 import {
@@ -17,6 +15,7 @@ import {
 import { createClient } from '@/utils/supabase/client'
 import { getUserRoleInfo } from '@/lib/getUserRole'
 import HeaderBellLink from './notifications/HeaderBellLink'
+import MobileDrawerNav from './MobileDrawerNav'
 
 const supabase = createClient()
 
@@ -98,13 +97,11 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
               <SheetContent
                 id="mobile-menu"
                 side="left"
-                className="p-4 overflow-y-auto"
+                className="p-0"
                 role="dialog"
                 aria-modal="true"
               >
-                <SidebarProvider>
-                  <Sidebar role={sidebarRole} collapsible />
-                </SidebarProvider>
+                <MobileDrawerNav role={sidebarRole} onNavigate={() => setOpen(false)} />
               </SheetContent>
             </Sheet>
           )}

--- a/talentify-next-frontend/components/MobileDrawerNav.tsx
+++ b/talentify-next-frontend/components/MobileDrawerNav.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { cn } from "@/lib/utils";
+import { useEffect, useMemo, useState } from "react";
+import { createClient } from "@/utils/supabase/client";
+import { navItems } from "@/components/nav-items";
+import { LogOut } from "lucide-react";
+
+export default function MobileDrawerNav({
+  role,
+  onNavigate,
+}: {
+  role: "talent" | "store";
+  onNavigate?: () => void;
+}) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const supabase = useMemo(() => createClient(), []);
+  const [loggedIn, setLoggedIn] = useState(false);
+
+  useEffect(() => {
+    const checkSession = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      setLoggedIn(!!session);
+    };
+
+    checkSession();
+
+    const { data: listener } = supabase.auth.onAuthStateChange(
+      (_event, session) => {
+        setLoggedIn(!!session);
+      },
+    );
+
+    return () => {
+      listener.subscription.unsubscribe();
+    };
+  }, [supabase]);
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut();
+    router.push("/login");
+    onNavigate?.();
+  };
+
+  const items = navItems.filter((item) => item.roles.includes(role));
+
+  return (
+    <div className="flex h-full flex-col">
+      <nav className="flex-1 overflow-y-auto pt-2" aria-label="サイドナビゲーション">
+        {items.map(({ href, label, icon: Icon }) => (
+          <Link
+            key={href}
+            href={href}
+            onClick={onNavigate}
+            className={cn(
+              "group flex items-center gap-4 rounded-2xl px-4 py-3 text-base transition-colors hover:bg-muted",
+              pathname === href
+                ? "bg-muted text-primary font-medium"
+                : "text-muted-foreground",
+            )}
+            aria-current={pathname === href ? "page" : undefined}
+          >
+            <Icon className="h-5 w-5 opacity-80 group-hover:opacity-100" />
+            <span className="label">{label}</span>
+          </Link>
+        ))}
+      </nav>
+      {loggedIn && (
+        <button
+          onClick={handleLogout}
+          className="flex items-center gap-4 px-4 py-3 text-base text-destructive hover:bg-muted"
+        >
+          <LogOut className="h-5 w-5 opacity-80" />
+          <span className="label">ログアウト</span>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/talentify-next-frontend/components/Sidebar.tsx
+++ b/talentify-next-frontend/components/Sidebar.tsx
@@ -12,49 +12,9 @@ import {
   TooltipContent,
 } from "@/components/ui/tooltip";
 import { createClient } from "@/utils/supabase/client";
-import {
-  LayoutDashboard,
-  Mail,
-  Calendar,
-  User,
-  Star,
-  Wallet,
-  Bell,
-  Settings,
-  Search,
-  LogOut,
-} from "lucide-react";
+import { LogOut } from "lucide-react";
 import { useSidebar } from "@/components/SidebarProvider";
-
-const navItems = {
-  talent: [
-    {
-      href: "/talent/dashboard",
-      label: "ダッシュボード",
-      icon: LayoutDashboard,
-    },
-    { href: "/talent/offers", label: "オファー一覧", icon: Mail },
-    { href: "/talent/schedule", label: "スケジュール管理", icon: Calendar },
-    { href: "/talent/edit", label: "プロフィール編集", icon: User },
-    { href: "/talent/reviews", label: "評価・レビュー", icon: Star },
-    { href: "/talent/payments", label: "ギャラ管理", icon: Wallet },
-    { href: "/talent/invoices", label: "請求管理", icon: Mail },
-    { href: "/talent/notifications", label: "通知", icon: Bell },
-    { href: "/talent/settings", label: "設定", icon: Settings },
-  ],
-  store: [
-    { href: "/search", label: "演者を探す", icon: Search },
-    { href: "/store/dashboard", label: "ダッシュボード", icon: LayoutDashboard },
-    { href: "/store/offers", label: "オファー管理", icon: Mail },
-    { href: "/store/schedule", label: "スケジュール", icon: Calendar },
-    { href: "/store/reviews", label: "レビュー管理", icon: Star },
-    { href: "/store/messages", label: "メッセージ", icon: Bell },
-    { href: "/store/notifications", label: "通知", icon: Bell },
-    { href: "/store/invoices", label: "請求一覧", icon: Wallet },
-    { href: "/store/edit", label: "店舗情報", icon: User },
-    { href: "/store/settings", label: "設定", icon: Star },
-  ],
-} as const;
+import { navItems } from "@/components/nav-items";
 
 export default function Sidebar({
   role = "talent",
@@ -95,7 +55,7 @@ export default function Sidebar({
     router.push("/login");
   };
 
-  const items = role === "store" ? navItems.store : navItems.talent;
+  const items = navItems.filter((item) => item.roles.includes(role));
 
   return (
     <div

--- a/talentify-next-frontend/components/nav-items.ts
+++ b/talentify-next-frontend/components/nav-items.ts
@@ -1,0 +1,31 @@
+import { LayoutDashboard, Mail, Calendar, User, Star, Wallet, Bell, Settings, Search, MessageCircle } from "lucide-react";
+
+export interface NavItem {
+  href: string;
+  label: string;
+  icon: any;
+  roles: ("talent" | "store")[];
+}
+
+export const navItems: NavItem[] = [
+  { href: "/search", label: "演者を探す", icon: Search, roles: ["store"] },
+  { href: "/store/dashboard", label: "ダッシュボード", icon: LayoutDashboard, roles: ["store"] },
+  { href: "/store/offers", label: "オファー管理", icon: Mail, roles: ["store"] },
+  { href: "/store/schedule", label: "スケジュール", icon: Calendar, roles: ["store"] },
+  { href: "/store/reviews", label: "レビュー管理", icon: Star, roles: ["store"] },
+  { href: "/store/messages", label: "メッセージ", icon: MessageCircle, roles: ["store"] },
+  { href: "/store/notifications", label: "通知", icon: Bell, roles: ["store"] },
+  { href: "/store/invoices", label: "請求一覧", icon: Wallet, roles: ["store"] },
+  { href: "/store/edit", label: "店舗情報", icon: User, roles: ["store"] },
+  { href: "/store/settings", label: "設定", icon: Settings, roles: ["store"] },
+
+  { href: "/talent/dashboard", label: "ダッシュボード", icon: LayoutDashboard, roles: ["talent"] },
+  { href: "/talent/offers", label: "オファー一覧", icon: Mail, roles: ["talent"] },
+  { href: "/talent/schedule", label: "スケジュール管理", icon: Calendar, roles: ["talent"] },
+  { href: "/talent/edit", label: "プロフィール編集", icon: User, roles: ["talent"] },
+  { href: "/talent/reviews", label: "評価・レビュー", icon: Star, roles: ["talent"] },
+  { href: "/talent/payments", label: "ギャラ管理", icon: Wallet, roles: ["talent"] },
+  { href: "/talent/invoices", label: "請求管理", icon: Mail, roles: ["talent"] },
+  { href: "/talent/notifications", label: "通知", icon: Bell, roles: ["talent"] },
+  { href: "/talent/settings", label: "設定", icon: Settings, roles: ["talent"] },
+];


### PR DESCRIPTION
## Summary
- show labeled navigation in mobile drawer
- centralize role-based nav items for sidebar reuse

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac0930e7f0833282afad74f60e45fb