### PR TITLE
feat: restore invoice creation entry

### DIFF
--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -44,11 +44,8 @@ export default async function StoreOfferPage({ params }: PageProps) {
   }
 
   const showActions = ['accepted', 'confirmed', 'completed'].includes(data.status as string)
-  const invoiceLink = showActions
-    ? invoice
-      ? `/store/invoices/${invoice.id}`
-      : `/store/offers/${params.id}/invoice`
-    : undefined
+  const invoiceLink = showActions && invoice ? `/store/invoices/${invoice.id}` : undefined
+  const invoiceText = invoice ? '請求書を見る' : undefined
   const paymentLink = showActions ? `/store/offers/${params.id}/payment` : undefined
 
   return (
@@ -57,7 +54,7 @@ export default async function StoreOfferPage({ params }: PageProps) {
         offer={offer}
         role="store"
         invoiceLink={invoiceLink}
-        invoiceText="請求書を作成・確認"
+        invoiceText={invoiceText}
       />
       <CancelOfferSection
         offerId={offer.id}

--- a/talentify-next-frontend/app/talent/invoices/new/page.tsx
+++ b/talentify-next-frontend/app/talent/invoices/new/page.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { useSearchParams, useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
+import { createClient } from '@/utils/supabase/client'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { toast } from 'sonner'
+
+export default function TalentInvoiceNewPage() {
+  const searchParams = useSearchParams()
+  const offerId = searchParams.get('offerId')
+  const router = useRouter()
+  const supabase = createClient()
+  const [amount, setAmount] = useState('')
+  const [invoiceUrl, setInvoiceUrl] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    const init = async () => {
+      if (!offerId) return
+      const { data: existing } = await supabase
+        .from('invoices')
+        .select('id')
+        .eq('offer_id', offerId)
+        .maybeSingle()
+      if (existing?.id) {
+        router.replace(`/talent/invoices/${existing.id}`)
+        return
+      }
+      const { data } = await supabase
+        .from('offers')
+        .select('invoice_amount,reward')
+        .eq('id', offerId)
+        .single()
+      if (data) {
+        setAmount(String(data.invoice_amount ?? data.reward ?? ''))
+      }
+    }
+    init()
+  }, [offerId, router, supabase])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!offerId) return
+    setLoading(true)
+    const res = await fetch('/api/invoices', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        offer_id: offerId,
+        amount: Number(amount),
+        invoice_url: invoiceUrl,
+      }),
+    })
+    if (!res.ok) {
+      toast.error('請求書の作成に失敗しました')
+      setLoading(false)
+      return
+    }
+    const data = await res.json()
+    router.replace(`/talent/invoices/${data.id}`)
+  }
+
+  return (
+    <main className="p-6 max-w-md space-y-4">
+      <h1 className="text-xl font-bold">請求書を作成</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block mb-2">金額</label>
+          <Input
+            type="number"
+            value={amount}
+            onChange={e => setAmount(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label className="block mb-2">請求書URL</label>
+          <Input
+            type="text"
+            value={invoiceUrl}
+            onChange={e => setInvoiceUrl(e.target.value)}
+            required
+          />
+        </div>
+        <Button type="submit" disabled={loading || !offerId}>
+          {loading ? '作成中...' : '作成'}
+        </Button>
+      </form>
+    </main>
+  )
+}

--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -103,8 +103,9 @@ export default function TalentOfferPage() {
   const invoiceLink = showActions
     ? invoiceId
       ? `/talent/invoices/${invoiceId}`
-      : `/talent/offers/${offer.id}/invoice`
+      : `/talent/invoices/new?offerId=${offer.id}`
     : undefined
+  const invoiceText = invoiceId ? '請求書を見る' : '請求書を作成'
   const paymentLink = showActions ? `/talent/offers/${offer.id}/payment` : undefined
 
   return (
@@ -116,7 +117,7 @@ export default function TalentOfferPage() {
         onDecline={handleDecline}
         actionLoading={actionLoading}
         invoiceLink={invoiceLink}
-        invoiceText="請求書を確認"
+        invoiceText={invoiceText}
       />
       <div id="chat" className="flex-1 min-h-0">
         <OfferChatThread


### PR DESCRIPTION
## Summary
- add invoice creation page at `/talent/invoices/new`
- show "請求書を作成" button on talent offer detail when no invoice exists
- hide invoice button for stores unless an invoice already exists

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad6b4e970483329cbf957373576399