### PR TITLE
fix: invoice routes use talent/store ids for auth

### DIFF
--- a/talentify-next-frontend/app/api/invoices/[id]/approve/route.ts
+++ b/talentify-next-frontend/app/api/invoices/[id]/approve/route.ts
@@ -21,7 +21,18 @@ export async function POST(
     if (invError || !invoice) {
       return NextResponse.json<{ error: string }>({ error: '請求書が見つかりません' }, { status: 404 })
     }
-    if (invoice.status !== 'submitted' || user.id !== invoice.store_id) {
+
+    const { data: store, error: storeError } = await supabase
+      .from('stores')
+      .select('id')
+      .eq('user_id', user.id)
+      .single()
+    if (
+      storeError ||
+      !store ||
+      invoice.status !== 'submitted' ||
+      store.id !== invoice.store_id
+    ) {
       return NextResponse.json<{ error: string }>({ error: '権限がありません' }, { status: 403 })
     }
 

--- a/talentify-next-frontend/app/api/invoices/[id]/pay/route.ts
+++ b/talentify-next-frontend/app/api/invoices/[id]/pay/route.ts
@@ -25,7 +25,18 @@ export async function POST(
     if (invError || !invoice) {
       return NextResponse.json<{ error: string }>({ error: '請求書が見つかりません' }, { status: 404 })
     }
-    if (invoice.status !== 'approved' || user.id !== invoice.store_id) {
+
+    const { data: store, error: storeError } = await supabase
+      .from('stores')
+      .select('id')
+      .eq('user_id', user.id)
+      .single()
+    if (
+      storeError ||
+      !store ||
+      invoice.status !== 'approved' ||
+      store.id !== invoice.store_id
+    ) {
       return NextResponse.json<{ error: string }>({ error: '権限がありません' }, { status: 403 })
     }
 

--- a/talentify-next-frontend/app/api/invoices/[id]/reject/route.ts
+++ b/talentify-next-frontend/app/api/invoices/[id]/reject/route.ts
@@ -22,7 +22,18 @@ export async function POST(
     if (invError || !invoice) {
       return NextResponse.json<{ error: string }>({ error: '請求書が見つかりません' }, { status: 404 })
     }
-    if (invoice.status !== 'submitted' || user.id !== invoice.store_id) {
+
+    const { data: store, error: storeError } = await supabase
+      .from('stores')
+      .select('id')
+      .eq('user_id', user.id)
+      .single()
+    if (
+      storeError ||
+      !store ||
+      invoice.status !== 'submitted' ||
+      store.id !== invoice.store_id
+    ) {
       return NextResponse.json<{ error: string }>({ error: '権限がありません' }, { status: 403 })
     }
 

--- a/talentify-next-frontend/app/api/invoices/[id]/route.ts
+++ b/talentify-next-frontend/app/api/invoices/[id]/route.ts
@@ -25,7 +25,13 @@ export async function PATCH(
     if (invoice.status !== 'draft') {
       return NextResponse.json<{ error: string }>({ error: '下書きのみ編集できます' }, { status: 400 })
     }
-    if (user.id !== invoice.talent_id) {
+
+    const { data: talent, error: talentError } = await supabase
+      .from('talents')
+      .select('id')
+      .eq('user_id', user.id)
+      .single()
+    if (talentError || !talent || talent.id !== invoice.talent_id) {
       return NextResponse.json<{ error: string }>({ error: '権限がありません' }, { status: 403 })
     }
 

--- a/talentify-next-frontend/app/api/invoices/[id]/submit/route.ts
+++ b/talentify-next-frontend/app/api/invoices/[id]/submit/route.ts
@@ -25,7 +25,18 @@ export async function POST(
     if (invError || !invoice) {
       return NextResponse.json<{ error: string }>({ error: '請求書が見つかりません' }, { status: 404 })
     }
-    if (invoice.status !== 'draft' || user.id !== invoice.talent_id) {
+
+    const { data: talent, error: talentError } = await supabase
+      .from('talents')
+      .select('id')
+      .eq('user_id', user.id)
+      .single()
+    if (
+      talentError ||
+      !talent ||
+      invoice.status !== 'draft' ||
+      talent.id !== invoice.talent_id
+    ) {
       return NextResponse.json<{ error: string }>({ error: '権限がありません' }, { status: 403 })
     }
 


### PR DESCRIPTION
## Summary
- resolve talent/store id from the logged in user before invoice comparisons
- authorize invoice creation, submission, approval, rejection and payment using table IDs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b66a7822b08332a0ec9962249e4117