### PR TITLE
Support submitted invoice status

### DIFF
--- a/talentify-next-frontend/app/store/invoices/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/invoices/[id]/page.tsx
@@ -31,6 +31,7 @@ function statusLabel(inv: Invoice): string {
   if (inv.offers?.paid) return '支払い完了'
   switch (inv.status) {
     case 'approved':
+    case 'submitted':
       return '提出済み'
     case 'rejected':
       return '差し戻し済み'
@@ -116,7 +117,7 @@ export default function StoreInvoiceDetail() {
         </CardContent>
       </Card>
 
-      {!invoice.offers?.paid && invoice.status === 'approved' && (
+      {!invoice.offers?.paid && invoice.status !== 'draft' && (
         <Button onClick={handlePay} disabled={paying}>
           {paying && <Loader2 className='mr-2 h-4 w-4 animate-spin' />}
           支払い完了にする

--- a/talentify-next-frontend/app/store/invoices/page.tsx
+++ b/talentify-next-frontend/app/store/invoices/page.tsx
@@ -17,6 +17,8 @@ function renderStatus(inv: Invoice) {
   switch (inv.status) {
     case 'approved':
       return <Badge variant='secondary'>提出済み</Badge>
+    case 'submitted':
+      return <Badge variant='secondary'>提出済み</Badge>
     case 'rejected':
       return <Badge variant='destructive'>差し戻し済み</Badge>
     default:

--- a/talentify-next-frontend/app/talent/invoices/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/invoices/[id]/page.tsx
@@ -14,6 +14,7 @@ const supabase = createClient()
 const statusLabels: Record<string, string> = {
   draft: '下書き',
   approved: '提出済み',
+  submitted: '提出済み',
   paid: '支払完了',
   rejected: '差し戻し',
 }

--- a/talentify-next-frontend/app/talent/invoices/page.tsx
+++ b/talentify-next-frontend/app/talent/invoices/page.tsx
@@ -12,6 +12,7 @@ import { formatJaDateTimeWithWeekday } from '@/utils/formatJaDateTimeWithWeekday
 const statusLabels: Record<string, string> = {
   draft: '下書き',
   approved: '提出済み',
+  submitted: '提出済み',
   paid: '支払完了',
   rejected: '差し戻し',
 }

--- a/talentify-next-frontend/components/offer/OfferPaymentStatusCard.tsx
+++ b/talentify-next-frontend/components/offer/OfferPaymentStatusCard.tsx
@@ -38,6 +38,7 @@ export default function OfferPaymentStatusCard({
   const statusLabel = (status?: string) => {
     switch (status) {
       case 'approved':
+      case 'submitted':
         return '提出済み'
       case 'rejected':
         return '差し戻し済み'
@@ -100,7 +101,7 @@ export default function OfferPaymentStatusCard({
                   </Link>
                 </Button>
               )}
-              {!paid && invoice.status === 'approved' && (
+              {!paid && invoice.status !== 'draft' && (
                 <Button onClick={handlePay} disabled={loading}>
                   {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                   支払い完了にする


### PR DESCRIPTION
## Summary
- Map `submitted` invoice status to "提出済み" on talent and store pages
- Allow store and offer payment flows to mark invoices as paid when status is not `draft`
- Clean up talent invoice detail inputs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8f9760b1483329cb358facb21df49