### PR TITLE
feat: add bank info to talent profile

### DIFF
--- a/supabase-docs/20250904_add_bank_fields_to_talents.sql
+++ b/supabase-docs/20250904_add_bank_fields_to_talents.sql
@@ -1,0 +1,7 @@
+-- Talentsテーブルに銀行口座情報を追加
+ALTER TABLE public.talents
+ADD COLUMN bank_name TEXT,
+ADD COLUMN branch_name TEXT,
+ADD COLUMN account_type TEXT,
+ADD COLUMN account_number TEXT,
+ADD COLUMN account_holder TEXT;

--- a/supabase/migrations/20250904000000_add_bank_fields_to_talents.sql
+++ b/supabase/migrations/20250904000000_add_bank_fields_to_talents.sql
@@ -1,0 +1,7 @@
+-- Talentsテーブルに銀行口座情報を追加
+ALTER TABLE public.talents
+  ADD COLUMN bank_name TEXT,
+  ADD COLUMN branch_name TEXT,
+  ADD COLUMN account_type TEXT,
+  ADD COLUMN account_number TEXT,
+  ADD COLUMN account_holder TEXT;

--- a/talentify-next-frontend/app/api/talent/profile/route.ts
+++ b/talentify-next-frontend/app/api/talent/profile/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+export async function GET() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  }
+  const { data, error } = await supabase
+    .from('talents')
+    .select('bank_name, branch_name, account_type, account_number, account_holder')
+    .eq('user_id', user.id)
+    .single()
+  if (error || !data) {
+    return NextResponse.json({ error: error?.message || 'not found' }, { status: 404 })
+  }
+  return NextResponse.json(data)
+}
+
+export async function PATCH(req: Request) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  }
+  const body = await req.json()
+  const updates = {
+    bank_name: body.bank_name,
+    branch_name: body.branch_name,
+    account_type: body.account_type,
+    account_number: body.account_number,
+    account_holder: body.account_holder,
+  }
+  const { error } = await supabase.from('talents').update(updates).eq('user_id', user.id)
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json({ message: '更新しました' }, { status: 200 })
+}

--- a/talentify-next-frontend/app/talent/settings/page.tsx
+++ b/talentify-next-frontend/app/talent/settings/page.tsx
@@ -1,19 +1,53 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { SectionCard } from '@/components/settings/SectionCard'
 import { ToggleRow } from '@/components/settings/ToggleRow'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { toast } from 'sonner'
 
 export default function TalentSettingsPage() {
   const [saving, setSaving] = useState(false)
   const [notifications, setNotifications] = useState({ offer: false, message: false })
+  const [bankInfo, setBankInfo] = useState({
+    bank_name: '',
+    branch_name: '',
+    account_type: '',
+    account_number: '',
+    account_holder: '',
+  })
+
+  useEffect(() => {
+    const fetchProfile = async () => {
+      const res = await fetch('/api/talent/profile')
+      if (res.ok) {
+        const data = await res.json()
+        setBankInfo({
+          bank_name: data.bank_name ?? '',
+          branch_name: data.branch_name ?? '',
+          account_type: data.account_type ?? '',
+          account_number: data.account_number ?? '',
+          account_holder: data.account_holder ?? '',
+        })
+      }
+    }
+    fetchProfile()
+  }, [])
 
   const handleSave = async () => {
     setSaving(true)
-    await new Promise((r) => setTimeout(r, 500))
-    toast('（PR-1では）設定は未保存です/TODO')
+    const res = await fetch('/api/talent/profile', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(bankInfo),
+    })
+    if (res.ok) {
+      toast('保存しました')
+    } else {
+      toast('保存に失敗しました')
+    }
     setSaving(false)
   }
 
@@ -49,6 +83,51 @@ export default function TalentSettingsPage() {
             <Button variant="outline" onClick={handleTodo}>
               変更
             </Button>
+          </div>
+        </div>
+      </SectionCard>
+
+      <SectionCard title="振込先" description="銀行口座情報を設定します">
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="bank_name">銀行名</Label>
+            <Input
+              id="bank_name"
+              value={bankInfo.bank_name}
+              onChange={(e) => setBankInfo({ ...bankInfo, bank_name: e.target.value })}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="branch_name">支店名</Label>
+            <Input
+              id="branch_name"
+              value={bankInfo.branch_name}
+              onChange={(e) => setBankInfo({ ...bankInfo, branch_name: e.target.value })}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="account_type">口座種別</Label>
+            <Input
+              id="account_type"
+              value={bankInfo.account_type}
+              onChange={(e) => setBankInfo({ ...bankInfo, account_type: e.target.value })}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="account_number">口座番号</Label>
+            <Input
+              id="account_number"
+              value={bankInfo.account_number}
+              onChange={(e) => setBankInfo({ ...bankInfo, account_number: e.target.value })}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="account_holder">口座名義人</Label>
+            <Input
+              id="account_holder"
+              value={bankInfo.account_holder}
+              onChange={(e) => setBankInfo({ ...bankInfo, account_holder: e.target.value })}
+            />
           </div>
         </div>
       </SectionCard>

--- a/talentify-next-frontend/supabase-docs/schema.md
+++ b/talentify-next-frontend/supabase-docs/schema.md
@@ -217,6 +217,11 @@ status が 'completed' の場合に支払い完了とみなし、その日時を
 - social_tiktok: text
 - gender: USER-DEFINED, DEFAULT 'other'
 - bio_others: text
+- bank_name: text
+- branch_name: text
+- account_type: text
+- account_number: text
+- account_holder: text
 
 ### visits
 - id: uuid, NOT NULL, DEFAULT gen_random_uuid()

--- a/talentify-next-frontend/types/supabase.ts
+++ b/talentify-next-frontend/types/supabase.ts
@@ -122,6 +122,11 @@ export type Database = {
           bio_hobby: string | null
           bio_certifications: string | null
           bio_others: string | null
+          bank_name: string | null
+          branch_name: string | null
+          account_type: string | null
+          account_number: string | null
+          account_holder: string | null
           genre: string | null
           notes: string | null
           achievements: string | null
@@ -158,6 +163,11 @@ export type Database = {
           bio_hobby?: string | null
           bio_certifications?: string | null
           bio_others?: string | null
+          bank_name?: string | null
+          branch_name?: string | null
+          account_type?: string | null
+          account_number?: string | null
+          account_holder?: string | null
           genre?: string | null
           notes?: string | null
           achievements?: string | null
@@ -194,6 +204,11 @@ export type Database = {
           bio_hobby?: string | null
           bio_certifications?: string | null
           bio_others?: string | null
+          bank_name?: string | null
+          branch_name?: string | null
+          account_type?: string | null
+          account_number?: string | null
+          account_holder?: string | null
           genre?: string | null
           notes?: string | null
           achievements?: string | null


### PR DESCRIPTION
## Summary
- allow talents to store bank account details via new settings form
- expose GET/PATCH `/api/talent/profile` for retrieving and updating bank info
- add database columns and Supabase types/docs for bank fields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9158df5888332a4e20221e0569da1