### PR TITLE
Revamp offer chat sidebar layout

### DIFF
--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -137,19 +137,14 @@ export default async function StoreOfferPage({ params }: PageProps) {
           )}
         </div>
 
-        <aside className="flex h-full flex-col gap-4 rounded-2xl border bg-card p-6 shadow-md" id="chat">
-          <div className="space-y-1">
-            <h2 className="text-lg font-semibold text-foreground">メッセージ</h2>
-            <p className="text-sm text-muted-foreground">オファーに関する連絡はチャットから行えます。</p>
-          </div>
-          <div className="flex-1 min-h-[520px]">
-            <OfferChatThread
-              offerId={offer.id}
-              currentUserId={user.id}
-              currentRole="store"
-              paymentLink={paymentLink}
-            />
-          </div>
+        <aside className="flex h-full flex-col" id="chat">
+          <OfferChatThread
+            offerId={offer.id}
+            currentUserId={user.id}
+            currentRole="store"
+            storeName={offer.storeName}
+            talentName={offer.performerName}
+          />
         </aside>
       </div>
     </div>

--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -524,19 +524,14 @@ export default function TalentOfferPage() {
           <OfferPaymentStatusCard paid={offer.paid} paidAt={offer.paidAt} />
         </div>
 
-        <aside className="flex h-full flex-col gap-4 rounded-2xl border bg-card p-6 shadow-md" id="chat">
-          <div className="space-y-1">
-            <h2 className="text-lg font-semibold text-foreground">メッセージ</h2>
-            <p className="text-sm text-muted-foreground">店舗との連絡はチャットをご利用ください。</p>
-          </div>
-          <div className="flex-1 min-h-[520px]">
-            <OfferChatThread
-              offerId={offer.id}
-              currentUserId={userId}
-              currentRole="talent"
-              paymentLink={paymentLink}
-            />
-          </div>
+        <aside className="flex h-full flex-col" id="chat">
+          <OfferChatThread
+            offerId={offer.id}
+            currentUserId={userId}
+            currentRole="talent"
+            storeName={offer.storeName}
+            talentName={offer.performerName}
+          />
         </aside>
       </div>
     </div>

--- a/talentify-next-frontend/components/offer/ChatMessageBubble.tsx
+++ b/talentify-next-frontend/components/offer/ChatMessageBubble.tsx
@@ -9,27 +9,37 @@ interface ChatMessageBubbleProps {
   message: OfferMessage
   currentUserId: string
   peerLastReadAt?: string | null
+  senderName: string
 }
 
 export default function ChatMessageBubble({
   message,
   currentUserId,
   peerLastReadAt,
+  senderName,
 }: ChatMessageBubbleProps) {
   const isMine = message.sender_user === currentUserId
   const supabase = createClient()
-  const time = format(new Date(message.created_at), 'HH:mm')
+  const time = format(new Date(message.created_at), 'yyyy/MM/dd HH:mm')
   const read = isMine && peerLastReadAt && new Date(peerLastReadAt) >= new Date(message.created_at)
 
   return (
     <div className={clsx('mb-3 flex', isMine ? 'justify-end' : 'justify-start')}>
       <div
         className={clsx(
-          'max-w-[80%] rounded-2xl px-4 py-3 text-sm shadow-md',
-          isMine ? 'bg-primary text-primary-foreground' : 'bg-muted'
+          'max-w-[80%] rounded-3xl px-5 py-4 text-sm shadow-md',
+          isMine ? 'bg-blue-600 text-white' : 'bg-slate-100 text-slate-900'
         )}
       >
-        {message.body && <p className="whitespace-pre-wrap break-words">{message.body}</p>}
+        <div className="space-y-1">
+          <p className={clsx('text-sm font-semibold', isMine ? 'text-white' : 'text-slate-900')}>{senderName}</p>
+          <p className={clsx('text-xs', isMine ? 'text-white/80' : 'text-slate-500')}>{time}</p>
+        </div>
+        {message.body && (
+          <p className={clsx('mt-3 whitespace-pre-wrap break-words text-sm', isMine ? 'text-white' : 'text-slate-900')}>
+            {message.body}
+          </p>
+        )}
         {message.attachments?.map(att => {
           const { data } = supabase.storage.from('offer-attachments').getPublicUrl(att.path)
           const url = data.publicUrl
@@ -39,7 +49,7 @@ export default function ChatMessageBubble({
                 key={att.path}
                 src={url}
                 alt={att.name}
-                className="mt-2 max-w-full rounded"
+                className="mt-3 max-w-full rounded-md"
               />
             )
           }
@@ -49,15 +59,18 @@ export default function ChatMessageBubble({
               href={url}
               target="_blank"
               rel="noreferrer"
-              className="block mt-2 underline"
+              className={clsx(
+                'mt-3 block text-sm underline',
+                isMine ? 'text-white' : 'text-blue-600'
+              )}
             >
               {att.name} ({Math.round(att.size / 1024)}KB)
             </a>
           )
         })}
-        <div className={clsx('mt-2 text-[11px] uppercase tracking-wide', isMine ? 'text-right' : 'text-left')}>
-          {time} {read && '✓'}
-        </div>
+        {isMine && read && (
+          <div className="mt-3 text-right text-[11px] text-white/80">既読</div>
+        )}
       </div>
     </div>
   )

--- a/talentify-next-frontend/components/offer/OfferChatInput.tsx
+++ b/talentify-next-frontend/components/offer/OfferChatInput.tsx
@@ -18,7 +18,7 @@ export default function OfferChatInput({ offerId, senderRole, onSent }: OfferCha
   const supabase = createClient()
 
   const handleSend = async () => {
-    if (!body) return
+    if (!body.trim()) return
     setSending(true)
     try {
       const message = await sendOfferMessage(supabase, {
@@ -47,11 +47,17 @@ export default function OfferChatInput({ offerId, senderRole, onSent }: OfferCha
         value={body}
         onChange={e => setBody(e.target.value)}
         onKeyDown={onKeyDown}
-        placeholder="メッセージを入力"
-        rows={1}
+        placeholder="メッセージを入力..."
+        rows={3}
+        className="min-h-[96px] resize-none rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-inner"
       />
-      <div className="flex justify-end gap-2">
-        <Button onClick={handleSend} disabled={sending}>
+      <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-slate-500">
+        <p>Enter + Shift で改行、Enter で送信</p>
+        <Button
+          onClick={handleSend}
+          disabled={sending || !body.trim()}
+          className="rounded-full bg-slate-800 px-6 text-white hover:bg-slate-700"
+        >
           送信
         </Button>
       </div>

--- a/talentify-next-frontend/components/offer/OfferChatThread.tsx
+++ b/talentify-next-frontend/components/offer/OfferChatThread.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
-import Link from 'next/link'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { createClient } from '@/utils/supabase/client'
 import type { OfferMessage } from '@/lib/supabase/offerMessages'
 import {
@@ -12,24 +11,31 @@ import {
 } from '@/lib/supabase/offerMessages'
 import ChatMessageBubble from './ChatMessageBubble'
 import OfferChatInput from './OfferChatInput'
-import { Button } from '@/components/ui/button'
+import { format } from 'date-fns'
+import { MessageCircle } from 'lucide-react'
 
 interface OfferChatThreadProps {
   offerId: string
   currentUserId: string
   currentRole: 'store' | 'talent' | 'admin'
-  paymentLink?: string
+  storeName: string
+  talentName: string
+  adminName?: string
 }
 export default function OfferChatThread({
   offerId,
   currentUserId,
   currentRole,
-  paymentLink,
+  storeName,
+  talentName,
+  adminName = 'サポート',
 }: OfferChatThreadProps) {
   const supabase = createClient()
   const [messages, setMessages] = useState<OfferMessage[]>([])
   const [loading, setLoading] = useState(true)
   const [peerLastReadAt, setPeerLastReadAt] = useState<string | null>(null)
+  const [unreadCount, setUnreadCount] = useState(0)
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<string | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const oldestRef = useRef<string | null>(null)
   const hasMoreRef = useRef(true)
@@ -39,21 +45,45 @@ export default function OfferChatThread({
     if (el) el.scrollTop = el.scrollHeight
   }
 
-  const updatePeerRead = async () => {
+  const updateReadReceipts = useCallback(async () => {
     const receipts = await getReadReceipts(supabase, offerId)
     const other = receipts.find(r => r.user_id !== currentUserId)
     setPeerLastReadAt(other?.last_read_at ?? null)
-  }
+  }, [currentUserId, offerId, supabase])
 
-  const loadInitial = async () => {
+  const markConversationAsRead = useCallback(async () => {
+    await upsertReadReceipt(supabase, offerId)
+    setUnreadCount(0)
+    await updateReadReceipts()
+  }, [offerId, supabase, updateReadReceipts])
+
+  const loadInitial = useCallback(async () => {
     const { data } = await listOfferMessages(supabase, offerId, { limit: 50 })
-    setMessages(data.reverse())
-    if (data.length > 0) oldestRef.current = data[data.length - 1].created_at
+    const ordered = data.slice().reverse()
+    setMessages(ordered)
+    hasMoreRef.current = true
+    if (ordered.length > 0) {
+      oldestRef.current = ordered[0].created_at
+      setLastUpdatedAt(ordered[ordered.length - 1].created_at)
+    } else {
+      oldestRef.current = null
+      setLastUpdatedAt(null)
+    }
     setLoading(false)
     scrollToBottom()
-    await upsertReadReceipt(supabase, offerId)
-    updatePeerRead()
-  }
+    const receipts = await getReadReceipts(supabase, offerId)
+    const other = receipts.find(r => r.user_id !== currentUserId)
+    const self = receipts.find(r => r.user_id === currentUserId)
+    setPeerLastReadAt(other?.last_read_at ?? null)
+    const lastRead = self?.last_read_at ?? null
+    const unread = ordered.filter(m => {
+      if (m.sender_user === currentUserId) return false
+      if (!lastRead) return true
+      return new Date(m.created_at) > new Date(lastRead)
+    }).length
+    setUnreadCount(unread)
+    await markConversationAsRead()
+  }, [currentUserId, markConversationAsRead, offerId, supabase])
 
   const loadMore = async () => {
     if (!hasMoreRef.current || !oldestRef.current) return
@@ -77,60 +107,106 @@ export default function OfferChatThread({
   }
 
   useEffect(() => {
-    loadInitial()
+    void loadInitial()
     const channel = subscribeOfferMessages(supabase, offerId, msg => {
       if (msg.sender_user === currentUserId) return
       setMessages(prev => [...prev, msg])
       scrollToBottom()
-      updatePeerRead()
+      setLastUpdatedAt(msg.created_at)
+      if (document.hasFocus()) {
+        void markConversationAsRead()
+      } else {
+        setUnreadCount(prev => prev + 1)
+        void updateReadReceipts()
+      }
     })
-    const onFocus = () => upsertReadReceipt(supabase, offerId)
+    const onFocus = () => {
+      void markConversationAsRead()
+    }
     window.addEventListener('focus', onFocus)
     return () => {
       channel.unsubscribe()
       window.removeEventListener('focus', onFocus)
     }
-  }, [offerId])
+  }, [currentUserId, loadInitial, markConversationAsRead, offerId, supabase, updateReadReceipts])
 
   const handleSent = (msg: OfferMessage) => {
     setMessages(prev => [...prev, msg])
     scrollToBottom()
-    updatePeerRead()
+    setLastUpdatedAt(msg.created_at)
+    void markConversationAsRead()
+  }
+
+  useEffect(() => {
+    if (messages.length === 0) return
+    setLastUpdatedAt(messages[messages.length - 1].created_at)
+  }, [messages])
+
+  const formatTimestamp = (iso: string | null) => {
+    if (!iso) return '-'
+    try {
+      return format(new Date(iso), 'yyyy/MM/dd HH:mm')
+    } catch (e) {
+      return '-'
+    }
+  }
+
+  const resolveSenderName = (message: OfferMessage) => {
+    switch (message.sender_role) {
+      case 'store':
+        return storeName || '店舗'
+      case 'talent':
+        return talentName || '演者'
+      case 'admin':
+        return adminName
+      default:
+        return 'ユーザー'
+    }
   }
 
   return (
-    <div className="flex h-full min-h-[520px] flex-col overflow-hidden rounded-xl border bg-card shadow-sm">
+    <div className="flex h-full min-h-[520px] flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <div className="flex items-center justify-between gap-4 border-b border-slate-100 px-5 py-4">
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2">
+            <MessageCircle className="h-5 w-5 text-slate-600" aria-hidden="true" />
+            <h3 className="text-base font-semibold text-slate-900">メッセージ</h3>
+            {unreadCount > 0 && (
+              <span className="inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-red-500 px-1 text-xs font-semibold text-white">
+                {unreadCount}
+              </span>
+            )}
+          </div>
+        </div>
+        <span className="text-xs text-slate-400">最終更新: {formatTimestamp(lastUpdatedAt)}</span>
+      </div>
       <div
         ref={containerRef}
         onScroll={handleScroll}
-        className="flex-1 overflow-y-auto p-4"
+        className="flex-1 overflow-y-auto px-5 py-4"
         aria-live="polite"
       >
         {loading && <p>Loading...</p>}
         {!loading && messages.length === 0 && (
-          <p className="text-center text-sm leading-relaxed text-muted-foreground">
+          <p className="text-center text-sm leading-relaxed text-slate-500">
             このオファーに関する連絡はまだありません。下の入力欄からメッセージを送信しましょう。
           </p>
         )}
-        {messages.map(m => (
-          <ChatMessageBubble
-            key={m.id}
-            message={m}
-            currentUserId={currentUserId}
-            peerLastReadAt={peerLastReadAt}
-          />
-        ))}
+        <div className="flex flex-col gap-4">
+          {messages.map(m => (
+            <ChatMessageBubble
+              key={m.id}
+              message={m}
+              currentUserId={currentUserId}
+              peerLastReadAt={peerLastReadAt}
+              senderName={resolveSenderName(m)}
+            />
+          ))}
+        </div>
       </div>
-      <div className="border-t bg-background p-4">
+      <div className="border-t border-slate-100 bg-slate-50 px-5 py-4">
         <OfferChatInput offerId={offerId} senderRole={currentRole} onSent={handleSent} />
       </div>
-      {paymentLink && (
-        <div className="flex flex-wrap justify-end gap-2 border-t bg-muted/40 p-4">
-          <Button variant="default" size="sm" asChild>
-            <Link href={paymentLink}>支払い状況</Link>
-          </Button>
-        </div>
-      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- refresh the offer chat thread card with a dedicated header, unread badge, last updated timestamp, and remove the obsolete payment status button
- show sender names and timestamps in redesigned chat bubbles while keeping read-receipt behaviour intact
- update the chat input helper text/button styling and pass participant names from the performer and store offer pages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d246c32b2c8332bebcff8b67c2ccca