### PR TITLE
Improve offer message interface

### DIFF
--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -42,9 +42,7 @@ export default function StoreOfferPage() {
 
   return (
     <div className="flex flex-col gap-4 h-full p-4">
-      <OfferHeaderCard offer={offer} role="store" onScrollToMessages={() => {
-        document.getElementById('chat')?.scrollIntoView({ behavior: 'smooth' })
-      }} />
+      <OfferHeaderCard offer={offer} role="store" />
       <div id="chat" className="flex-1 min-h-0">
         <OfferChatThread
           offerId={offer.id}

--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -45,9 +45,6 @@ export default function TalentOfferPage() {
       <OfferHeaderCard
         offer={offer}
         role="talent"
-        onScrollToMessages={() => {
-          document.getElementById('chat')?.scrollIntoView({ behavior: 'smooth' })
-        }}
       />
       <div id="chat" className="flex-1 min-h-0">
         <OfferChatThread

--- a/talentify-next-frontend/components/offer/OfferChatInput.tsx
+++ b/talentify-next-frontend/components/offer/OfferChatInput.tsx
@@ -3,8 +3,7 @@
 import { useState, KeyboardEvent } from 'react'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
-import { uploadAttachment } from '@/lib/supabase/storage'
-import { sendOfferMessage, Attachment } from '@/lib/supabase/offerMessages'
+import { sendOfferMessage } from '@/lib/supabase/offerMessages'
 import { createClient } from '@/utils/supabase/client'
 
 interface OfferChatInputProps {
@@ -16,26 +15,19 @@ interface OfferChatInputProps {
 export default function OfferChatInput({ offerId, senderRole, onSent }: OfferChatInputProps) {
   const [body, setBody] = useState('')
   const [sending, setSending] = useState(false)
-  const [files, setFiles] = useState<File[]>([])
   const supabase = createClient()
 
   const handleSend = async () => {
-    if (!body && files.length === 0) return
+    if (!body) return
     setSending(true)
-    let attachments: Attachment[] = []
     try {
-      for (const file of files) {
-        const uploaded = await uploadAttachment(supabase, file)
-        attachments.push(uploaded)
-      }
       const message = await sendOfferMessage(supabase, {
         offerId,
         senderRole,
         body: body.trim() || null,
-        attachments,
+        attachments: [],
       })
       setBody('')
-      setFiles([])
       onSent?.(message)
     } finally {
       setSending(false)
@@ -58,12 +50,7 @@ export default function OfferChatInput({ offerId, senderRole, onSent }: OfferCha
         placeholder="メッセージを入力"
         rows={1}
       />
-      <div className="flex items-center justify-between">
-        <input
-          type="file"
-          multiple
-          onChange={e => setFiles(Array.from(e.target.files || []))}
-        />
+      <div className="flex justify-end">
         <Button onClick={handleSend} disabled={sending}>
           送信
         </Button>

--- a/talentify-next-frontend/components/offer/OfferHeaderCard.tsx
+++ b/talentify-next-frontend/components/offer/OfferHeaderCard.tsx
@@ -15,7 +15,6 @@ interface OfferHeaderCardProps {
     invoiceStatus?: 'not_submitted' | 'submitted' | 'paid'
   }
   role: 'store' | 'talent'
-  onScrollToMessages?: () => void
   onAccept?: () => void
   onDecline?: () => void
   onCancel?: () => void
@@ -32,18 +31,18 @@ const statusColor: Record<string, string> = {
 export default function OfferHeaderCard({
   offer,
   role,
-  onScrollToMessages,
   onAccept,
   onDecline,
   onCancel,
 }: OfferHeaderCardProps) {
   const status = statusColor[offer.status] || 'bg-gray-100 text-gray-800'
+  const statusLabel = offer.status === 'pending' ? '返答待ち' : offer.status
 
   return (
     <Card>
-      <CardHeader className="flex items-center justify-between">
+      <CardHeader className="flex items-center">
         <CardTitle>オファー詳細</CardTitle>
-        <Badge className={status}>{offer.status}</Badge>
+        <Badge className={`${status} ml-auto mr-2`}>{statusLabel}</Badge>
       </CardHeader>
       <CardContent className="space-y-4">
         <OfferSummary
@@ -58,10 +57,7 @@ export default function OfferHeaderCard({
           {role === 'store' && (
             <>
               <Button variant="outline" size="sm" onClick={onCancel}>
-                キャンセル
-              </Button>
-              <Button variant="secondary" size="sm" onClick={onScrollToMessages}>
-                メッセージへ
+                オファーをキャンセル
               </Button>
             </>
           )}
@@ -72,9 +68,6 @@ export default function OfferHeaderCard({
               </Button>
               <Button variant="outline" size="sm" onClick={onDecline}>
                 辞退
-              </Button>
-              <Button variant="secondary" size="sm" onClick={onScrollToMessages}>
-                メッセージへ
               </Button>
             </>
           )}


### PR DESCRIPTION
## Summary
- translate pending status to 日本語 and soften badge placement
- remove unused メッセージへ button and rename cancel action
- drop temporary file attachment field from chat input

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac143483d88332a6c130e511b9550e