### PR TITLE
feat: redesign offer detail into two-column layout

### DIFF
--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -37,9 +37,8 @@ export default async function StoreOfferPage({ params }: PageProps) {
     .select('id,status')
     .eq('offer_id', params.id)
     .maybeSingle()
-
-  const invoiceStatus = invoice
-    ? invoice.status === 'paid'
+  const invoiceStatus: 'not_submitted' | 'submitted' | 'paid' = invoice
+    ? data.paid
       ? 'paid'
       : 'submitted'
     : 'not_submitted'

--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -1,8 +1,13 @@
 import { notFound } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
-import OfferHeaderCard from '@/components/offer/OfferHeaderCard'
 import OfferChatThread from '@/components/offer/OfferChatThread'
+import OfferSummary from '@/components/offer/OfferSummary'
+import OfferPaymentStatusCard from '@/components/offer/OfferPaymentStatusCard'
 import CancelOfferSection from './CancelOfferSection'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { format } from 'date-fns'
+import { ja } from 'date-fns/locale'
 
 type PageProps = {
   params: { id: string }
@@ -18,7 +23,7 @@ export default async function StoreOfferPage({ params }: PageProps) {
   const { data } = await supabase
     .from('offers')
     .select(
-      'id,status,date,message,talent_id,user_id,canceled_at, talents(stage_name,avatar_url), stores(store_name)'
+      'id,status,date,updated_at,message,talent_id,user_id,canceled_at,paid,paid_at, talents(stage_name,avatar_url), stores(store_name)'
     )
     .eq('id', params.id)
     .single()
@@ -29,10 +34,15 @@ export default async function StoreOfferPage({ params }: PageProps) {
 
   const { data: invoice } = await supabase
     .from('invoices')
-    .select('id')
+    .select('id,status')
     .eq('offer_id', params.id)
     .maybeSingle()
 
+  const invoiceStatus = invoice
+    ? invoice.status === 'paid'
+      ? 'paid'
+      : 'submitted'
+    : 'not_submitted'
   const offer = {
     id: data.id as string,
     status: data.status as string,
@@ -41,33 +51,75 @@ export default async function StoreOfferPage({ params }: PageProps) {
     performerName: data.talents?.stage_name || '',
     performerAvatarUrl: data.talents?.avatar_url || null,
     storeName: data.stores?.store_name || '',
+    updatedAt: data.updated_at as string,
+    paid: data.paid as boolean,
+    paidAt: data.paid_at as string | null,
+    invoiceStatus,
   }
 
   const showActions = ['accepted', 'confirmed', 'completed'].includes(data.status as string)
-  const invoiceLink = showActions && invoice ? `/store/invoices/${invoice.id}` : undefined
-  const invoiceText = invoice ? '請求書を見る' : undefined
   const paymentLink = showActions ? `/store/offers/${params.id}/payment` : undefined
+  const formattedUpdatedAt = format(new Date(offer.updatedAt), 'yyyy/MM/dd HH:mm', {
+    locale: ja,
+  })
+
+  const renderStatusBadge = () => {
+    if (offer.status === 'confirmed' || offer.status === 'accepted') {
+      return <Badge>承認済み</Badge>
+    }
+    if (offer.status === 'rejected') {
+      return <Badge variant="secondary">辞退済み</Badge>
+    }
+    if (offer.status === 'canceled') {
+      return <Badge variant="destructive">キャンセル済み</Badge>
+    }
+    return <Badge variant="secondary">未承諾</Badge>
+  }
 
   return (
-    <div className="flex flex-col gap-4 h-full p-4">
-      <OfferHeaderCard
-        offer={offer}
-        role="store"
-        invoiceLink={invoiceLink}
-        invoiceText={invoiceText}
-      />
-      <CancelOfferSection
-        offerId={offer.id}
-        initialStatus={data.status}
-        initialCanceledAt={data.canceled_at}
-      />
-      <div id="chat" className="flex-1 min-h-0">
-        <OfferChatThread
-          offerId={offer.id}
-          currentUserId={user.id}
-          currentRole="store"
-          paymentLink={paymentLink}
-        />
+    <div className="flex flex-col lg:flex-row gap-4 h-full p-4">
+      <div className="flex flex-col gap-4 w-full lg:w-1/3">
+        <Card>
+          <CardHeader>
+            <CardTitle>オファー詳細</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <OfferSummary
+              performerName={offer.performerName}
+              performerAvatarUrl={offer.performerAvatarUrl}
+              storeName={offer.storeName}
+              date={offer.date}
+              message={offer.message}
+              invoiceStatus={offer.invoiceStatus}
+            />
+            <div className="mt-4">
+              <CancelOfferSection
+                offerId={offer.id}
+                initialStatus={data.status}
+                initialCanceledAt={data.canceled_at}
+              />
+            </div>
+          </CardContent>
+        </Card>
+        <OfferPaymentStatusCard paid={offer.paid} paidAt={offer.paidAt} />
+      </div>
+      <div className="flex flex-col flex-1 gap-4 w-full lg:w-2/3">
+        <div className="flex items-center justify-between p-4 bg-white rounded shadow">
+          <div className="flex items-center gap-2">
+            {renderStatusBadge()}
+            <span className="text-sm text-muted-foreground">
+              最終更新: {formattedUpdatedAt}
+            </span>
+          </div>
+        </div>
+        <div id="chat" className="flex-1 min-h-0">
+          <OfferChatThread
+            offerId={offer.id}
+            currentUserId={user.id}
+            currentRole="store"
+            paymentLink={paymentLink}
+          />
+        </div>
       </div>
     </div>
   )

--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -3,8 +3,15 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useParams } from 'next/navigation'
 import { createClient } from '@/utils/supabase/client'
-import OfferHeaderCard from '@/components/offer/OfferHeaderCard'
+import Link from 'next/link'
 import OfferChatThread from '@/components/offer/OfferChatThread'
+import OfferSummary from '@/components/offer/OfferSummary'
+import OfferPaymentStatusCard from '@/components/offer/OfferPaymentStatusCard'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { format } from 'date-fns'
+import { ja } from 'date-fns/locale'
 import { toast } from 'sonner'
 
 export default function TalentOfferPage() {
@@ -20,12 +27,22 @@ export default function TalentOfferPage() {
     const { data } = await supabase
       .from('offers')
       .select(
-        'id,status,date,message,talent_id,user_id, talents(stage_name,avatar_url), stores(store_name)'
+        'id,status,date,updated_at,message,talent_id,user_id,paid,paid_at, talents(stage_name,avatar_url), stores(store_name)'
       )
       .eq('id', params.id)
       .or('and(status.eq.canceled,accepted_at.not.is.null),status.neq.canceled')
       .single()
     if (data) {
+      const { data: invoice } = await supabase
+        .from('invoices')
+        .select('id,status')
+        .eq('offer_id', params.id)
+        .maybeSingle()
+      const invoiceStatus = invoice
+        ? invoice.status === 'paid'
+          ? 'paid'
+          : 'submitted'
+        : 'not_submitted'
       setOffer({
         id: data.id,
         status: data.status,
@@ -34,12 +51,11 @@ export default function TalentOfferPage() {
         performerName: data.talents?.stage_name || '',
         performerAvatarUrl: data.talents?.avatar_url || null,
         storeName: data.stores?.store_name || '',
+        updatedAt: data.updated_at,
+        paid: data.paid,
+        paidAt: data.paid_at,
+        invoiceStatus,
       })
-      const { data: invoice } = await supabase
-        .from('invoices')
-        .select('id')
-        .eq('offer_id', params.id)
-        .maybeSingle()
       setInvoiceId(invoice?.id ?? null)
     } else {
       setOffer(null)
@@ -107,25 +123,85 @@ export default function TalentOfferPage() {
     : undefined
   const invoiceText = invoiceId ? '請求書を見る' : '請求書を作成'
   const paymentLink = showActions ? `/talent/offers/${offer.id}/payment` : undefined
+  const formattedUpdatedAt = format(new Date(offer.updatedAt), 'yyyy/MM/dd HH:mm', {
+    locale: ja,
+  })
+
+  const renderStatusBadge = () => {
+    if (offer.status === 'confirmed' || offer.status === 'accepted') {
+      return <Badge>承認済み</Badge>
+    }
+    if (offer.status === 'rejected') {
+      return <Badge variant="secondary">辞退済み</Badge>
+    }
+    if (offer.status === 'canceled') {
+      return <Badge variant="destructive">キャンセル済み</Badge>
+    }
+    return <Badge variant="secondary">未承諾</Badge>
+  }
 
   return (
-    <div className="flex flex-col gap-4 h-full p-4">
-      <OfferHeaderCard
-        offer={offer}
-        role="talent"
-        onAccept={handleAccept}
-        onDecline={handleDecline}
-        actionLoading={actionLoading}
-        invoiceLink={invoiceLink}
-        invoiceText={invoiceText}
-      />
-      <div id="chat" className="flex-1 min-h-0">
-        <OfferChatThread
-          offerId={offer.id}
-          currentUserId={userId}
-          currentRole="talent"
-          paymentLink={paymentLink}
-        />
+    <div className="flex flex-col lg:flex-row gap-4 h-full p-4">
+      <div className="flex flex-col gap-4 w-full lg:w-1/3">
+        <Card>
+          <CardHeader>
+            <CardTitle>オファー詳細</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <OfferSummary
+              performerName={offer.performerName}
+              performerAvatarUrl={offer.performerAvatarUrl}
+              storeName={offer.storeName}
+              date={offer.date}
+              message={offer.message}
+              invoiceStatus={offer.invoiceStatus}
+            />
+            {offer.status === 'pending' && (
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  variant="default"
+                  size="sm"
+                  onClick={handleAccept}
+                  disabled={actionLoading !== null}
+                >
+                  {actionLoading === 'accept' ? '承諾中...' : '承諾'}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleDecline}
+                  disabled={actionLoading !== null}
+                >
+                  {actionLoading === 'decline' ? '辞退中...' : '辞退'}
+                </Button>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+        <OfferPaymentStatusCard paid={offer.paid} paidAt={offer.paidAt} />
+      </div>
+      <div className="flex flex-col flex-1 gap-4 w-full lg:w-2/3">
+        <div className="flex items-center justify-between p-4 bg-white rounded shadow">
+          <div className="flex items-center gap-2">
+            {renderStatusBadge()}
+            <span className="text-sm text-muted-foreground">
+              最終更新: {formattedUpdatedAt}
+            </span>
+          </div>
+          {invoiceLink && (
+            <Button variant="default" size="sm" asChild>
+              <Link href={invoiceLink}>{invoiceText}</Link>
+            </Button>
+          )}
+        </div>
+        <div id="chat" className="flex-1 min-h-0">
+          <OfferChatThread
+            offerId={offer.id}
+            currentUserId={userId}
+            currentRole="talent"
+            paymentLink={paymentLink}
+          />
+        </div>
       </div>
     </div>
   )

--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -38,8 +38,8 @@ export default function TalentOfferPage() {
         .select('id,status')
         .eq('offer_id', params.id)
         .maybeSingle()
-      const invoiceStatus = invoice
-        ? invoice.status === 'paid'
+      const invoiceStatus: 'not_submitted' | 'submitted' | 'paid' = invoice
+        ? data.paid
           ? 'paid'
           : 'submitted'
         : 'not_submitted'

--- a/talentify-next-frontend/components/offer/OfferPaymentStatusCard.tsx
+++ b/talentify-next-frontend/components/offer/OfferPaymentStatusCard.tsx
@@ -1,0 +1,32 @@
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { format } from 'date-fns'
+import { ja } from 'date-fns/locale'
+
+interface OfferPaymentStatusCardProps {
+  paid: boolean
+  paidAt?: string | null
+}
+
+export default function OfferPaymentStatusCard({ paid, paidAt }: OfferPaymentStatusCardProps) {
+  const paidAtFormatted = paidAt ? format(new Date(paidAt), 'yyyy/MM/dd', { locale: ja }) : null
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>支払い状況</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {paid ? (
+          <div className="flex items-center gap-2">
+            <Badge className="bg-green-500 text-white">支払い完了</Badge>
+            {paidAtFormatted && (
+              <span className="text-sm text-muted-foreground">{paidAtFormatted}</span>
+            )}
+          </div>
+        ) : (
+          <Badge className="bg-red-500 text-white">支払い未完了</Badge>
+        )}
+      </CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION
## Summary
- redesign talent and store offer pages into responsive 2-column layout
- add payment status card and status header with invoice button

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1147c84148332b83e7d7e40431ca7