### PR TITLE
Fix talent-side data fetch filters

### DIFF
--- a/talentify-next-frontend/utils/getInvoicesForTalent.ts
+++ b/talentify-next-frontend/utils/getInvoicesForTalent.ts
@@ -1,30 +1,20 @@
 'use client'
 import { createClient } from '@/utils/supabase/client'
 import type { Database } from '@/types/supabase'
+import { getTalentId } from './getTalentId'
 
 const supabase = createClient()
 
 export type Invoice = Database['public']['Tables']['invoices']['Row']
 
 export async function getInvoicesForTalent() {
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) return [] as Invoice[]
-
-  const { data: talent, error: talentError } = await supabase
-    .from('talents')
-    .select('id')
-    .eq('user_id', user.id)
-    .single()
-
-  if (talentError || !talent) {
-    console.error('failed to fetch talent', talentError)
-    return [] as Invoice[]
-  }
+  const talentId = await getTalentId()
+  if (!talentId) return [] as Invoice[]
 
   const { data, error } = await supabase
     .from('invoices')
     .select('*')
-    .eq('talent_id', talent.id)
+    .eq('talent_id', talentId)
     .order('created_at', { ascending: false })
 
   if (error) {

--- a/talentify-next-frontend/utils/getTalentId.ts
+++ b/talentify-next-frontend/utils/getTalentId.ts
@@ -1,0 +1,29 @@
+'use client'
+
+import { createClient } from '@/utils/supabase/client'
+
+const supabase = createClient()
+
+/**
+ * Fetch the talent id for the currently authenticated user.
+ * Returns `null` when no authenticated user or talent record exists.
+ */
+export async function getTalentId(): Promise<string | null> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return null
+
+  const { data, error } = await supabase
+    .from('talents')
+    .select('id')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (error) {
+    console.error('failed to fetch talent id', error)
+    return null
+  }
+
+  return data?.id ?? null
+}

--- a/talentify-next-frontend/utils/getTalentSchedule.ts
+++ b/talentify-next-frontend/utils/getTalentSchedule.ts
@@ -6,33 +6,20 @@ export type TalentSchedule = {
 }
 
 import { createClient } from '@/utils/supabase/client'
+import { getTalentId } from './getTalentId'
 
 /**
  * Fetch confirmed schedules for the current talent user
  */
 export async function getTalentSchedule(): Promise<TalentSchedule[]> {
   const supabase = createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-
-  if (!user) return []
-
-  const { data: talent, error: talentError } = await supabase
-    .from('talents')
-    .select('id')
-    .eq('user_id', user.id)
-    .single()
-
-  if (talentError || !talent) {
-    console.error('failed to fetch talent', talentError)
-    return []
-  }
+  const talentId = await getTalentId()
+  if (!talentId) return []
 
   const { data, error } = await supabase
     .from('offers')
     .select('id, date, time_range, stores(store_name)')
-    .eq('talent_id', talent.id)
+    .eq('talent_id', talentId)
     .eq('status', 'confirmed')
     .order('date', { ascending: true })
 


### PR DESCRIPTION
## Summary
- add reusable helper to fetch current talent id
- use talent id helper when querying offers, schedules, and invoices

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad6ed09d60833290ee1c0da2cfa6aa