### PR TITLE
Refine offer detail layout with full-width progress tracker

### DIFF
--- a/talentify-next-frontend/app/store/offers/[id]/StoreOfferProgressPanel.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/StoreOfferProgressPanel.tsx
@@ -293,7 +293,7 @@ export default function StoreOfferProgressPanel({
 
   return (
     <div className="space-y-8">
-      <div className="mx-auto w-full max-w-3xl">
+      <div className="w-full">
         <OfferProgressTracker
           steps={progressSteps}
           selectedStep={activeStep}

--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -2,7 +2,6 @@ import { notFound } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import OfferChatThread from '@/components/offer/OfferChatThread'
 import OfferSummary from '@/components/offer/OfferSummary'
-import OfferPaymentStatusCard from '@/components/offer/OfferPaymentStatusCard'
 import CancelOfferSection from './CancelOfferSection'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import { getOfferProgress } from '@/utils/offerProgress'
@@ -78,74 +77,69 @@ export default async function StoreOfferPage({ params }: PageProps) {
 
   return (
     <div className="p-4 sm:p-6 lg:p-8">
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 lg:grid lg:grid-cols-[minmax(0,1.75fr)_minmax(0,1fr)] lg:items-start lg:gap-8">
-        <div className="flex flex-col gap-6">
-          <Card className="shadow-sm">
-            <CardHeader className="space-y-2">
-              <CardTitle>進捗状況</CardTitle>
-              <p className="text-sm text-muted-foreground">オファーの進行状況と各ステップの対応内容を確認できます。</p>
-            </CardHeader>
-            <CardContent className="space-y-8">
-              <StoreOfferProgressPanel
-                steps={steps}
-                currentStep={current}
-                offer={{
-                  id: offer.id,
-                  status: offer.status,
-                  date: offer.date,
-                  updatedAt: offer.updatedAt,
-                  submittedAt: offer.submittedAt,
-                  paid: offer.paid,
-                  paidAt: offer.paidAt,
-                  invoiceStatus: offer.invoiceStatus,
-                }}
-                invoice={invoiceData}
-                paymentLink={paymentLink}
-              />
-            </CardContent>
-          </Card>
-
-          <Card className="shadow-sm">
-            <CardHeader>
-              <CardTitle>オファー詳細</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <OfferSummary
-                performerName={offer.performerName}
-                performerAvatarUrl={offer.performerAvatarUrl}
-                storeName={offer.storeName}
-                date={offer.date}
-                message={offer.message}
-                invoiceStatus={offer.invoiceStatus}
-              />
-              <CancelOfferSection
-                offerId={offer.id}
-                initialStatus={data.status}
-                initialCanceledAt={data.canceled_at}
-              />
-            </CardContent>
-          </Card>
-
-          {invoiceData && (
-            <OfferPaymentStatusCard
-              title="請求"
-              offerId={offer.id}
-              paid={offer.paid}
-              paidAt={offer.paidAt}
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 lg:gap-8">
+        <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div className="space-y-4">
+            <div>
+              <h2 className="text-lg font-semibold text-slate-900">進捗状況</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                オファーの進行状況と各ステップの対応内容を確認できます。
+              </p>
+            </div>
+            <StoreOfferProgressPanel
+              steps={steps}
+              currentStep={current}
+              offer={{
+                id: offer.id,
+                status: offer.status,
+                date: offer.date,
+                updatedAt: offer.updatedAt,
+                submittedAt: offer.submittedAt,
+                paid: offer.paid,
+                paidAt: offer.paidAt,
+                invoiceStatus: offer.invoiceStatus,
+              }}
               invoice={invoiceData}
+              paymentLink={paymentLink}
             />
-          )}
-        </div>
+          </div>
+        </section>
 
-        <aside className="flex h-full flex-col" id="chat">
-          <OfferChatThread
-            offerId={offer.id}
-            currentUserId={user.id}
-            currentRole="store"
-            storeName={offer.storeName}
-            talentName={offer.performerName}
-          />
-        </aside>
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)] lg:items-start lg:gap-8">
+          <div className="flex flex-col gap-6">
+            <Card className="shadow-sm">
+              <CardHeader>
+                <CardTitle>オファー詳細</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <OfferSummary
+                  performerName={offer.performerName}
+                  performerAvatarUrl={offer.performerAvatarUrl}
+                  storeName={offer.storeName}
+                  date={offer.date}
+                  message={offer.message}
+                  invoiceStatus={offer.invoiceStatus}
+                />
+                <CancelOfferSection
+                  offerId={offer.id}
+                  initialStatus={data.status}
+                  initialCanceledAt={data.canceled_at}
+                />
+              </CardContent>
+            </Card>
+          </div>
+
+          <aside className="flex h-full flex-col" id="chat">
+            <OfferChatThread
+              offerId={offer.id}
+              currentUserId={user.id}
+              currentRole="store"
+              storeName={offer.storeName}
+              talentName={offer.performerName}
+              className="lg:h-[600px] lg:max-h-[70vh]"
+            />
+          </aside>
+        </div>
       </div>
     </div>
   )

--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -431,108 +431,107 @@ export default function TalentOfferPage() {
 
   return (
     <div className="p-4 sm:p-6 lg:p-8">
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 lg:grid lg:grid-cols-[minmax(0,1.75fr)_minmax(0,1fr)] lg:items-start lg:gap-8">
-        <div className="flex flex-col gap-6">
-          <Card className="shadow-sm">
-            <CardHeader className="space-y-2">
-              <CardTitle>進捗状況</CardTitle>
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 lg:gap-8">
+        <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div className="space-y-6">
+            <div className="space-y-2">
+              <h2 className="text-lg font-semibold text-slate-900">進捗状況</h2>
               <p className="text-sm text-muted-foreground">オファーの進行状況と次に行うアクションを確認できます。</p>
-            </CardHeader>
-            <CardContent className="space-y-8">
-              <div className="flex flex-wrap items-center justify-between gap-3">
-                <div className="flex items-center gap-2">
-                  {statusDisplay.badge}
-                  <span className="text-xs text-muted-foreground">最終更新: {formattedUpdatedAt}</span>
-                </div>
-                <span className="text-xs text-muted-foreground">
-                  提出日時: {formattedSubmittedAt}
-                </span>
+            </div>
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div className="flex items-center gap-2">
+                {statusDisplay.badge}
+                <span className="text-xs text-muted-foreground">最終更新: {formattedUpdatedAt}</span>
               </div>
-              <div className="mx-auto w-full max-w-3xl">
-                <OfferProgressTracker
-                  steps={progressSteps}
-                  selectedStep={activeStep}
-                  onStepSelect={setActiveStep}
-                />
-              </div>
-              <div className="rounded-2xl border bg-card p-6 shadow-md">
-                <div className="flex flex-wrap items-center gap-2">
-                  <h3 className="text-base font-semibold text-foreground">{detail.title}</h3>
-                  {detail.badge}
-                </div>
-                <p className="mt-3 text-sm leading-relaxed text-muted-foreground">{detail.description}</p>
-                {detail.meta && detail.meta.length > 0 && (
-                  <dl className="mt-4 grid gap-4 sm:grid-cols-2">
-                    {detail.meta.map(item => (
-                      <div key={item.label} className="space-y-1">
-                        <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                          {item.label}
-                        </dt>
-                        <dd className="text-sm font-semibold text-foreground">{item.value}</dd>
-                      </div>
-                    ))}
-                  </dl>
-                )}
-                {detail.actions && detail.actions.length > 0 && (
-                  <div className="mt-6 flex flex-wrap justify-end gap-2">
-                    {detail.actions.map((action, index) => (
-                      <div key={index} className="inline-flex">{action}</div>
-                    ))}
-                  </div>
-                )}
-                {detail.note && <div className="mt-4 text-sm text-muted-foreground">{detail.note}</div>}
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card className="shadow-sm">
-            <CardHeader>
-              <CardTitle>オファー詳細</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <OfferSummary
-                performerName={offer.performerName}
-                performerAvatarUrl={offer.performerAvatarUrl}
-                storeName={offer.storeName}
-                date={offer.date}
-                message={offer.message}
-                invoiceStatus={offer.invoiceStatus}
+              <span className="text-xs text-muted-foreground">提出日時: {formattedSubmittedAt}</span>
+            </div>
+            <div className="w-full">
+              <OfferProgressTracker
+                steps={progressSteps}
+                selectedStep={activeStep}
+                onStepSelect={setActiveStep}
               />
-              {offer.status === 'pending' && (
-                <div className="flex flex-wrap justify-end gap-2">
-                  <Button
-                    variant="default"
-                    size="sm"
-                    onClick={handleAccept}
-                    disabled={actionLoading !== null}
-                  >
-                    {actionLoading === 'accept' ? '承諾中...' : '承諾'}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleDecline}
-                    disabled={actionLoading !== null}
-                  >
-                    {actionLoading === 'decline' ? '辞退中...' : '辞退'}
-                  </Button>
+            </div>
+            <div className="rounded-2xl border bg-card p-6 shadow-md">
+              <div className="flex flex-wrap items-center gap-2">
+                <h3 className="text-base font-semibold text-foreground">{detail.title}</h3>
+                {detail.badge}
+              </div>
+              <p className="mt-3 text-sm leading-relaxed text-muted-foreground">{detail.description}</p>
+              {detail.meta && detail.meta.length > 0 && (
+                <dl className="mt-4 grid gap-4 sm:grid-cols-2">
+                  {detail.meta.map(item => (
+                    <div key={item.label} className="space-y-1">
+                      <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{item.label}</dt>
+                      <dd className="text-sm font-semibold text-foreground">{item.value}</dd>
+                    </div>
+                  ))}
+                </dl>
+              )}
+              {detail.actions && detail.actions.length > 0 && (
+                <div className="mt-6 flex flex-wrap justify-end gap-2">
+                  {detail.actions.map((action, index) => (
+                    <div key={index} className="inline-flex">{action}</div>
+                  ))}
                 </div>
               )}
-            </CardContent>
-          </Card>
+              {detail.note && <div className="mt-4 text-sm text-muted-foreground">{detail.note}</div>}
+            </div>
+          </div>
+        </section>
 
-          <OfferPaymentStatusCard paid={offer.paid} paidAt={offer.paidAt} />
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)] lg:items-start lg:gap-8">
+          <div className="flex flex-col gap-6">
+            <Card className="shadow-sm">
+              <CardHeader>
+                <CardTitle>オファー詳細</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <OfferSummary
+                  performerName={offer.performerName}
+                  performerAvatarUrl={offer.performerAvatarUrl}
+                  storeName={offer.storeName}
+                  date={offer.date}
+                  message={offer.message}
+                  invoiceStatus={offer.invoiceStatus}
+                />
+                {offer.status === 'pending' && (
+                  <div className="flex flex-wrap justify-end gap-2">
+                    <Button
+                      variant="default"
+                      size="sm"
+                      onClick={handleAccept}
+                      disabled={actionLoading !== null}
+                    >
+                      {actionLoading === 'accept' ? '承諾中...' : '承諾'}
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={handleDecline}
+                      disabled={actionLoading !== null}
+                    >
+                      {actionLoading === 'decline' ? '辞退中...' : '辞退'}
+                    </Button>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+
+            <OfferPaymentStatusCard paid={offer.paid} paidAt={offer.paidAt} />
+          </div>
+
+          <aside className="flex h-full flex-col" id="chat">
+            <OfferChatThread
+              offerId={offer.id}
+              currentUserId={userId}
+              currentRole="talent"
+              storeName={offer.storeName}
+              talentName={offer.performerName}
+              className="lg:h-[600px] lg:max-h-[70vh]"
+            />
+          </aside>
         </div>
-
-        <aside className="flex h-full flex-col" id="chat">
-          <OfferChatThread
-            offerId={offer.id}
-            currentUserId={userId}
-            currentRole="talent"
-            storeName={offer.storeName}
-            talentName={offer.performerName}
-          />
-        </aside>
       </div>
     </div>
   )

--- a/talentify-next-frontend/components/offer/OfferChatThread.tsx
+++ b/talentify-next-frontend/components/offer/OfferChatThread.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { cn } from '@/lib/utils'
 import { createClient } from '@/utils/supabase/client'
 import type { OfferMessage } from '@/lib/supabase/offerMessages'
 import {
@@ -21,6 +22,7 @@ interface OfferChatThreadProps {
   storeName: string
   talentName: string
   adminName?: string
+  className?: string
 }
 export default function OfferChatThread({
   offerId,
@@ -29,6 +31,7 @@ export default function OfferChatThread({
   storeName,
   talentName,
   adminName = 'サポート',
+  className,
 }: OfferChatThreadProps) {
   const supabase = createClient()
   const [messages, setMessages] = useState<OfferMessage[]>([])
@@ -165,7 +168,12 @@ export default function OfferChatThread({
   }
 
   return (
-    <div className="flex h-full min-h-[520px] flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+    <div
+      className={cn(
+        'flex h-full min-h-[520px] flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm',
+        className,
+      )}
+    >
       <div className="flex items-center justify-between gap-4 border-b border-slate-100 px-5 py-4">
         <div className="flex items-center gap-3">
           <div className="flex items-center gap-2">

--- a/talentify-next-frontend/components/offer/OfferProgressTracker.tsx
+++ b/talentify-next-frontend/components/offer/OfferProgressTracker.tsx
@@ -42,20 +42,6 @@ export default function OfferProgressTracker({ steps, selectedStep, onStepSelect
   const activeStep =
     selectedStep ?? steps.find(step => step.status === 'current')?.key ?? steps[steps.length - 1]?.key
   const completedCount = steps.filter(step => step.status === 'complete').length
-  const currentIndex = steps.findIndex(step => step.status === 'current')
-  const lastCompletedIndex = steps.reduce((acc, step, index) => (step.status === 'complete' ? index : acc), -1)
-  const progressTargetIndex =
-    currentIndex >= 0 ? currentIndex : Math.max(lastCompletedIndex, steps.length > 0 ? 0 : -1)
-  const progressPercentage = (() => {
-    if (steps.length <= 1) {
-      return 100
-    }
-    if (progressTargetIndex < 0) {
-      return 0
-    }
-    const ratio = progressTargetIndex / (steps.length - 1)
-    return Math.max(0, Math.min(100, ratio * 100))
-  })()
 
   const getDisplaySubLabel = (step: OfferProgressStep) => {
     if (step.status === 'upcoming') {
@@ -72,63 +58,74 @@ export default function OfferProgressTracker({ steps, selectedStep, onStepSelect
         </span>
       </div>
       <div className="overflow-x-auto">
-        <div className="min-w-[640px]">
-          <div className="space-y-6">
-            <div className="relative h-1 w-full rounded-full bg-[#E0E0E0]">
-              <div
-                className="absolute inset-y-0 left-0 rounded-full bg-[#1976D2] transition-all"
-                style={{ width: `${progressPercentage}%` }}
-              />
-            </div>
-            <div className="flex justify-between gap-3">
-              {steps.map((step, index) => {
-                const isSelected = step.key === activeStep
-                const iconStyles = iconStylesByStatus[step.status]
-                const displaySubLabel = getDisplaySubLabel(step)
-                return (
-                  <div key={step.key} className="flex min-w-0 flex-1 flex-col items-center text-center">
-                    <button
-                      type="button"
-                      onClick={() => onStepSelect?.(step.key)}
-                      className="flex flex-col items-center gap-3 focus:outline-none"
-                      aria-pressed={isSelected}
+        <div className="min-w-[640px] space-y-6">
+          <div className="flex justify-between gap-3">
+            {steps.map((step, index) => {
+              const isSelected = step.key === activeStep
+              const iconStyles = iconStylesByStatus[step.status]
+              const displaySubLabel = getDisplaySubLabel(step)
+              const prevStep = steps[index - 1]
+              const nextStep = steps[index + 1]
+              const leftConnectorActive = prevStep ? prevStep.status === 'complete' : false
+              const rightConnectorActive = nextStep ? step.status === 'complete' : false
+
+              return (
+                <div key={step.key} className="relative flex min-w-0 flex-1 flex-col items-center text-center">
+                  {index > 0 && (
+                    <span
+                      className="absolute left-0 top-7 block h-1 w-1/2 -translate-y-1/2 rounded-full"
+                      style={{ backgroundColor: leftConnectorActive ? '#1976D2' : '#E0E0E0' }}
+                      aria-hidden="true"
+                    />
+                  )}
+                  {index < steps.length - 1 && (
+                    <span
+                      className="absolute right-0 top-7 block h-1 w-1/2 -translate-y-1/2 rounded-full"
+                      style={{ backgroundColor: rightConnectorActive ? '#1976D2' : '#E0E0E0' }}
+                      aria-hidden="true"
+                    />
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => onStepSelect?.(step.key)}
+                    className="flex flex-col items-center gap-3 focus:outline-none"
+                    aria-pressed={isSelected}
+                  >
+                    <div
+                      className={cn(
+                        'relative z-10 flex h-14 w-14 items-center justify-center rounded-full transition-all',
+                        iconStyles.outer,
+                        isSelected && 'ring-2 ring-[#1976D2] ring-opacity-60 ring-offset-2',
+                      )}
                     >
                       <div
                         className={cn(
-                          'flex h-14 w-14 items-center justify-center rounded-full transition-all',
-                          iconStyles.outer,
-                          isSelected && 'ring-2 ring-[#1976D2] ring-opacity-60 ring-offset-2',
+                          'flex h-11 w-11 items-center justify-center rounded-full text-base font-semibold transition-all',
+                          iconStyles.inner,
                         )}
                       >
-                        <div
-                          className={cn(
-                            'flex h-11 w-11 items-center justify-center rounded-full text-base font-semibold transition-all',
-                            iconStyles.inner,
-                          )}
-                        >
-                          {step.status === 'complete' ? (
-                            <Check className="h-5 w-5" />
-                          ) : (
-                            <span>{index + 1}</span>
-                          )}
-                        </div>
+                        {step.status === 'complete' ? (
+                          <Check className="h-5 w-5" />
+                        ) : (
+                          <span>{index + 1}</span>
+                        )}
                       </div>
-                      <div className="flex min-h-[3.5rem] flex-col items-center justify-start gap-1">
-                        <span className={cn('text-sm font-semibold', titleColorByStatus[step.status])}>{step.title}</span>
-                        <span className={cn('text-xs font-medium', dateColorByStatus[step.status])}>
-                          {displaySubLabel ||
-                            (step.status === 'current'
-                              ? '期限: -'
-                              : step.status === 'complete'
-                                ? '-'
-                                : ' ')}
-                        </span>
-                      </div>
-                    </button>
-                  </div>
-                )
-              })}
-            </div>
+                    </div>
+                    <div className="flex min-h-[3.5rem] flex-col items-center justify-start gap-1">
+                      <span className={cn('text-sm font-semibold', titleColorByStatus[step.status])}>{step.title}</span>
+                      <span className={cn('text-xs font-medium', dateColorByStatus[step.status])}>
+                        {displaySubLabel ||
+                          (step.status === 'current'
+                            ? '期限: -'
+                            : step.status === 'complete'
+                              ? '-'
+                              : ' ')}
+                      </span>
+                    </div>
+                  </button>
+                </div>
+              )
+            })}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- restyle store and talent offer detail pages to show a full-width progress tracker with a two-column layout for details and chat
- connect progress tracker icons with visual connectors and allow the chat thread height to be constrained via a new className prop

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d256d23594833286a4b6ea09ae1bd7