### PR TITLE
feat(talent): restrict offer actions after response

### DIFF
--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -1,59 +1,85 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useParams } from 'next/navigation'
 import { createClient } from '@/utils/supabase/client'
 import OfferHeaderCard from '@/components/offer/OfferHeaderCard'
 import OfferChatThread from '@/components/offer/OfferChatThread'
+import { toast } from 'sonner'
 
 export default function TalentOfferPage() {
   const params = useParams<{ id: string }>()
   const supabase = createClient()
   const [offer, setOffer] = useState<any>(null)
   const [userId, setUserId] = useState<string | null>(null)
+  const [actionLoading, setActionLoading] = useState<'accept' | 'decline' | null>(null)
+
+  const loadOffer = useCallback(async () => {
+    const { data } = await supabase
+      .from('offers')
+      .select(
+        'id,status,date,message,talent_id,user_id, talents(stage_name,avatar_url), stores(store_name)'
+      )
+      .eq('id', params.id)
+      .single()
+    if (data) {
+      setOffer({
+        id: data.id,
+        status: data.status,
+        date: data.date,
+        message: data.message,
+        performerName: data.talents?.stage_name || '',
+        performerAvatarUrl: data.talents?.avatar_url || null,
+        storeName: data.stores?.store_name || '',
+      })
+    }
+  }, [params.id, supabase])
 
   useEffect(() => {
-    const load = async () => {
+    const init = async () => {
       const { data: userData } = await supabase.auth.getUser()
       setUserId(userData.user?.id ?? null)
-      const { data } = await supabase
-        .from('offers')
-        .select('id,status,date,message,talent_id,user_id, talents(stage_name,avatar_url), stores(store_name)')
-        .eq('id', params.id)
-        .single()
-      if (data) {
-        setOffer({
-          id: data.id,
-          status: data.status,
-          date: data.date,
-          message: data.message,
-          performerName: data.talents?.stage_name || '',
-          performerAvatarUrl: data.talents?.avatar_url || null,
-          storeName: data.stores?.store_name || '',
-        })
-      }
+      await loadOffer()
     }
-    load()
-  }, [params.id, supabase])
+    init()
+  }, [loadOffer, supabase])
 
   if (!offer || !userId) {
     return <p className="p-4">Loading...</p>
   }
 
   const handleAccept = async () => {
+    if (offer.status !== 'pending') return
+    setActionLoading('accept')
+    setOffer({ ...offer, status: 'confirmed' })
     const { error } = await supabase
       .from('offers')
       .update({ status: 'confirmed' })
       .eq('id', offer.id)
-    if (!error) setOffer({ ...offer, status: 'confirmed' })
+    if (error) {
+      toast.error('承諾に失敗しました')
+      setOffer(prev => ({ ...prev, status: 'pending' }))
+    } else {
+      await loadOffer()
+    }
+    setActionLoading(null)
   }
 
   const handleDecline = async () => {
+    if (offer.status !== 'pending') return
+    setActionLoading('decline')
+    setOffer({ ...offer, status: 'rejected' })
     const { error } = await supabase
       .from('offers')
       .update({ status: 'rejected' })
       .eq('id', offer.id)
-    if (!error) setOffer({ ...offer, status: 'rejected' })
+    if (error) {
+      toast.error('辞退に失敗しました')
+      setOffer(prev => ({ ...prev, status: 'pending' }))
+    } else {
+      await loadOffer()
+    }
+    setActionLoading(null)
   }
 
   return (
@@ -63,6 +89,7 @@ export default function TalentOfferPage() {
         role="talent"
         onAccept={handleAccept}
         onDecline={handleDecline}
+        actionLoading={actionLoading}
       />
       <div id="chat" className="flex-1 min-h-0">
         <OfferChatThread

--- a/talentify-next-frontend/components/offer/OfferHeaderCard.tsx
+++ b/talentify-next-frontend/components/offer/OfferHeaderCard.tsx
@@ -18,14 +18,8 @@ interface OfferHeaderCardProps {
   onAccept?: () => void
   onDecline?: () => void
   onCancel?: () => void
-}
-
-const statusColor: Record<string, string> = {
-  pending: 'bg-yellow-100 text-yellow-800',
-  confirmed: 'bg-green-100 text-green-800',
-  rejected: 'bg-red-100 text-red-800',
-  completed: 'bg-gray-100 text-gray-800',
-  canceled: 'bg-red-100 text-red-800',
+  /** action in progress to control loading state of buttons */
+  actionLoading?: 'accept' | 'decline' | null
 }
 
 export default function OfferHeaderCard({
@@ -34,22 +28,28 @@ export default function OfferHeaderCard({
   onAccept,
   onDecline,
   onCancel,
+  actionLoading = null,
 }: OfferHeaderCardProps) {
-  const status = statusColor[offer.status] || 'bg-gray-100 text-gray-800'
-  const statusLabel =
-    offer.status === 'pending'
-      ? '返答待ち'
-      : offer.status === 'rejected'
-        ? '辞退'
-        : offer.status === 'confirmed'
-          ? '承諾済み'
-          : offer.status
+  const renderStatusBadge = () => {
+    if (offer.status === 'pending') return null
+    if (offer.status === 'confirmed') {
+      return <Badge className="ml-auto mr-2">承諾済み</Badge>
+    }
+    if (offer.status === 'rejected') {
+      return (
+        <Badge variant="secondary" className="ml-auto mr-2">
+          辞退済み
+        </Badge>
+      )
+    }
+    return <Badge className="ml-auto mr-2">{offer.status}</Badge>
+  }
 
   return (
     <Card>
       <CardHeader className="flex items-center">
         <CardTitle>オファー詳細</CardTitle>
-        <Badge className={`${status} ml-auto mr-2`}>{statusLabel}</Badge>
+        {renderStatusBadge()}
       </CardHeader>
       <CardContent className="space-y-4">
         <OfferSummary
@@ -62,19 +62,27 @@ export default function OfferHeaderCard({
         />
         <div className="flex flex-wrap gap-2">
           {role === 'store' && (
-            <>
-              <Button variant="outline" size="sm" onClick={onCancel}>
-                オファーをキャンセル
-              </Button>
-            </>
+            <Button variant="outline" size="sm" onClick={onCancel}>
+              オファーをキャンセル
+            </Button>
           )}
-          {role === 'talent' && (
+          {role === 'talent' && offer.status === 'pending' && (
             <>
-              <Button variant="default" size="sm" onClick={onAccept}>
-                承諾
+              <Button
+                variant="default"
+                size="sm"
+                onClick={onAccept}
+                disabled={actionLoading !== null}
+              >
+                {actionLoading === 'accept' ? '承諾中...' : '承諾'}
               </Button>
-              <Button variant="outline" size="sm" onClick={onDecline}>
-                辞退
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onDecline}
+                disabled={actionLoading !== null}
+              >
+                {actionLoading === 'decline' ? '辞退中...' : '辞退'}
               </Button>
             </>
           )}


### PR DESCRIPTION
## Summary
- hide accept/decline buttons once an offer is answered and show corresponding status badges
- disable accept/decline actions during API calls with optimistic status updates and error handling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad118e766c833292a1bcb4c45578fa