### PR TITLE
Connect talent offer actions

### DIFF
--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -40,11 +40,29 @@ export default function TalentOfferPage() {
     return <p className="p-4">Loading...</p>
   }
 
+  const handleAccept = async () => {
+    const { error } = await supabase
+      .from('offers')
+      .update({ status: 'accepted' })
+      .eq('id', offer.id)
+    if (!error) setOffer({ ...offer, status: 'accepted' })
+  }
+
+  const handleDecline = async () => {
+    const { error } = await supabase
+      .from('offers')
+      .update({ status: 'declined' })
+      .eq('id', offer.id)
+    if (!error) setOffer({ ...offer, status: 'declined' })
+  }
+
   return (
     <div className="flex flex-col gap-4 h-full p-4">
       <OfferHeaderCard
         offer={offer}
         role="talent"
+        onAccept={handleAccept}
+        onDecline={handleDecline}
       />
       <div id="chat" className="flex-1 min-h-0">
         <OfferChatThread

--- a/talentify-next-frontend/components/offer/OfferHeaderCard.tsx
+++ b/talentify-next-frontend/components/offer/OfferHeaderCard.tsx
@@ -23,6 +23,7 @@ interface OfferHeaderCardProps {
 const statusColor: Record<string, string> = {
   pending: 'bg-yellow-100 text-yellow-800',
   accepted: 'bg-green-100 text-green-800',
+  declined: 'bg-red-100 text-red-800',
   confirmed: 'bg-blue-100 text-blue-800',
   completed: 'bg-gray-100 text-gray-800',
   canceled: 'bg-red-100 text-red-800',
@@ -36,7 +37,12 @@ export default function OfferHeaderCard({
   onCancel,
 }: OfferHeaderCardProps) {
   const status = statusColor[offer.status] || 'bg-gray-100 text-gray-800'
-  const statusLabel = offer.status === 'pending' ? '返答待ち' : offer.status
+  const statusLabel =
+    offer.status === 'pending'
+      ? '返答待ち'
+      : offer.status === 'declined'
+        ? '辞退'
+        : offer.status
 
   return (
     <Card>


### PR DESCRIPTION
## Summary
- hook up accept/decline buttons on talent offer page
- show decline status color and label in offer header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac1b1b280c8332900b12c6fa4343d2