### PR TITLE
feat: add invoice payment workflow

### DIFF
--- a/talentify-next-frontend/app/store/invoices/page.tsx
+++ b/talentify-next-frontend/app/store/invoices/page.tsx
@@ -58,13 +58,10 @@ export default function StoreInvoicesPage() {
             {invoices.map(inv => (
               <TableRow key={inv.id}>
                 <TableCell>{formatJaDateTimeWithWeekday(inv.created_at ?? '')}</TableCell>
-                <TableCell>¥{inv.amount.toLocaleString()}</TableCell>
+                <TableCell>¥{inv.amount.toLocaleString('ja-JP')}</TableCell>
                 <TableCell>{renderStatus(inv)}</TableCell>
                 <TableCell>
                   <div className='flex gap-2'>
-                    <Button size='sm' asChild>
-                      <Link href={`/store/invoices/${inv.id}`}>詳細</Link>
-                    </Button>
                     {inv.invoice_url && (
                       <Button size='sm' variant='outline' asChild>
                         <Link href={inv.invoice_url} target='_blank'>
@@ -72,6 +69,9 @@ export default function StoreInvoicesPage() {
                         </Link>
                       </Button>
                     )}
+                    <Button size='sm' asChild>
+                      <Link href={`/store/invoices/${inv.id}`}>詳細</Link>
+                    </Button>
                   </div>
                 </TableCell>
               </TableRow>

--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -109,7 +109,15 @@ export default async function StoreOfferPage({ params }: PageProps) {
             </div>
           </CardContent>
         </Card>
-        <OfferPaymentStatusCard paid={offer.paid} paidAt={offer.paidAt} invoice={invoiceData} />
+        {invoiceData && (
+          <OfferPaymentStatusCard
+            title="請求"
+            offerId={offer.id}
+            paid={offer.paid}
+            paidAt={offer.paidAt}
+            invoice={invoiceData}
+          />
+        )}
       </div>
       <div className="flex flex-col flex-1 gap-4 w-full lg:w-2/3">
         <div className="flex items-center justify-between p-4 bg-white rounded shadow">


### PR DESCRIPTION
## Summary
- add invoice card on store offer detail with PDF link and pay action
- expose PDF and detail links in invoice listing
- redirect to review creation after marking an invoice paid

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b66689478c8332ac49862d2f034728