### PR TITLE
fix role misdetection and message links

### DIFF
--- a/talentify-next-frontend/app/talent/dashboard/page.tsx
+++ b/talentify-next-frontend/app/talent/dashboard/page.tsx
@@ -16,7 +16,7 @@ export default async function TalentDashboard() {
         confirmed={schedule.length}
         link='/talent/offers'
       />
-      <MessageAlertCard count={unreadMessagesCount} link='/talents/messages' />
+      <MessageAlertCard count={unreadMessagesCount} link='/talent/messages' />
       <NotificationListCard className='sm:col-span-2 lg:col-span-3' />
       <div className='sm:col-span-2 lg:col-span-3'>
         <ProfileProgressCard />

--- a/talentify-next-frontend/app/talent/messages/page.tsx
+++ b/talentify-next-frontend/app/talent/messages/page.tsx
@@ -11,13 +11,13 @@ export default function TalentMessagesPage() {
     <main className="p-4">
       <div className="border-b mb-4 flex space-x-4">
         <Link
-          href="/talents/messages?tab=direct"
+          href="/talent/messages?tab=direct"
           className={`px-2 pb-2 border-b-2 ${tabParam === 'direct' ? 'border-blue-500 font-medium' : 'border-transparent text-gray-500'}`}
         >
           直通
         </Link>
         <Link
-          href="/talents/messages?tab=offer"
+          href="/talent/messages?tab=offer"
           className={`px-2 pb-2 border-b-2 ${tabParam === 'offer' ? 'border-blue-500 font-medium' : 'border-transparent text-gray-500'}`}
         >
           オファー

--- a/talentify-next-frontend/app/talent/notifications/page.tsx
+++ b/talentify-next-frontend/app/talent/notifications/page.tsx
@@ -47,7 +47,7 @@ export default function TalentNotificationsPage() {
   }
 
   const linkFor = (n: NotificationRow) => {
-    if (n.type === 'message') return '/talents/messages'
+    if (n.type === 'message') return '/talent/messages'
     const offerId = (n.data as any)?.offer_id
     return offerId ? `/talent/offers/${offerId}` : '#'
   }

--- a/talentify-next-frontend/components/Header.tsx
+++ b/talentify-next-frontend/components/Header.tsx
@@ -41,15 +41,6 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
       let displayName = name
 
       if (!displayName) {
-        const { data: profile } = await supabase
-          .from('profiles' as any)
-          .select('display_name')
-          .eq('id', user.id)
-          .maybeSingle()
-        displayName = (profile as any)?.display_name ?? null
-      }
-
-      if (!displayName) {
         displayName = user.email?.split('@')[0] ?? 'ユーザー'
       }
 

--- a/talentify-next-frontend/components/messages/HeaderMessageLink.tsx
+++ b/talentify-next-frontend/components/messages/HeaderMessageLink.tsx
@@ -39,7 +39,7 @@ export default function HeaderMessageLink() {
   }, [role])
 
   if (role !== 'store' && role !== 'talent') return null
-  const href = role === 'talent' ? '/talents/messages' : '/store/messages'
+  const href = role === 'talent' ? '/talent/messages' : '/store/messages'
   const formatted = formatUnreadCount(count)
 
   return (

--- a/talentify-next-frontend/components/nav-items.ts
+++ b/talentify-next-frontend/components/nav-items.ts
@@ -22,7 +22,7 @@ export const navItems: NavItem[] = [
   { href: "/talent/dashboard", label: "ダッシュボード", icon: LayoutDashboard, roles: ["talent"] },
   { href: "/talent/offers", label: "オファー一覧", icon: Mail, roles: ["talent"] },
   { href: "/talent/schedule", label: "スケジュール管理", icon: Calendar, roles: ["talent"] },
-  { href: "/talents/messages", label: "メッセージ", icon: MessageCircle, roles: ["talent"] },
+  { href: "/talent/messages", label: "メッセージ", icon: MessageCircle, roles: ["talent"] },
   { href: "/talent/edit", label: "プロフィール編集", icon: User, roles: ["talent"] },
   { href: "/talent/reviews", label: "評価・レビュー", icon: Star, roles: ["talent"] },
   { href: "/talent/payments", label: "ギャラ管理", icon: Wallet, roles: ["talent"] },

--- a/talentify-next-frontend/lib/getUserRole.ts
+++ b/talentify-next-frontend/lib/getUserRole.ts
@@ -5,43 +5,74 @@ export type UserRole = 'store' | 'talent' | 'company'
 
 export async function getUserRoleInfo(
   supabase: SupabaseClient<Database>,
-  userId: string
+  userId: string,
 ): Promise<{ role: UserRole | null; name: string | null; isSetupComplete: boolean | null }> {
-  const [
-    { data: store },
-    { data: talent },
-    { data: company },
-  ] = await Promise.all([
-    supabase
-      .from('stores' as any)
-      .select('store_name, is_setup_complete')
-      .eq('user_id', userId)
-      .maybeSingle(),
-    supabase
-      .from('talents' as any)
-      .select('stage_name, is_setup_complete')
-      .eq('user_id', userId)
-      .maybeSingle(),
-    supabase
-      .from('companies' as any)
-      .select('display_name, is_setup_complete')
-      .eq('user_id', userId)
-      .maybeSingle(),
-  ])
+  // user_metadata に role が設定されている場合はそれを優先
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  const metaRole = (user?.user_metadata as any)?.role as UserRole | undefined
 
-  if (store) {
+  const fetchRole = (
+    table: 'talents' | 'stores' | 'companies',
+    nameField: string,
+  ) =>
+    supabase
+      .from(table as any)
+      .select(`${nameField}, is_setup_complete`)
+      .eq('user_id', userId)
+      .maybeSingle()
+
+  if (metaRole) {
+    const table =
+      metaRole === 'talent'
+        ? 'talents'
+        : metaRole === 'store'
+        ? 'stores'
+        : 'companies'
+    const nameField =
+      metaRole === 'talent'
+        ? 'stage_name'
+        : metaRole === 'store'
+        ? 'store_name'
+        : 'display_name'
+    const { data } = await fetchRole(table, nameField)
     return {
-      role: 'store',
-      name: (store as any).store_name ?? '店舗ユーザー',
-      isSetupComplete: (store as any).is_setup_complete ?? false,
+      role: metaRole,
+      name:
+        metaRole === 'talent'
+          ? (data as any)?.stage_name ?? null
+          : metaRole === 'store'
+          ? (data as any)?.store_name ?? '店舗ユーザー'
+          : (data as any)?.display_name ?? '会社ユーザー',
+      isSetupComplete: (data as any)?.is_setup_complete ?? false,
     }
   }
+
+  // メタデータがない場合はテーブルを優先順位順に検索 (talent > store > company)
+  const [
+    { data: talent },
+    { data: store },
+    { data: company },
+  ] = await Promise.all([
+    fetchRole('talents', 'stage_name'),
+    fetchRole('stores', 'store_name'),
+    fetchRole('companies', 'display_name'),
+  ])
 
   if (talent) {
     return {
       role: 'talent',
       name: (talent as any).stage_name ?? null,
       isSetupComplete: (talent as any).is_setup_complete ?? false,
+    }
+  }
+
+  if (store) {
+    return {
+      role: 'store',
+      name: (store as any).store_name ?? '店舗ユーザー',
+      isSetupComplete: (store as any).is_setup_complete ?? false,
     }
   }
 
@@ -55,3 +86,4 @@ export async function getUserRoleInfo(
 
   return { role: null, name: null, isSetupComplete: null }
 }
+

--- a/talentify-next-frontend/middleware.ts
+++ b/talentify-next-frontend/middleware.ts
@@ -18,9 +18,22 @@ export async function middleware(req: NextRequest) {
 
   if (session?.user) {
     const { role } = await getUserRoleInfo(supabase, session.user.id)
+
     if ((role === 'store' || role === 'talent') && pathname.startsWith('/messages')) {
       const redirectUrl = req.nextUrl.clone()
       redirectUrl.pathname = `/${role}${pathname}`
+      return NextResponse.redirect(redirectUrl)
+    }
+
+    if (pathname.startsWith('/store') && role !== 'store') {
+      const redirectUrl = req.nextUrl.clone()
+      redirectUrl.pathname = role ? `/${role}/dashboard` : '/login'
+      return NextResponse.redirect(redirectUrl)
+    }
+
+    if (pathname.startsWith('/talent') && role !== 'talent') {
+      const redirectUrl = req.nextUrl.clone()
+      redirectUrl.pathname = role ? `/${role}/dashboard` : '/login'
       return NextResponse.redirect(redirectUrl)
     }
   }


### PR DESCRIPTION
## Summary
- prioritize user_metadata when resolving user roles
- guard /store and /talent routes and redirect /messages to role-specific paths
- fix talent message URL and remove profiles fallback in header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad7380bf7083328c051e377ff755fe