### PR TITLE
Add invoice PDF download endpoint

### DIFF
--- a/talentify-next-frontend/app/api/invoices/[id]/pdf/route.ts
+++ b/talentify-next-frontend/app/api/invoices/[id]/pdf/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { PDFDocument, StandardFonts } from 'pdf-lib'
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const supabase = await createClient()
+  const { id } = params
+
+  try {
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser()
+    if (userError || !user) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+    }
+
+    const { data: invoice, error: invError } = await supabase
+      .from('invoices')
+      .select(
+        'id, amount, transport_fee, extra_fee, invoice_number, due_date, created_at, store_id, talent_id, talents:talent_id(bank_name, branch_name, account_type, account_number, account_holder)'
+      )
+      .eq('id', id)
+      .single()
+    if (invError || !invoice) {
+      return NextResponse.json({ error: 'invoice_not_found' }, { status: 404 })
+    }
+
+    const { data: store } = await supabase
+      .from('stores')
+      .select('id')
+      .eq('user_id', user.id)
+      .maybeSingle()
+    const { data: talent } = await supabase
+      .from('talents')
+      .select('id')
+      .eq('user_id', user.id)
+      .maybeSingle()
+
+    const authorized =
+      (store && store.id === invoice.store_id) ||
+      (talent && talent.id === invoice.talent_id)
+    if (!authorized) {
+      return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+    }
+
+    const pdfDoc = await PDFDocument.create()
+    const page = pdfDoc.addPage()
+    const { height } = page.getSize()
+    const font = await pdfDoc.embedFont(StandardFonts.Helvetica)
+    const fontSize = 12
+    const lineHeight = 20
+    let y = height - 50
+    const drawLine = (text: string) => {
+      page.drawText(text, { x: 50, y, size: fontSize, font })
+      y -= lineHeight
+    }
+    const blank = () => {
+      y -= lineHeight
+    }
+    const toYen = (n: number) => `¥${n.toLocaleString('ja-JP')}`
+    const formatDate = (d: string | null) =>
+      d ? new Date(d).toLocaleDateString('ja-JP') : ''
+
+    drawLine(`請求日: ${formatDate(invoice.created_at)}`)
+    drawLine(`請求書番号: ${invoice.invoice_number ?? ''}`)
+    drawLine(`支払期限: ${formatDate(invoice.due_date)}`)
+    blank()
+    const baseFee =
+      invoice.amount - (invoice.transport_fee ?? 0) - (invoice.extra_fee ?? 0)
+    drawLine(`基本報酬: ${toYen(baseFee)}`)
+    drawLine(`交通費: ${toYen(invoice.transport_fee ?? 0)}`)
+    drawLine(`追加料金: ${toYen(invoice.extra_fee ?? 0)}`)
+    drawLine(`合計金額: ${toYen(invoice.amount)}`)
+    blank()
+    drawLine('振込先情報:')
+    drawLine(`銀行名: ${invoice.talents?.bank_name ?? ''}`)
+    drawLine(`支店名: ${invoice.talents?.branch_name ?? ''}`)
+    drawLine(`口座種別: ${invoice.talents?.account_type ?? ''}`)
+    drawLine(`口座番号: ${invoice.talents?.account_number ?? ''}`)
+    drawLine(`口座名義: ${invoice.talents?.account_holder ?? ''}`)
+
+    const pdfBytes = await pdfDoc.save()
+
+    return new NextResponse(pdfBytes, {
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': `attachment; filename=invoice-${id}.pdf`,
+      },
+    })
+  } catch (e) {
+    console.error('[GET /invoices/:id/pdf]', e)
+    return new NextResponse('Internal Server Error', { status: 500 })
+  }
+}
+

--- a/talentify-next-frontend/app/store/invoices/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/invoices/[id]/page.tsx
@@ -67,6 +67,7 @@ export default function StoreInvoiceDetail() {
   const [invoice, setInvoice] = useState<Invoice | null>(null)
   const [loading, setLoading] = useState(true)
   const [paying, setPaying] = useState(false)
+  const [downloading, setDownloading] = useState(false)
 
   const load = async () => {
     const { data } = await supabase
@@ -105,6 +106,25 @@ export default function StoreInvoiceDetail() {
       }
     } else {
       toast.error('支払いの記録に失敗しました')
+    }
+  }
+
+  const handleDownload = async () => {
+    setDownloading(true)
+    const res = await fetch(`/api/invoices/${id}/pdf`)
+    setDownloading(false)
+    if (res.ok) {
+      const blob = await res.blob()
+      const url = window.URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `invoice-${id}.pdf`
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+      window.URL.revokeObjectURL(url)
+    } else {
+      toast.error('PDFのダウンロードに失敗しました')
     }
   }
 
@@ -193,6 +213,11 @@ export default function StoreInvoiceDetail() {
           )}
         </CardContent>
       </Card>
+
+      <Button onClick={handleDownload} disabled={downloading}>
+        {downloading && <Loader2 className='mr-2 h-4 w-4 animate-spin' />}
+        請求書をダウンロード
+      </Button>
 
       {!invoice.offers?.paid && invoice.status !== 'draft' && (
         <Button onClick={handlePay} disabled={paying}>

--- a/talentify-next-frontend/package-lock.json
+++ b/talentify-next-frontend/package-lock.json
@@ -25,6 +25,7 @@
         "jspdf": "^2.5.1",
         "lucide-react": "^0.525.0",
         "next": "^13.5.11",
+        "pdf-lib": "^1.17.1",
         "react": "^18.3.1",
         "react-big-calendar": "^1.19.4",
         "react-dom": "^18.3.1",
@@ -1622,6 +1623,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -8995,6 +9014,12 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -9077,6 +9102,24 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/performance-now": {
       "version": "2.1.0",

--- a/talentify-next-frontend/package.json
+++ b/talentify-next-frontend/package.json
@@ -27,6 +27,7 @@
     "jspdf": "^2.5.1",
     "lucide-react": "^0.525.0",
     "next": "^13.5.11",
+    "pdf-lib": "^1.17.1",
     "react": "^18.3.1",
     "react-big-calendar": "^1.19.4",
     "react-dom": "^18.3.1",


### PR DESCRIPTION
## Summary
- add API route to generate invoice PDF with bank details
- enable store invoice page to download generated PDF
- include pdf-lib dependency for server-side PDF creation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b91f982d3c8332b62a01a7171f097a