### PR TITLE
feat: auto approve invoice submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 NEXT_PUBLIC_API_BASE=
 NEXT_PUBLIC_SITE_URL=https://example.com
 NOTIFICATION_WEBHOOK_URL=https://example.com/webhook
+INVOICE_AUTO_APPROVE=true
 
 `NEXT_PUBLIC_API_BASE` を空にしておくと、フロントエンドと同じオリジンの API ルートを使用します。別ドメインを指定すると認証リクエストが CORS でブロックされるため注意してください。特に本番環境ではこの値を設定せず、フロントと API を同一ドメインでホスティングする構成を推奨します。
 

--- a/supabase/migrations/20250903000000_auto_approve_invoices.sql
+++ b/supabase/migrations/20250903000000_auto_approve_invoices.sql
@@ -1,0 +1,2 @@
+-- Convert existing submitted invoices to approved
+update invoices set status = 'approved' where status = 'submitted';

--- a/talentify-next-frontend/__tests__/invoiceStatus.test.ts
+++ b/talentify-next-frontend/__tests__/invoiceStatus.test.ts
@@ -1,0 +1,19 @@
+import { getSubmitStatus } from '@/app/api/invoices/utils'
+
+describe('getSubmitStatus', () => {
+  const backup = process.env.INVOICE_AUTO_APPROVE
+
+  afterEach(() => {
+    process.env.INVOICE_AUTO_APPROVE = backup
+  })
+
+  it('returns approved when env true', () => {
+    process.env.INVOICE_AUTO_APPROVE = 'true'
+    expect(getSubmitStatus()).toBe('approved')
+  })
+
+  it('returns submitted when env not true', () => {
+    delete process.env.INVOICE_AUTO_APPROVE
+    expect(getSubmitStatus()).toBe('submitted')
+  })
+})

--- a/talentify-next-frontend/app/api/invoices/route.ts
+++ b/talentify-next-frontend/app/api/invoices/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { getSubmitStatus } from './utils'
 
 export async function POST(req: NextRequest) {
   const supabase = await createClient()
@@ -58,7 +59,7 @@ export async function POST(req: NextRequest) {
       store_id: offer.store_id,
       talent_id: offer.talent_id,
       amount,
-      status: 'submitted' as const,
+      status: getSubmitStatus() as 'submitted' | 'approved',
       notes,
       transport_fee,
       extra_fee,
@@ -77,7 +78,7 @@ export async function POST(req: NextRequest) {
         .from('offers')
         .update({ invoice_amount: null, invoice_date: null, paid: null, paid_at: null })
         .eq('id', offer_id)
-      return NextResponse.json({ id: updated.id }, { status: 200 })
+      return NextResponse.json({ id: updated.id, status: payload.status }, { status: 200 })
     }
 
     const { data: inserted, error: insertError } = await supabase
@@ -92,7 +93,7 @@ export async function POST(req: NextRequest) {
       .update({ invoice_amount: null, invoice_date: null, paid: null, paid_at: null })
       .eq('id', offer_id)
 
-    return NextResponse.json({ id: inserted.id }, { status: 201 })
+    return NextResponse.json({ id: inserted.id, status: payload.status }, { status: 201 })
   } catch (err: any) {
     console.error({ code: err.code, message: err.message })
     if (err.code === '23505' && offerId) {

--- a/talentify-next-frontend/app/api/invoices/utils.ts
+++ b/talentify-next-frontend/app/api/invoices/utils.ts
@@ -1,0 +1,3 @@
+export function getSubmitStatus() {
+  return process.env.INVOICE_AUTO_APPROVE === 'true' ? 'approved' : 'submitted'
+}

--- a/talentify-next-frontend/app/store/invoices/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/invoices/[id]/page.tsx
@@ -30,10 +30,8 @@ interface RawInvoice extends Omit<Invoice, 'offers'> {
 function statusLabel(inv: Invoice): string {
   if (inv.offers?.paid) return '支払い完了'
   switch (inv.status) {
-    case 'submitted':
-      return '承認待ち'
     case 'approved':
-      return '承認済み'
+      return '提出済み'
     case 'rejected':
       return '差し戻し済み'
     default:
@@ -118,7 +116,7 @@ export default function StoreInvoiceDetail() {
         </CardContent>
       </Card>
 
-      {!invoice.offers?.paid && (
+      {!invoice.offers?.paid && invoice.status === 'approved' && (
         <Button onClick={handlePay} disabled={paying}>
           {paying && <Loader2 className='mr-2 h-4 w-4 animate-spin' />}
           支払い完了にする

--- a/talentify-next-frontend/app/store/invoices/page.tsx
+++ b/talentify-next-frontend/app/store/invoices/page.tsx
@@ -15,10 +15,8 @@ function renderStatus(inv: Invoice) {
     return <Badge variant='success'>支払い完了</Badge>
   }
   switch (inv.status) {
-    case 'submitted':
-      return <Badge variant='secondary'>承認待ち</Badge>
     case 'approved':
-      return <Badge>承認済み</Badge>
+      return <Badge variant='secondary'>提出済み</Badge>
     case 'rejected':
       return <Badge variant='destructive'>差し戻し済み</Badge>
     default:

--- a/talentify-next-frontend/app/talent/invoices/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/invoices/[id]/page.tsx
@@ -13,8 +13,7 @@ const supabase = createClient()
 
 const statusLabels: Record<string, string> = {
   draft: '下書き',
-  submitted: '請求済み',
-  approved: '承認済み',
+  approved: '提出済み',
   paid: '支払完了',
   rejected: '差し戻し',
 }

--- a/talentify-next-frontend/app/talent/invoices/new/page.tsx
+++ b/talentify-next-frontend/app/talent/invoices/new/page.tsx
@@ -61,21 +61,13 @@ export default function TalentInvoiceNewPage() {
 
   const statusLabel = () => {
     if (invoice?.payment_status === 'paid') return '支払済み'
-    if (invoice?.status === 'approved') return '承認済み'
-    if (invoice?.status === 'submitted') return '提出済み'
+    if (invoice?.status === 'approved') return '提出済み'
     return '下書き'
   }
 
   const currentStep = () => {
-    if (invoice?.payment_status === 'paid') return 3
-    switch (invoice?.status) {
-      case 'approved':
-        return 2
-      case 'submitted':
-        return 1
-      default:
-        return 0
-    }
+    if (invoice?.payment_status === 'paid') return 2
+    return invoice?.status === 'approved' ? 1 : 0
   }
 
   const saveDraft = async () => {
@@ -187,7 +179,7 @@ export default function TalentInvoiceNewPage() {
     ? format(new Date(offer.date), 'yyyy/MM/dd (EEE)', { locale: ja })
     : ''
 
-  const steps = ['下書き保存', '提出待ち', '承認待ち', '支払い完了']
+  const steps = ['下書き保存', '提出済み', '支払い完了']
 
   return (
     <main className="p-6">

--- a/talentify-next-frontend/app/talent/invoices/page.tsx
+++ b/talentify-next-frontend/app/talent/invoices/page.tsx
@@ -11,8 +11,7 @@ import { formatJaDateTimeWithWeekday } from '@/utils/formatJaDateTimeWithWeekday
 
 const statusLabels: Record<string, string> = {
   draft: '下書き',
-  submitted: '請求済み',
-  approved: '承認済み',
+  approved: '提出済み',
   paid: '支払完了',
   rejected: '差し戻し',
 }

--- a/talentify-next-frontend/components/offer/OfferPaymentStatusCard.tsx
+++ b/talentify-next-frontend/components/offer/OfferPaymentStatusCard.tsx
@@ -37,10 +37,8 @@ export default function OfferPaymentStatusCard({
 
   const statusLabel = (status?: string) => {
     switch (status) {
-      case 'submitted':
-        return '承認待ち'
       case 'approved':
-        return '承認済み'
+        return '提出済み'
       case 'rejected':
         return '差し戻し済み'
       default:
@@ -102,7 +100,7 @@ export default function OfferPaymentStatusCard({
                   </Link>
                 </Button>
               )}
-              {!paid && (
+              {!paid && invoice.status === 'approved' && (
                 <Button onClick={handlePay} disabled={loading}>
                   {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                   支払い完了にする

--- a/talentify-next-frontend/supabase-docs/invoices-status-and-payment.md
+++ b/talentify-next-frontend/supabase-docs/invoices-status-and-payment.md
@@ -3,7 +3,7 @@
 - 目的: invoice の提出/支払い状態の追跡
 - カラム/型:
   - `invoices.status` … enum `status_type` (`draft`, `submitted`, `approved`, `rejected`, …)
-    - ※今回 'submitted' を追加。
+    - `submitted` は enum に残るが現在のフローでは使用せず、提出時に自動的に `approved` へ遷移する。
   - `invoices.payment_status` … enum `payment_status` (`pending`, `processing`, `paid`, `failed`)
   - `invoices.paid_at` … `timestamptz`
 - ユニーク制約: `invoices(offer_id)`（1オファー=1請求）


### PR DESCRIPTION
## Summary
- auto-approve invoices on submit via INVOICE_AUTO_APPROVE flag
- update UI to show 提出済み and enable pay when approved
- migrate existing submitted invoices to approved

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6a0ea7a9c8332b040c003f5fd47e8