### PR TITLE
docs: add offer message tables and RLS policies

### DIFF
--- a/supabase-docs/20250830_offer_message_tables.sql
+++ b/supabase-docs/20250830_offer_message_tables.sql
@@ -1,0 +1,85 @@
+-- Schema: offer_messages and offer_read_receipts
+
+-- offer_messages stores chat messages per offer
+create table if not exists public.offer_messages (
+  id            uuid primary key default gen_random_uuid(),
+  offer_id      uuid not null references public.offers(id) on delete cascade,
+  sender_user   uuid not null,
+  sender_role   text not null check (sender_role in ('store','talent','admin')),
+  body          text,
+  attachments   jsonb default '[]',
+  created_at    timestamptz not null default now()
+);
+
+create index on public.offer_messages(offer_id, created_at desc);
+create index on public.offer_messages(sender_user, created_at desc);
+
+-- offer_read_receipts keeps lightweight read state per user
+create table if not exists public.offer_read_receipts (
+  id         uuid primary key default gen_random_uuid(),
+  offer_id   uuid not null references public.offers(id) on delete cascade,
+  user_id    uuid not null,
+  last_read_at timestamptz not null default now(),
+  unique (offer_id, user_id)
+);
+
+create index on public.offer_read_receipts(offer_id, user_id);
+
+-- Enable RLS
+alter table public.offer_messages enable row level security;
+alter table public.offer_read_receipts enable row level security;
+
+-- Policies
+create policy offer_msg_select on public.offer_messages
+for select using (
+  exists (
+    select 1 from public.offers o
+    where o.id = offer_messages.offer_id
+      and (
+        o.user_id = auth.uid()
+        or exists (select 1 from public.stores s  where s.id = o.store_id  and s.user_id = auth.uid())
+        or exists (select 1 from public.talents t where t.id = o.talent_id and t.user_id = auth.uid())
+      )
+  )
+);
+
+create policy offer_msg_insert on public.offer_messages
+for insert with check (
+  exists (
+    select 1 from public.offers o
+    where o.id = offer_messages.offer_id
+      and (
+        o.user_id = auth.uid()
+        or exists (select 1 from public.stores s  where s.id = o.store_id  and s.user_id = auth.uid())
+        or exists (select 1 from public.talents t where t.id = o.talent_id and t.user_id = auth.uid())
+      )
+  )
+);
+
+create policy offer_receipt_select on public.offer_read_receipts
+for select using (
+  exists (
+    select 1 from public.offers o
+    where o.id = offer_read_receipts.offer_id
+      and (
+        o.user_id = auth.uid()
+        or exists (select 1 from public.stores s  where s.id = o.store_id  and s.user_id = auth.uid())
+        or exists (select 1 from public.talents t where t.id = o.talent_id and t.user_id = auth.uid())
+      )
+  )
+);
+
+create policy offer_receipt_upsert on public.offer_read_receipts
+for all using (true) with check (
+  user_id = auth.uid()
+  and exists (
+    select 1 from public.offers o
+    where o.id = offer_read_receipts.offer_id
+      and (
+        o.user_id = auth.uid()
+        or exists (select 1 from public.stores s  where s.id = o.store_id  and s.user_id = auth.uid())
+        or exists (select 1 from public.talents t where t.id = o.talent_id and t.user_id = auth.uid())
+      )
+  )
+);
+

--- a/supabase-docs/rls/20250830_offer_messages_policies.md
+++ b/supabase-docs/rls/20250830_offer_messages_policies.md
@@ -1,0 +1,79 @@
+# RLS: public.offer_messages & public.offer_read_receipts (2025-08-30)
+
+## Tables
+
+- `public.offer_messages`
+- `public.offer_read_receipts`
+
+## Enable RLS
+
+```sql
+ALTER TABLE public.offer_messages ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.offer_read_receipts ENABLE ROW LEVEL SECURITY;
+```
+
+## Policies
+
+```sql
+-- Read messages related to offers the user can access
+CREATE POLICY offer_msg_select ON public.offer_messages
+FOR SELECT USING (
+  EXISTS (
+    SELECT 1 FROM public.offers o
+    WHERE o.id = offer_messages.offer_id
+      AND (
+        o.user_id = auth.uid()
+        OR EXISTS (SELECT 1 FROM public.stores s  WHERE s.id = o.store_id  AND s.user_id = auth.uid())
+        OR EXISTS (SELECT 1 FROM public.talents t WHERE t.id = o.talent_id AND t.user_id = auth.uid())
+      )
+  )
+);
+
+-- Write messages when the user has access to the offer
+CREATE POLICY offer_msg_insert ON public.offer_messages
+FOR INSERT WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM public.offers o
+    WHERE o.id = offer_messages.offer_id
+      AND (
+        o.user_id = auth.uid()
+        OR EXISTS (SELECT 1 FROM public.stores s  WHERE s.id = o.store_id  AND s.user_id = auth.uid())
+        OR EXISTS (SELECT 1 FROM public.talents t WHERE t.id = o.talent_id AND t.user_id = auth.uid())
+      )
+  )
+);
+
+-- Read receipts for accessible offers
+CREATE POLICY offer_receipt_select ON public.offer_read_receipts
+FOR SELECT USING (
+  EXISTS (
+    SELECT 1 FROM public.offers o
+    WHERE o.id = offer_read_receipts.offer_id
+      AND (
+        o.user_id = auth.uid()
+        OR EXISTS (SELECT 1 FROM public.stores s  WHERE s.id = o.store_id  AND s.user_id = auth.uid())
+        OR EXISTS (SELECT 1 FROM public.talents t WHERE t.id = o.talent_id AND t.user_id = auth.uid())
+      )
+  )
+);
+
+-- Upsert receipts for the current user only
+CREATE POLICY offer_receipt_upsert ON public.offer_read_receipts
+FOR ALL USING (true) WITH CHECK (
+  user_id = auth.uid()
+  AND EXISTS (
+    SELECT 1 FROM public.offers o
+    WHERE o.id = offer_read_receipts.offer_id
+      AND (
+        o.user_id = auth.uid()
+        OR EXISTS (SELECT 1 FROM public.stores s  WHERE s.id = o.store_id  AND s.user_id = auth.uid())
+        OR EXISTS (SELECT 1 FROM public.talents t WHERE t.id = o.talent_id AND t.user_id = auth.uid())
+      )
+  )
+);
+```
+
+## Notes
+
+- Policies ensure only store owners, talent, or offer creator can read/write messages and receipts tied to the offer.
+- `sender_user` is expected to be `auth.uid()` and `sender_role` determined on the client.


### PR DESCRIPTION
## Summary
- document offer_messages and offer_read_receipts tables
- include RLS policies enforcing offer-based access control

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0a4497488332ba8f2bd057bb220b