### PR TITLE
Fix cancel offer button in store offer page

### DIFF
--- a/talentify-next-frontend/__tests__/offer-cancel-button.test.tsx
+++ b/talentify-next-frontend/__tests__/offer-cancel-button.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import OfferCancelButton from '@/components/offers/OfferCancelButton';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: jest.fn() }),
+}));
+
+jest.mock('@/utils/supabase/client', () => ({
+  createClient: () => ({
+    from: () => ({
+      update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+    }),
+  }),
+}));
+
+describe('OfferCancelButton', () => {
+  it('is disabled when status is not cancellable', () => {
+    const html = renderToStaticMarkup(
+      <OfferCancelButton offerId="1" currentStatus="canceled" />
+    );
+    expect(html).toContain('disabled');
+  });
+
+  it('is enabled when status is cancellable', () => {
+    const html = renderToStaticMarkup(
+      <OfferCancelButton offerId="1" currentStatus="pending" />
+    );
+    // button without disabled attribute
+    expect(html).not.toContain('disabled');
+  });
+});

--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'next/navigation'
 import { createClient } from '@/utils/supabase/client'
 import OfferHeaderCard from '@/components/offer/OfferHeaderCard'
 import OfferChatThread from '@/components/offer/OfferChatThread'
+import OfferCancelButton from '@/components/offers/OfferCancelButton'
 
 export default function StoreOfferPage() {
   const params = useParams<{ id: string }>()
@@ -43,6 +44,7 @@ export default function StoreOfferPage() {
   return (
     <div className="flex flex-col gap-4 h-full p-4">
       <OfferHeaderCard offer={offer} role="store" />
+      <OfferCancelButton offerId={offer.id} currentStatus={offer.status} />
       <div id="chat" className="flex-1 min-h-0">
         <OfferChatThread
           offerId={offer.id}

--- a/talentify-next-frontend/components/offer/OfferHeaderCard.tsx
+++ b/talentify-next-frontend/components/offer/OfferHeaderCard.tsx
@@ -17,7 +17,6 @@ interface OfferHeaderCardProps {
   role: 'store' | 'talent'
   onAccept?: () => void
   onDecline?: () => void
-  onCancel?: () => void
   /** action in progress to control loading state of buttons */
   actionLoading?: 'accept' | 'decline' | null
 }
@@ -27,7 +26,6 @@ export default function OfferHeaderCard({
   role,
   onAccept,
   onDecline,
-  onCancel,
   actionLoading = null,
 }: OfferHeaderCardProps) {
   const renderStatusBadge = () => {
@@ -61,11 +59,6 @@ export default function OfferHeaderCard({
           invoiceStatus={offer.invoiceStatus}
         />
         <div className="flex flex-wrap gap-2">
-          {role === 'store' && (
-            <Button variant="outline" size="sm" onClick={onCancel}>
-              オファーをキャンセル
-            </Button>
-          )}
           {role === 'talent' && offer.status === 'pending' && (
             <>
               <Button

--- a/talentify-next-frontend/components/offers/OfferCancelButton.tsx
+++ b/talentify-next-frontend/components/offers/OfferCancelButton.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/utils/supabase/client";
+
+export default function OfferCancelButton({
+  offerId,
+  currentStatus,
+}: { offerId: string; currentStatus: string }) {
+  const supabase = createClient();
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  const cancellable = new Set(["pending", "accepted", "confirmed"]);
+  const disabled = loading || !cancellable.has(currentStatus);
+
+  const onClick = async () => {
+    if (disabled) return;
+    console.log("cancel click:", offerId);
+    if (!confirm("このオファーを取り下げますか？")) return;
+
+    try {
+      setLoading(true);
+      const { error } = await supabase
+        .from("offers")
+        .update({
+          status: "canceled",
+          canceled_at: new Date().toISOString(),
+          canceled_by_role: "store",
+        })
+        .eq("id", offerId);
+
+      if (error) throw error;
+      alert("オファーを取り下げました。");
+      router.refresh();
+    } catch (e) {
+      console.error("cancel offer failed:", e);
+      alert("取り下げに失敗しました。");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      data-testid="offer-cancel-button"
+      className={`btn btn-outline ${disabled ? "opacity-50 cursor-not-allowed" : ""}`}
+    >
+      {loading ? "処理中..." : "オファーをキャンセル"}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add client-side `OfferCancelButton` to update Supabase and refresh the page
- remove non-working cancel action from `OfferHeaderCard` and use the new button on the store offer page
- test button's disabled state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad4e02ccf4833297348088c85f98f3