### PR TITLE
fix: allow direct messages without offer

### DIFF
--- a/supabase/migrations/20250901000001_allow_null_offer_id_in_offer_messages.sql
+++ b/supabase/migrations/20250901000001_allow_null_offer_id_in_offer_messages.sql
@@ -1,0 +1,15 @@
+-- Allow direct messages without an offer by making offer_id nullable
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'offer_messages'
+      AND column_name = 'offer_id'
+      AND is_nullable = 'NO'
+  ) THEN
+    ALTER TABLE public.offer_messages
+      ALTER COLUMN offer_id DROP NOT NULL;
+  END IF;
+END$$;

--- a/talentify-next-frontend/app/api/messages/send/route.ts
+++ b/talentify-next-frontend/app/api/messages/send/route.ts
@@ -30,15 +30,19 @@ export async function POST(req: NextRequest) {
     senderRole = talent ? 'talent' : 'admin'
   }
 
+  const message: Record<string, unknown> = {
+    sender_user: user.id,
+    receiver_user: receiverUser,
+    sender_role: senderRole,
+    body,
+  }
+  if (offerId) {
+    message.offer_id = offerId
+  }
+
   const { data, error } = await supabase
     .from('offer_messages')
-    .insert({
-      offer_id: offerId ?? null,
-      sender_user: user.id,
-      receiver_user: receiverUser,
-      sender_role: senderRole,
-      body,
-    })
+    .insert(message)
     .select('*')
     .single()
 

--- a/talentify-next-frontend/app/api/messages/send/route.ts
+++ b/talentify-next-frontend/app/api/messages/send/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import type { Database } from '@/lib/supabase/types'
 
 export async function POST(req: NextRequest) {
   const supabase = await createClient()
@@ -30,14 +31,12 @@ export async function POST(req: NextRequest) {
     senderRole = talent ? 'talent' : 'admin'
   }
 
-  const message: Record<string, unknown> = {
+  const message: Database['public']['Tables']['offer_messages']['Insert'] = {
     sender_user: user.id,
     receiver_user: receiverUser,
     sender_role: senderRole,
     body,
-  }
-  if (offerId) {
-    message.offer_id = offerId
+    ...(offerId ? { offer_id: offerId } : {}),
   }
 
   const { data, error } = await supabase


### PR DESCRIPTION
## Summary
- allow `offer_messages.offer_id` to be nullable for direct messaging
- send API omits `offer_id` when not provided

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad4d3e3dec8332a6cf857a21713c1f