### PR TITLE
Improve offer detail layout and chat styling

### DIFF
--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -273,90 +273,94 @@ export default async function StoreOfferPage({ params }: PageProps) {
   const detail = buildStepDetail(current)
 
   return (
-    <div className="flex h-full flex-col gap-6 p-4 lg:flex-row">
-      <div className="flex flex-1 flex-col gap-6">
-        <Card>
-          <CardHeader className="space-y-1">
-            <CardTitle>進捗状況</CardTitle>
-            <p className="text-sm text-muted-foreground">オファーの進行状況と各ステップの対応内容を確認できます。</p>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            <OfferProgressTracker steps={steps} />
-            <div className="rounded-lg border bg-background p-5 shadow-sm">
-              <div className="flex flex-wrap items-center gap-2">
-                <h3 className="text-base font-semibold text-foreground">{detail.title}</h3>
-                {detail.badge}
+    <div className="p-4 sm:p-6 lg:p-8">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 lg:grid lg:grid-cols-[minmax(0,1.75fr)_minmax(0,1fr)] lg:items-start lg:gap-8">
+        <div className="flex flex-col gap-6">
+          <Card className="shadow-sm">
+            <CardHeader className="space-y-2">
+              <CardTitle>進捗状況</CardTitle>
+              <p className="text-sm text-muted-foreground">オファーの進行状況と各ステップの対応内容を確認できます。</p>
+            </CardHeader>
+            <CardContent className="space-y-8">
+              <div className="mx-auto w-full max-w-3xl">
+                <OfferProgressTracker steps={steps} />
               </div>
-              <p className="mt-3 text-sm text-muted-foreground">{detail.description}</p>
-              {detail.meta && detail.meta.length > 0 && (
-                <dl className="mt-4 grid gap-4 sm:grid-cols-2">
-                  {detail.meta.map(item => (
-                    <div key={item.label} className="space-y-1">
-                      <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                        {item.label}
-                      </dt>
-                      <dd className="text-sm font-semibold text-foreground">{item.value}</dd>
-                    </div>
-                  ))}
-                </dl>
-              )}
-              {detail.actions && detail.actions.length > 0 && (
-                <div className="mt-4 flex flex-wrap gap-2">
-                  {detail.actions.map((action, index) => (
-                    <div key={index} className="inline-flex">{action}</div>
-                  ))}
+              <div className="rounded-2xl border bg-card p-6 shadow-md">
+                <div className="flex flex-wrap items-center gap-2">
+                  <h3 className="text-base font-semibold text-foreground">{detail.title}</h3>
+                  {detail.badge}
                 </div>
-              )}
-              {detail.note && <div className="mt-4 text-sm text-muted-foreground">{detail.note}</div>}
-            </div>
-          </CardContent>
-        </Card>
+                <p className="mt-3 text-sm leading-relaxed text-muted-foreground">{detail.description}</p>
+                {detail.meta && detail.meta.length > 0 && (
+                  <dl className="mt-4 grid gap-4 sm:grid-cols-2">
+                    {detail.meta.map(item => (
+                      <div key={item.label} className="space-y-1">
+                        <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                          {item.label}
+                        </dt>
+                        <dd className="text-sm font-semibold text-foreground">{item.value}</dd>
+                      </div>
+                    ))}
+                  </dl>
+                )}
+                {detail.actions && detail.actions.length > 0 && (
+                  <div className="mt-6 flex flex-wrap justify-end gap-2">
+                    {detail.actions.map((action, index) => (
+                      <div key={index} className="inline-flex">{action}</div>
+                    ))}
+                  </div>
+                )}
+                {detail.note && <div className="mt-4 text-sm text-muted-foreground">{detail.note}</div>}
+              </div>
+            </CardContent>
+          </Card>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>オファー詳細</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <OfferSummary
-              performerName={offer.performerName}
-              performerAvatarUrl={offer.performerAvatarUrl}
-              storeName={offer.storeName}
-              date={offer.date}
-              message={offer.message}
-              invoiceStatus={offer.invoiceStatus}
-            />
-            <CancelOfferSection
+          <Card className="shadow-sm">
+            <CardHeader>
+              <CardTitle>オファー詳細</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <OfferSummary
+                performerName={offer.performerName}
+                performerAvatarUrl={offer.performerAvatarUrl}
+                storeName={offer.storeName}
+                date={offer.date}
+                message={offer.message}
+                invoiceStatus={offer.invoiceStatus}
+              />
+              <CancelOfferSection
+                offerId={offer.id}
+                initialStatus={data.status}
+                initialCanceledAt={data.canceled_at}
+              />
+            </CardContent>
+          </Card>
+
+          {invoiceData && (
+            <OfferPaymentStatusCard
+              title="請求"
               offerId={offer.id}
-              initialStatus={data.status}
-              initialCanceledAt={data.canceled_at}
+              paid={offer.paid}
+              paidAt={offer.paidAt}
+              invoice={invoiceData}
             />
-          </CardContent>
-        </Card>
-
-        {invoiceData && (
-          <OfferPaymentStatusCard
-            title="請求"
-            offerId={offer.id}
-            paid={offer.paid}
-            paidAt={offer.paidAt}
-            invoice={invoiceData}
-          />
-        )}
-      </div>
-
-      <div className="flex w-full flex-col gap-4 lg:max-w-md xl:max-w-lg">
-        <div>
-          <h2 className="text-base font-semibold text-foreground">メッセージ</h2>
-          <p className="text-sm text-muted-foreground">オファーに関する連絡は右のチャットから行えます。</p>
+          )}
         </div>
-        <div id="chat" className="flex-1 min-h-[520px]">
-          <OfferChatThread
-            offerId={offer.id}
-            currentUserId={user.id}
-            currentRole="store"
-            paymentLink={paymentLink}
-          />
-        </div>
+
+        <aside className="flex h-full flex-col gap-4 rounded-2xl border bg-card p-6 shadow-md" id="chat">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold text-foreground">メッセージ</h2>
+            <p className="text-sm text-muted-foreground">オファーに関する連絡はチャットから行えます。</p>
+          </div>
+          <div className="flex-1 min-h-[520px]">
+            <OfferChatThread
+              offerId={offer.id}
+              currentUserId={user.id}
+              currentRole="store"
+              paymentLink={paymentLink}
+            />
+          </div>
+        </aside>
       </div>
     </div>
   )

--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -326,97 +326,101 @@ export default function TalentOfferPage() {
   const detail = buildStepDetail(current)
 
   return (
-    <div className="flex h-full flex-col gap-6 p-4 lg:flex-row">
-      <div className="flex flex-1 flex-col gap-6">
-        <Card>
-          <CardHeader className="space-y-1">
-            <CardTitle>進捗状況</CardTitle>
-            <p className="text-sm text-muted-foreground">オファーの進行状況と次に行うアクションを確認できます。</p>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            <OfferProgressTracker steps={steps} />
-            <div className="rounded-lg border bg-background p-5 shadow-sm">
-              <div className="flex flex-wrap items-center gap-2">
-                <h3 className="text-base font-semibold text-foreground">{detail.title}</h3>
-                {detail.badge}
+    <div className="p-4 sm:p-6 lg:p-8">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 lg:grid lg:grid-cols-[minmax(0,1.75fr)_minmax(0,1fr)] lg:items-start lg:gap-8">
+        <div className="flex flex-col gap-6">
+          <Card className="shadow-sm">
+            <CardHeader className="space-y-2">
+              <CardTitle>進捗状況</CardTitle>
+              <p className="text-sm text-muted-foreground">オファーの進行状況と次に行うアクションを確認できます。</p>
+            </CardHeader>
+            <CardContent className="space-y-8">
+              <div className="mx-auto w-full max-w-3xl">
+                <OfferProgressTracker steps={steps} />
               </div>
-              <p className="mt-3 text-sm text-muted-foreground">{detail.description}</p>
-              {detail.meta && detail.meta.length > 0 && (
-                <dl className="mt-4 grid gap-4 sm:grid-cols-2">
-                  {detail.meta.map(item => (
-                    <div key={item.label} className="space-y-1">
-                      <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                        {item.label}
-                      </dt>
-                      <dd className="text-sm font-semibold text-foreground">{item.value}</dd>
-                    </div>
-                  ))}
-                </dl>
-              )}
-              {detail.actions && detail.actions.length > 0 && (
-                <div className="mt-4 flex flex-wrap gap-2">
-                  {detail.actions.map((action, index) => (
-                    <div key={index} className="inline-flex">{action}</div>
-                  ))}
+              <div className="rounded-2xl border bg-card p-6 shadow-md">
+                <div className="flex flex-wrap items-center gap-2">
+                  <h3 className="text-base font-semibold text-foreground">{detail.title}</h3>
+                  {detail.badge}
+                </div>
+                <p className="mt-3 text-sm leading-relaxed text-muted-foreground">{detail.description}</p>
+                {detail.meta && detail.meta.length > 0 && (
+                  <dl className="mt-4 grid gap-4 sm:grid-cols-2">
+                    {detail.meta.map(item => (
+                      <div key={item.label} className="space-y-1">
+                        <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                          {item.label}
+                        </dt>
+                        <dd className="text-sm font-semibold text-foreground">{item.value}</dd>
+                      </div>
+                    ))}
+                  </dl>
+                )}
+                {detail.actions && detail.actions.length > 0 && (
+                  <div className="mt-6 flex flex-wrap justify-end gap-2">
+                    {detail.actions.map((action, index) => (
+                      <div key={index} className="inline-flex">{action}</div>
+                    ))}
+                  </div>
+                )}
+                {detail.note && <div className="mt-4 text-sm text-muted-foreground">{detail.note}</div>}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="shadow-sm">
+            <CardHeader>
+              <CardTitle>オファー詳細</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <OfferSummary
+                performerName={offer.performerName}
+                performerAvatarUrl={offer.performerAvatarUrl}
+                storeName={offer.storeName}
+                date={offer.date}
+                message={offer.message}
+                invoiceStatus={offer.invoiceStatus}
+              />
+              {offer.status === 'pending' && (
+                <div className="flex flex-wrap justify-end gap-2">
+                  <Button
+                    variant="default"
+                    size="sm"
+                    onClick={handleAccept}
+                    disabled={actionLoading !== null}
+                  >
+                    {actionLoading === 'accept' ? '承諾中...' : '承諾'}
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleDecline}
+                    disabled={actionLoading !== null}
+                  >
+                    {actionLoading === 'decline' ? '辞退中...' : '辞退'}
+                  </Button>
                 </div>
               )}
-              {detail.note && <div className="mt-4 text-sm text-muted-foreground">{detail.note}</div>}
-            </div>
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>オファー詳細</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <OfferSummary
-              performerName={offer.performerName}
-              performerAvatarUrl={offer.performerAvatarUrl}
-              storeName={offer.storeName}
-              date={offer.date}
-              message={offer.message}
-              invoiceStatus={offer.invoiceStatus}
+          <OfferPaymentStatusCard paid={offer.paid} paidAt={offer.paidAt} />
+        </div>
+
+        <aside className="flex h-full flex-col gap-4 rounded-2xl border bg-card p-6 shadow-md" id="chat">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold text-foreground">メッセージ</h2>
+            <p className="text-sm text-muted-foreground">店舗との連絡はチャットをご利用ください。</p>
+          </div>
+          <div className="flex-1 min-h-[520px]">
+            <OfferChatThread
+              offerId={offer.id}
+              currentUserId={userId}
+              currentRole="talent"
+              paymentLink={paymentLink}
             />
-            {offer.status === 'pending' && (
-              <div className="flex flex-wrap gap-2">
-                <Button
-                  variant="default"
-                  size="sm"
-                  onClick={handleAccept}
-                  disabled={actionLoading !== null}
-                >
-                  {actionLoading === 'accept' ? '承諾中...' : '承諾'}
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={handleDecline}
-                  disabled={actionLoading !== null}
-                >
-                  {actionLoading === 'decline' ? '辞退中...' : '辞退'}
-                </Button>
-              </div>
-            )}
-          </CardContent>
-        </Card>
-
-        <OfferPaymentStatusCard paid={offer.paid} paidAt={offer.paidAt} />
-      </div>
-
-      <div className="flex w-full flex-col gap-4 lg:max-w-md xl:max-w-lg">
-        <div>
-          <h2 className="text-base font-semibold text-foreground">メッセージ</h2>
-          <p className="text-sm text-muted-foreground">店舗との連絡はチャットを利用してください。</p>
-        </div>
-        <div id="chat" className="flex-1 min-h-[520px]">
-          <OfferChatThread
-            offerId={offer.id}
-            currentUserId={userId}
-            currentRole="talent"
-            paymentLink={paymentLink}
-          />
-        </div>
+          </div>
+        </aside>
       </div>
     </div>
   )

--- a/talentify-next-frontend/components/offer/ChatMessageBubble.tsx
+++ b/talentify-next-frontend/components/offer/ChatMessageBubble.tsx
@@ -22,10 +22,10 @@ export default function ChatMessageBubble({
   const read = isMine && peerLastReadAt && new Date(peerLastReadAt) >= new Date(message.created_at)
 
   return (
-    <div className={clsx('flex mb-2', isMine ? 'justify-end' : 'justify-start')}> 
+    <div className={clsx('mb-3 flex', isMine ? 'justify-end' : 'justify-start')}>
       <div
         className={clsx(
-          'rounded px-3 py-2 max-w-[80%] shadow',
+          'max-w-[80%] rounded-2xl px-4 py-3 text-sm shadow-md',
           isMine ? 'bg-primary text-primary-foreground' : 'bg-muted'
         )}
       >
@@ -55,7 +55,7 @@ export default function ChatMessageBubble({
             </a>
           )
         })}
-        <div className={clsx('text-xs mt-1', isMine ? 'text-right' : 'text-left')}>
+        <div className={clsx('mt-2 text-[11px] uppercase tracking-wide', isMine ? 'text-right' : 'text-left')}>
           {time} {read && '✓'}
         </div>
       </div>

--- a/talentify-next-frontend/components/offer/OfferChatInput.tsx
+++ b/talentify-next-frontend/components/offer/OfferChatInput.tsx
@@ -42,7 +42,7 @@ export default function OfferChatInput({ offerId, senderRole, onSent }: OfferCha
   }
 
   return (
-    <div className="border-t p-2 space-y-2">
+    <div className="space-y-3">
       <Textarea
         value={body}
         onChange={e => setBody(e.target.value)}
@@ -50,7 +50,7 @@ export default function OfferChatInput({ offerId, senderRole, onSent }: OfferCha
         placeholder="メッセージを入力"
         rows={1}
       />
-      <div className="flex justify-end">
+      <div className="flex justify-end gap-2">
         <Button onClick={handleSend} disabled={sending}>
           送信
         </Button>

--- a/talentify-next-frontend/components/offer/OfferChatThread.tsx
+++ b/talentify-next-frontend/components/offer/OfferChatThread.tsx
@@ -99,16 +99,16 @@ export default function OfferChatThread({
   }
 
   return (
-    <div className="flex flex-col h-full border rounded">
+    <div className="flex h-full min-h-[520px] flex-col overflow-hidden rounded-xl border bg-card shadow-sm">
       <div
         ref={containerRef}
         onScroll={handleScroll}
-        className="flex-1 overflow-y-auto p-2"
+        className="flex-1 overflow-y-auto p-4"
         aria-live="polite"
       >
         {loading && <p>Loading...</p>}
         {!loading && messages.length === 0 && (
-          <p className="text-sm text-center text-muted-foreground">
+          <p className="text-center text-sm leading-relaxed text-muted-foreground">
             このオファーに関する連絡はまだありません。下の入力欄からメッセージを送信しましょう。
           </p>
         )}
@@ -121,9 +121,11 @@ export default function OfferChatThread({
           />
         ))}
       </div>
-      <OfferChatInput offerId={offerId} senderRole={currentRole} onSent={handleSent} />
+      <div className="border-t bg-background p-4">
+        <OfferChatInput offerId={offerId} senderRole={currentRole} onSent={handleSent} />
+      </div>
       {paymentLink && (
-        <div className="border-t p-2 flex flex-wrap gap-2 justify-end">
+        <div className="flex flex-wrap justify-end gap-2 border-t bg-muted/40 p-4">
           <Button variant="default" size="sm" asChild>
             <Link href={paymentLink}>支払い状況</Link>
           </Button>


### PR DESCRIPTION
## Summary
- adjust the store and talent offer detail pages to use a responsive two-column layout with a highlighted step detail card
- refresh the chat sidebar container to match the new layout and keep actions aligned
- update chat bubbles and input spacing for better readability

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2286620348332bfd253143483d138