### PR TITLE
feat: add header message link with unread badge

### DIFF
--- a/supabase-docs/20250901_unread_messages_rpc.sql
+++ b/supabase-docs/20250901_unread_messages_rpc.sql
@@ -1,0 +1,20 @@
+-- RPC to get unread messages count for current user
+create or replace function public.unread_messages_count()
+returns bigint
+language sql
+security definer
+set search_path = public
+as $$
+  select count(*)::bigint
+  from messages m
+  join conversation_participants p on p.conversation_id = m.conversation_id
+  where p.user_id = auth.uid()
+    and m.sender_user_id <> auth.uid()
+    and m.created_at > coalesce(p.last_read_at, 'epoch');
+$$;
+
+grant execute on function public.unread_messages_count() to authenticated;
+
+-- Helpful indexes for performance
+create index if not exists messages_conversation_created_idx on public.messages(conversation_id, created_at);
+create index if not exists conversation_participants_user_idx on public.conversation_participants(user_id);

--- a/talentify-next-frontend/app/messages/page.js
+++ b/talentify-next-frontend/app/messages/page.js
@@ -2,6 +2,7 @@
 import { useState, useEffect, useRef, useMemo } from 'react'
 import Image from 'next/image'
 import { createClient } from '@/utils/supabase/client'
+import { EmptyState } from '@/components/ui/empty-state'
 
 const supabase = createClient()
 
@@ -40,6 +41,7 @@ export default function MessageBoxPage() {
   const [userId, setUserId] = useState(null)
   const [activeId, setActiveId] = useState(null)
   const [input, setInput] = useState('')
+  const [loading, setLoading] = useState(true)
   const messagesEndRef = useRef(null)
 
   useEffect(() => {
@@ -56,6 +58,7 @@ export default function MessageBoxPage() {
       } catch (e) {
         console.error(e)
       }
+      setLoading(false)
     }
     init()
   }, [])
@@ -87,6 +90,20 @@ export default function MessageBoxPage() {
   }, [activeId, messages])
 
   const activeThread = threads.find(t => t.id === activeId)
+
+  if (!loading && threads.length === 0) {
+    return (
+      <main className="flex justify-center">
+        <EmptyState
+          title="メッセージはまだありません"
+          description="店舗からの連絡やオファーのやり取りがここに届きます。"
+          actionHref="/profile"
+          actionLabel="プロフィールを充実させる"
+          className="py-20"
+        />
+      </main>
+    )
+  }
 
   const handleSend = async () => {
     if (!input || !activeId) return

--- a/talentify-next-frontend/components/Header.tsx
+++ b/talentify-next-frontend/components/Header.tsx
@@ -15,6 +15,7 @@ import {
 import { createClient } from '@/utils/supabase/client'
 import { getUserRoleInfo } from '@/lib/getUserRole'
 import HeaderBellLink from './notifications/HeaderBellLink'
+import HeaderMessageLink from './messages/HeaderMessageLink'
 import MobileDrawerNav from './MobileDrawerNav'
 
 const supabase = createClient()
@@ -113,7 +114,8 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
           <>
             {sidebarRole ? (
               isLoggedIn && (
-                <div className="ml-auto md:hidden">
+                <div className="ml-auto flex items-center gap-2 md:hidden">
+                  <HeaderMessageLink />
                   <HeaderBellLink />
                 </div>
               )
@@ -131,6 +133,7 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
                 )}
                 {isLoggedIn && (
                   <div className="ml-auto flex items-center gap-2 md:hidden">
+                    <HeaderMessageLink />
                     <HeaderBellLink />
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
@@ -190,6 +193,7 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
                 </>
               ) : (
                 <>
+                  <HeaderMessageLink />
                   <HeaderBellLink />
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>

--- a/talentify-next-frontend/components/messages/HeaderMessageLink.tsx
+++ b/talentify-next-frontend/components/messages/HeaderMessageLink.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import { MessageSquare } from 'lucide-react'
+import { createClient } from '@/utils/supabase/client'
+import { getUnreadMessageCount } from '@/utils/messages'
+import { formatUnreadCount } from '@/utils/notifications'
+
+const supabase = createClient()
+
+export default function HeaderMessageLink() {
+  const [count, setCount] = useState(0)
+
+  const refreshCount = async () => {
+    const c = await getUnreadMessageCount()
+    setCount(c)
+  }
+
+  useEffect(() => {
+    refreshCount()
+    const channel = supabase
+      .channel('header-message')
+      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'messages' }, () => {
+        refreshCount()
+      })
+      .subscribe()
+    const interval = setInterval(refreshCount, 60000)
+    return () => {
+      supabase.removeChannel(channel)
+      clearInterval(interval)
+    }
+  }, [])
+
+  const formatted = formatUnreadCount(count)
+
+  return (
+    <Link
+      href="/messages"
+      aria-label="メッセージ"
+      className="relative p-2 rounded-full hover:bg-muted focus:outline-none"
+    >
+      <MessageSquare className="h-6 w-6" />
+      {formatted && (
+        <span
+          aria-live="polite"
+          className="absolute -top-1 -right-1 flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-red-500 px-1 text-xs text-white"
+        >
+          {formatted}
+        </span>
+      )}
+    </Link>
+  )
+}

--- a/talentify-next-frontend/types/supabase.ts
+++ b/talentify-next-frontend/types/supabase.ts
@@ -589,6 +589,10 @@ export type Database = {
         }
         Returns: Database['public']['Tables']['offers']['Row']
       }
+      unread_messages_count: {
+        Args: Record<PropertyKey, never>
+        Returns: number
+      }
     }
     Enums: {
       invoice_status: 'draft' | 'submitted' | 'approved' | 'rejected' | 'pending'

--- a/talentify-next-frontend/utils/messages.ts
+++ b/talentify-next-frontend/utils/messages.ts
@@ -1,0 +1,19 @@
+'use client'
+
+import { createClient } from '@/utils/supabase/client'
+
+const supabase = createClient()
+
+export async function getUnreadMessageCount(): Promise<number> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return 0
+
+  const { data, error } = await supabase.rpc('unread_messages_count')
+  if (error) {
+    console.error('failed to fetch unread messages count', error)
+    return 0
+  }
+  return (data as number) ?? 0
+}


### PR DESCRIPTION
## Summary
- add unread message badge and link to header
- show empty state for messages page
- document unread_messages_count RPC

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac1dd20c8083329c03d4f3c612a19d