### PR TITLE
Fix offer acceptance and read receipt upsert

### DIFF
--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -43,17 +43,17 @@ export default function TalentOfferPage() {
   const handleAccept = async () => {
     const { error } = await supabase
       .from('offers')
-      .update({ status: 'accepted' })
+      .update({ status: 'confirmed' })
       .eq('id', offer.id)
-    if (!error) setOffer({ ...offer, status: 'accepted' })
+    if (!error) setOffer({ ...offer, status: 'confirmed' })
   }
 
   const handleDecline = async () => {
     const { error } = await supabase
       .from('offers')
-      .update({ status: 'declined' })
+      .update({ status: 'rejected' })
       .eq('id', offer.id)
-    if (!error) setOffer({ ...offer, status: 'declined' })
+    if (!error) setOffer({ ...offer, status: 'rejected' })
   }
 
   return (

--- a/talentify-next-frontend/components/offer/OfferHeaderCard.tsx
+++ b/talentify-next-frontend/components/offer/OfferHeaderCard.tsx
@@ -22,9 +22,8 @@ interface OfferHeaderCardProps {
 
 const statusColor: Record<string, string> = {
   pending: 'bg-yellow-100 text-yellow-800',
-  accepted: 'bg-green-100 text-green-800',
-  declined: 'bg-red-100 text-red-800',
-  confirmed: 'bg-blue-100 text-blue-800',
+  confirmed: 'bg-green-100 text-green-800',
+  rejected: 'bg-red-100 text-red-800',
   completed: 'bg-gray-100 text-gray-800',
   canceled: 'bg-red-100 text-red-800',
 }
@@ -40,9 +39,11 @@ export default function OfferHeaderCard({
   const statusLabel =
     offer.status === 'pending'
       ? '返答待ち'
-      : offer.status === 'declined'
+      : offer.status === 'rejected'
         ? '辞退'
-        : offer.status
+        : offer.status === 'confirmed'
+          ? '承諾済み'
+          : offer.status
 
   return (
     <Card>

--- a/talentify-next-frontend/lib/supabase/offerMessages.ts
+++ b/talentify-next-frontend/lib/supabase/offerMessages.ts
@@ -86,11 +86,14 @@ export async function upsertReadReceipt(client: SupabaseClient, offerId: string)
     data: { user },
   } = await client.auth.getUser()
   if (!user) return
-  await client.from('offer_read_receipts').upsert({
-    offer_id: offerId,
-    user_id: user.id,
-    last_read_at: new Date().toISOString(),
-  })
+  await client.from('offer_read_receipts').upsert(
+    {
+      offer_id: offerId,
+      user_id: user.id,
+      last_read_at: new Date().toISOString(),
+    },
+    { onConflict: 'offer_id,user_id' }
+  )
 }
 
 export async function getReadReceipts(client: SupabaseClient, offerId: string) {


### PR DESCRIPTION
## Summary
- Use `confirmed`/`rejected` statuses when a talent accepts or declines an offer
- Display new statuses in offer header labels
- Upsert offer read receipts without duplicate key conflicts

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ad0bd57f348332b94f06f4cc5c24bf