### PR TITLE
Refactor offer detail pages with progress tracker layout

### DIFF
--- a/talentify-next-frontend/components/offer/OfferProgressTracker.tsx
+++ b/talentify-next-frontend/components/offer/OfferProgressTracker.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { Check } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { OfferProgressStep } from '@/utils/offerProgress'
+
+interface OfferProgressTrackerProps {
+  steps: OfferProgressStep[]
+}
+
+const stepStatusStyles: Record<OfferProgressStep['status'], string> = {
+  complete: 'bg-primary text-primary-foreground border-primary',
+  current: 'border-2 border-primary text-primary',
+  upcoming: 'border border-border text-muted-foreground',
+}
+
+export default function OfferProgressTracker({ steps }: OfferProgressTrackerProps) {
+  return (
+    <div className="space-y-6">
+      <div className="hidden md:flex md:flex-col md:gap-4">
+        <div className="flex items-start">
+          {steps.map((step, index) => {
+            const isLast = index === steps.length - 1
+            const circleClass = stepStatusStyles[step.status]
+            const lineActive = step.status === 'complete'
+            return (
+              <div key={step.key} className="flex flex-1 items-center">
+                <div className="flex flex-col items-center gap-2">
+                  <div
+                    className={cn(
+                      'flex h-10 w-10 items-center justify-center rounded-full bg-background text-sm font-medium',
+                      circleClass,
+                    )}
+                  >
+                    {step.status === 'complete' ? (
+                      <Check className="h-5 w-5" />
+                    ) : (
+                      <span>{index + 1}</span>
+                    )}
+                  </div>
+                  <span className="text-sm font-medium text-foreground">{step.title}</span>
+                </div>
+                {!isLast && (
+                  <div
+                    className={cn(
+                      'mx-4 h-[2px] flex-1 rounded-full bg-border transition-colors',
+                      lineActive && 'bg-primary',
+                    )}
+                    aria-hidden
+                  />
+                )}
+              </div>
+            )
+          })}
+        </div>
+      </div>
+
+      <ol className="flex flex-col gap-4 md:hidden">
+        {steps.map((step, index) => {
+          const circleClass = stepStatusStyles[step.status]
+          return (
+            <li key={step.key} className="flex items-start gap-3">
+              <div
+                className={cn(
+                  'mt-1 flex h-8 w-8 items-center justify-center rounded-full bg-background text-sm font-medium',
+                  circleClass,
+                )}
+              >
+                {step.status === 'complete' ? <Check className="h-4 w-4" /> : <span>{index + 1}</span>}
+              </div>
+              <div className="flex flex-col">
+                <span className="text-sm font-medium text-foreground">{step.title}</span>
+                <span className="text-xs text-muted-foreground">
+                  {step.status === 'complete'
+                    ? '完了'
+                    : step.status === 'current'
+                      ? '進行中'
+                      : '未完了'}
+                </span>
+              </div>
+            </li>
+          )
+        })}
+      </ol>
+    </div>
+  )
+}

--- a/talentify-next-frontend/utils/offerProgress.ts
+++ b/talentify-next-frontend/utils/offerProgress.ts
@@ -1,0 +1,83 @@
+export type OfferStepKey =
+  | 'offer_submitted'
+  | 'approval'
+  | 'visit'
+  | 'invoice'
+  | 'payment'
+  | 'review'
+
+export type OfferProgressStatus = 'complete' | 'current' | 'upcoming'
+
+export interface OfferProgressStep {
+  key: OfferStepKey
+  title: string
+  status: OfferProgressStatus
+}
+
+export const OFFER_STEP_LABELS: Record<OfferStepKey, string> = {
+  offer_submitted: 'オファー提出',
+  approval: '承認',
+  visit: '来店実施',
+  invoice: '請求',
+  payment: '支払い',
+  review: 'レビュー',
+}
+
+interface ProgressParams {
+  status: string
+  invoiceStatus: 'not_submitted' | 'submitted' | 'paid'
+  paid: boolean
+  reviewCompleted?: boolean
+}
+
+export function getOfferProgress({
+  status,
+  invoiceStatus,
+  paid,
+  reviewCompleted = false,
+}: ProgressParams): { steps: OfferProgressStep[]; current: OfferStepKey } {
+  const order: OfferStepKey[] = [
+    'offer_submitted',
+    'approval',
+    'visit',
+    'invoice',
+    'payment',
+    'review',
+  ]
+
+  const completed = new Set<OfferStepKey>(['offer_submitted'])
+
+  if (['accepted', 'confirmed', 'completed'].includes(status)) {
+    completed.add('approval')
+  }
+
+  if (status === 'completed') {
+    completed.add('visit')
+  }
+
+  if (invoiceStatus !== 'not_submitted' || paid) {
+    completed.add('invoice')
+  }
+
+  if (paid || invoiceStatus === 'paid') {
+    completed.add('payment')
+  }
+
+  if (reviewCompleted) {
+    completed.add('review')
+  }
+
+  const current = order.find(step => !completed.has(step)) ?? 'review'
+
+  const steps: OfferProgressStep[] = order.map(step => ({
+    key: step,
+    title: OFFER_STEP_LABELS[step],
+    status: completed.has(step)
+      ? 'complete'
+      : step === current
+        ? 'current'
+        : 'upcoming',
+  }))
+
+  return { steps, current }
+}


### PR DESCRIPTION
## Summary
- add a reusable progress tracker component and utility to determine offer step state
- refactor the store and talent offer detail pages to adopt the new tracker layout and chat sidebar
- surface step-specific metadata and actions in the detail panels while keeping existing behaviours intact

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2212a88a08332aa456bcaf18dc35f