### PR TITLE
feat: add billing buttons on offer detail

### DIFF
--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -27,6 +27,12 @@ export default async function StoreOfferPage({ params }: PageProps) {
     notFound()
   }
 
+  const { data: invoice } = await supabase
+    .from('invoices')
+    .select('id')
+    .eq('offer_id', params.id)
+    .maybeSingle()
+
   const offer = {
     id: data.id as string,
     status: data.status as string,
@@ -37,9 +43,22 @@ export default async function StoreOfferPage({ params }: PageProps) {
     storeName: data.stores?.store_name || '',
   }
 
+  const showActions = ['accepted', 'confirmed', 'completed'].includes(data.status as string)
+  const invoiceLink = showActions
+    ? invoice
+      ? `/store/invoices/${invoice.id}`
+      : `/store/offers/${params.id}/invoice`
+    : undefined
+  const paymentLink = showActions ? `/store/offers/${params.id}/payment` : undefined
+
   return (
     <div className="flex flex-col gap-4 h-full p-4">
-      <OfferHeaderCard offer={offer} role="store" />
+      <OfferHeaderCard
+        offer={offer}
+        role="store"
+        invoiceLink={invoiceLink}
+        invoiceText="請求書を作成・確認"
+      />
       <CancelOfferSection
         offerId={offer.id}
         initialStatus={data.status}
@@ -50,6 +69,7 @@ export default async function StoreOfferPage({ params }: PageProps) {
           offerId={offer.id}
           currentUserId={user.id}
           currentRole="store"
+          paymentLink={paymentLink}
         />
       </div>
     </div>

--- a/talentify-next-frontend/components/offer/OfferChatThread.tsx
+++ b/talentify-next-frontend/components/offer/OfferChatThread.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
+import Link from 'next/link'
 import { createClient } from '@/utils/supabase/client'
 import type { OfferMessage } from '@/lib/supabase/offerMessages'
 import {
@@ -11,14 +12,20 @@ import {
 } from '@/lib/supabase/offerMessages'
 import ChatMessageBubble from './ChatMessageBubble'
 import OfferChatInput from './OfferChatInput'
+import { Button } from '@/components/ui/button'
 
 interface OfferChatThreadProps {
   offerId: string
   currentUserId: string
   currentRole: 'store' | 'talent' | 'admin'
+  paymentLink?: string
 }
-
-export default function OfferChatThread({ offerId, currentUserId, currentRole }: OfferChatThreadProps) {
+export default function OfferChatThread({
+  offerId,
+  currentUserId,
+  currentRole,
+  paymentLink,
+}: OfferChatThreadProps) {
   const supabase = createClient()
   const [messages, setMessages] = useState<OfferMessage[]>([])
   const [loading, setLoading] = useState(true)
@@ -115,6 +122,13 @@ export default function OfferChatThread({ offerId, currentUserId, currentRole }:
         ))}
       </div>
       <OfferChatInput offerId={offerId} senderRole={currentRole} onSent={handleSent} />
+      {paymentLink && (
+        <div className="border-t p-2 flex flex-wrap gap-2 justify-end">
+          <Button variant="default" size="sm" asChild>
+            <Link href={paymentLink}>支払い状況</Link>
+          </Button>
+        </div>
+      )}
     </div>
   )
 }

--- a/talentify-next-frontend/components/offer/OfferHeaderCard.tsx
+++ b/talentify-next-frontend/components/offer/OfferHeaderCard.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -19,6 +20,9 @@ interface OfferHeaderCardProps {
   onDecline?: () => void
   /** action in progress to control loading state of buttons */
   actionLoading?: 'accept' | 'decline' | null
+  /** link and text for invoice action button */
+  invoiceLink?: string
+  invoiceText?: string
 }
 
 export default function OfferHeaderCard({
@@ -27,27 +31,32 @@ export default function OfferHeaderCard({
   onAccept,
   onDecline,
   actionLoading = null,
+  invoiceLink,
+  invoiceText,
 }: OfferHeaderCardProps) {
   const renderStatusBadge = () => {
     if (offer.status === 'pending') return null
     if (offer.status === 'confirmed') {
-      return <Badge className="ml-auto mr-2">承諾済み</Badge>
+      return <Badge>承諾済み</Badge>
     }
     if (offer.status === 'rejected') {
-      return (
-        <Badge variant="secondary" className="ml-auto mr-2">
-          辞退済み
-        </Badge>
-      )
+      return <Badge variant="secondary">辞退済み</Badge>
     }
-    return <Badge className="ml-auto mr-2">{offer.status}</Badge>
+    return <Badge>{offer.status}</Badge>
   }
 
   return (
     <Card>
       <CardHeader className="flex items-center">
         <CardTitle>オファー詳細</CardTitle>
-        {renderStatusBadge()}
+        <div className="ml-auto flex items-center gap-2">
+          {invoiceLink && (
+            <Button variant="default" size="sm" asChild>
+              <Link href={invoiceLink}>{invoiceText}</Link>
+            </Button>
+          )}
+          {renderStatusBadge()}
+        </div>
       </CardHeader>
       <CardContent className="space-y-4">
         <OfferSummary


### PR DESCRIPTION
## Summary
- add invoice action button to offer header
- show payment status button below chat
- hook offer pages to query invoice and build role-specific links

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad68f2f8008332a84dc738c2603eef