### PR TITLE
Update offer detail layout with progress and summary

### DIFF
--- a/talentify-next-frontend/app/store/offers/[id]/StoreOfferProgressPanel.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/StoreOfferProgressPanel.tsx
@@ -16,6 +16,7 @@ interface StoreOfferProgressPanelProps {
     id: string
     status: string
     date: string | null
+    respondDeadline: string | null
     updatedAt: string
     submittedAt: string | null
     paid: boolean
@@ -71,17 +72,27 @@ export default function StoreOfferProgressPanel({
     return offer.date ? format(new Date(offer.date), 'yyyy/MM/dd (EEE) HH:mm', { locale: ja }) : '未設定'
   }, [offer.date])
 
+  const formattedRespondDeadline = useMemo(() => {
+    return offer.respondDeadline
+      ? format(new Date(offer.respondDeadline), 'yyyy/MM/dd', { locale: ja })
+      : null
+  }, [offer.respondDeadline])
+
   const paymentCompletedLabel = useMemo(() => {
     return offer.paidAt ? format(new Date(offer.paidAt), 'yyyy/MM/dd', { locale: ja }) : undefined
   }, [offer.paidAt])
 
   const submittedDateLabel = useMemo(() => {
-    return offer.submittedAt ? format(new Date(offer.submittedAt), 'yyyy/MM/dd', { locale: ja }) : null
+    return offer.submittedAt
+      ? `提出日時: ${format(new Date(offer.submittedAt), 'yyyy/MM/dd', { locale: ja })}`
+      : null
   }, [offer.submittedAt])
 
   const approvalDeadlineLabel = useMemo(() => {
-    return offer.date ? format(new Date(offer.date), 'yyyy/MM/dd', { locale: ja }) : null
-  }, [offer.date])
+    return formattedRespondDeadline
+      ? `承認期限: ${formattedRespondDeadline}`
+      : '承認期限: 未設定'
+  }, [formattedRespondDeadline])
 
   const statusBadge = useMemo(() => {
     switch (offer.status) {
@@ -101,23 +112,26 @@ export default function StoreOfferProgressPanel({
     return steps.map(step => {
       switch (step.key) {
         case 'offer_submitted':
-          return { ...step, subLabel: submittedDateLabel ?? '未登録' }
+          return { ...step, subLabel: submittedDateLabel ?? '提出日時: 未登録' }
         case 'approval':
           return {
             ...step,
-            subLabel: approvalDeadlineLabel ? `期限: ${approvalDeadlineLabel}` : '期限: 未設定',
+            subLabel: approvalDeadlineLabel,
           }
         case 'visit':
-          return { ...step, subLabel: formattedVisitDate }
+          return { ...step, subLabel: `来店予定: ${formattedVisitDate}` }
         case 'invoice':
-          return { ...step, subLabel: invoiceStatusText[offer.invoiceStatus] }
+          return { ...step, subLabel: `請求状況: ${invoiceStatusText[offer.invoiceStatus]}` }
         case 'payment':
           return {
             ...step,
-            subLabel: paymentCompletedLabel ?? (offer.paid ? '支払済み' : '未払い'),
+            subLabel:
+              paymentCompletedLabel != null
+                ? `支払い日: ${paymentCompletedLabel}`
+                : `支払い状況: ${offer.paid ? '完了' : '未完了'}`,
           }
         case 'review':
-          return { ...step, subLabel: step.status === 'complete' ? '完了' : '未実施' }
+          return { ...step, subLabel: `レビュー: ${step.status === 'complete' ? '完了' : '未実施'}` }
         default:
           return step
       }
@@ -300,7 +314,7 @@ export default function StoreOfferProgressPanel({
           onStepSelect={setActiveStep}
         />
       </div>
-      <div className="rounded-2xl border bg-card p-6 shadow-md">
+      <div className="rounded-2xl border border-slate-200 bg-slate-50 p-6 shadow-sm">
         <div className="flex flex-wrap items-center gap-2">
           <h3 className="text-base font-semibold text-foreground">{detail.title}</h3>
           {detail.badge}

--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -1,9 +1,12 @@
 import { notFound } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
+import { format } from 'date-fns'
+import { ja } from 'date-fns/locale'
 import OfferChatThread from '@/components/offer/OfferChatThread'
-import OfferSummary from '@/components/offer/OfferSummary'
 import CancelOfferSection from './CancelOfferSection'
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
 import { getOfferProgress } from '@/utils/offerProgress'
 import StoreOfferProgressPanel from './StoreOfferProgressPanel'
 
@@ -21,7 +24,7 @@ export default async function StoreOfferPage({ params }: PageProps) {
   const { data } = await supabase
     .from('offers')
     .select(
-      'id,status,date,created_at,updated_at,message,talent_id,user_id,canceled_at,paid,paid_at, talents(stage_name,avatar_url), stores(store_name)'
+      'id,status,date,respond_deadline,reward,created_at,updated_at,message,talent_id,user_id,canceled_at,paid,paid_at, talents(stage_name,avatar_url), stores(store_name)'
     )
     .eq('id', params.id)
     .single()
@@ -46,6 +49,7 @@ export default async function StoreOfferPage({ params }: PageProps) {
     id: data.id as string,
     status: data.status as string,
     date: data.date as string,
+    respondDeadline: data.respond_deadline as string | null,
     submittedAt: data.created_at as string | null,
     message: data.message as string,
     performerName: data.talents?.stage_name || '',
@@ -55,6 +59,7 @@ export default async function StoreOfferPage({ params }: PageProps) {
     paid: data.paid as boolean,
     paidAt: data.paid_at as string | null,
     invoiceStatus,
+    reward: data.reward as number | null,
   }
 
   const invoiceData = invoice
@@ -75,14 +80,46 @@ export default async function StoreOfferPage({ params }: PageProps) {
     paid: offer.paid,
   })
 
+  const formattedUpdatedAt = format(new Date(offer.updatedAt), 'yyyy/MM/dd HH:mm', { locale: ja })
+  const formattedSubmittedAt = offer.submittedAt
+    ? format(new Date(offer.submittedAt), 'yyyy/MM/dd HH:mm', { locale: ja })
+    : '未提出'
+
+  const statusLabel = getStatusLabel(offer.status)
+  const statusClassName = getStatusBadgeClassName(offer.status)
+
   return (
-    <div className="p-4 sm:p-6 lg:p-8">
+    <div className="bg-slate-50 p-4 sm:p-6 lg:p-8">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 lg:gap-8">
-        <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-          <div className="space-y-4">
-            <div>
+        <section className="rounded-2xl bg-white p-6 shadow-sm">
+          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div className="space-y-3">
+              <div className="flex items-center gap-2">
+                <h1 className="text-2xl font-bold text-slate-900">オファー詳細</h1>
+              </div>
+              <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-sm text-slate-600">
+                <div className="flex items-center gap-2">
+                  <span className="font-medium text-slate-900">{offer.performerName || 'タレント未設定'}</span>
+                  <span className="text-slate-300">/</span>
+                  <span>{offer.storeName || '店舗未設定'}</span>
+                </div>
+                <span className="inline-flex h-4 w-px bg-slate-200" aria-hidden="true" />
+                <span>{formattedSubmittedAt}</span>
+                <Badge className={cn('flex items-center gap-1', statusClassName)}>{statusLabel}</Badge>
+              </div>
+            </div>
+            <div className="text-xs text-slate-500 md:text-right">
+              <div className="font-medium text-slate-400">最終更新日時</div>
+              <div>{formattedUpdatedAt}</div>
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-2xl bg-white p-6 shadow-sm">
+          <div className="space-y-3">
+            <div className="flex flex-col gap-2">
               <h2 className="text-lg font-semibold text-slate-900">進捗状況</h2>
-              <p className="mt-1 text-sm text-muted-foreground">
+              <p className="text-sm text-muted-foreground">
                 オファーの進行状況と各ステップの対応内容を確認できます。
               </p>
             </div>
@@ -93,6 +130,7 @@ export default async function StoreOfferPage({ params }: PageProps) {
                 id: offer.id,
                 status: offer.status,
                 date: offer.date,
+                respondDeadline: offer.respondDeadline,
                 updatedAt: offer.updatedAt,
                 submittedAt: offer.submittedAt,
                 paid: offer.paid,
@@ -107,19 +145,42 @@ export default async function StoreOfferPage({ params }: PageProps) {
 
         <div className="grid gap-6 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)] lg:items-start lg:gap-8">
           <div className="flex flex-col gap-6">
-            <Card className="shadow-sm">
-              <CardHeader>
-                <CardTitle>オファー詳細</CardTitle>
+            <Card className="rounded-lg border border-slate-200 bg-white p-0 shadow-sm">
+              <CardHeader className="mb-0 flex flex-col gap-2 border-b border-slate-100 p-6 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <CardTitle className="text-lg">オファー提出</CardTitle>
+                  <p className="mt-1 text-sm text-slate-600">
+                    オファーが正常に提出されました。進捗に応じてタレントへ連絡を行いましょう。
+                  </p>
+                </div>
+                <Badge className={cn('self-start', statusClassName)}>{statusLabel}</Badge>
               </CardHeader>
-              <CardContent className="space-y-4">
-                <OfferSummary
-                  performerName={offer.performerName}
-                  performerAvatarUrl={offer.performerAvatarUrl}
-                  storeName={offer.storeName}
-                  date={offer.date}
-                  message={offer.message}
-                  invoiceStatus={offer.invoiceStatus}
-                />
+              <CardContent className="space-y-6 p-6">
+                <dl className="grid gap-4 text-sm sm:grid-cols-2">
+                  <div className="space-y-1">
+                    <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">提出日時</dt>
+                    <dd className="text-base font-semibold text-slate-900">{formattedSubmittedAt}</dd>
+                  </div>
+                  <div className="space-y-1">
+                    <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">提出者</dt>
+                    <dd className="text-sm font-medium text-slate-900">{offer.storeName || '未設定'}</dd>
+                  </div>
+                  <div className="space-y-1">
+                    <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">オファー金額</dt>
+                    <dd className="text-base font-semibold text-slate-900">
+                      {offer.reward != null ? `¥${offer.reward.toLocaleString('ja-JP')}` : '未設定'}
+                    </dd>
+                  </div>
+                  <div className="space-y-1">
+                    <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">ステータス</dt>
+                    <dd>
+                      <Badge className={cn('mt-1', statusClassName)}>{statusLabel}</Badge>
+                    </dd>
+                  </div>
+                </dl>
+                <div className="rounded-lg border border-dashed border-slate-200 bg-slate-50 p-4 text-sm text-slate-600">
+                  このオファーに関する詳細についてお気軽にメッセージをお送りください。
+                </div>
                 <CancelOfferSection
                   offerId={offer.id}
                   initialStatus={data.status}
@@ -143,4 +204,38 @@ export default async function StoreOfferPage({ params }: PageProps) {
       </div>
     </div>
   )
+}
+
+function getStatusLabel(status: string) {
+  switch (status) {
+    case 'accepted':
+    case 'confirmed':
+      return '承認済み'
+    case 'completed':
+      return '完了'
+    case 'rejected':
+      return '辞退済み'
+    case 'canceled':
+      return 'キャンセル'
+    case 'draft':
+      return '下書き'
+    default:
+      return '承認待ち'
+  }
+}
+
+function getStatusBadgeClassName(status: string) {
+  switch (status) {
+    case 'completed':
+    case 'confirmed':
+    case 'accepted':
+      return 'bg-emerald-500 text-white'
+    case 'draft':
+      return 'bg-slate-200 text-slate-700'
+    case 'rejected':
+    case 'canceled':
+      return 'bg-slate-300 text-slate-700'
+    default:
+      return 'bg-orange-400 text-white'
+  }
 }

--- a/talentify-next-frontend/components/offer/OfferProgressTracker.tsx
+++ b/talentify-next-frontend/components/offer/OfferProgressTracker.tsx
@@ -14,13 +14,13 @@ interface OfferProgressTrackerProps {
 const titleColorByStatus: Record<OfferProgressStep['status'], string> = {
   complete: 'text-[#00B26F]',
   current: 'text-[#1976D2]',
-  upcoming: 'text-[#BDBDBD]',
+  upcoming: 'text-slate-400',
 }
 
 const dateColorByStatus: Record<OfferProgressStep['status'], string> = {
-  complete: 'text-[#00B26F]',
-  current: 'text-[#FF9800]',
-  upcoming: 'text-transparent',
+  complete: 'text-slate-500',
+  current: 'text-[#1976D2]',
+  upcoming: 'text-slate-400',
 }
 
 const iconStylesByStatus: Record<OfferProgressStep['status'], { outer: string; inner: string }> = {
@@ -43,17 +43,10 @@ export default function OfferProgressTracker({ steps, selectedStep, onStepSelect
     selectedStep ?? steps.find(step => step.status === 'current')?.key ?? steps[steps.length - 1]?.key
   const completedCount = steps.filter(step => step.status === 'complete').length
 
-  const getDisplaySubLabel = (step: OfferProgressStep) => {
-    if (step.status === 'upcoming') {
-      return ''
-    }
-    return step.subLabel ?? ''
-  }
-
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-end">
-        <span className="text-xs font-medium text-[#1976D2]">
+        <span className="text-xs font-medium text-slate-500">
           {completedCount}/{steps.length}ステップ完了
         </span>
       </div>
@@ -63,7 +56,7 @@ export default function OfferProgressTracker({ steps, selectedStep, onStepSelect
             {steps.map((step, index) => {
               const isSelected = step.key === activeStep
               const iconStyles = iconStylesByStatus[step.status]
-              const displaySubLabel = getDisplaySubLabel(step)
+              const displaySubLabel = step.subLabel ?? ''
               const prevStep = steps[index - 1]
               const nextStep = steps[index + 1]
               const leftConnectorActive = prevStep ? prevStep.status === 'complete' : false
@@ -114,12 +107,7 @@ export default function OfferProgressTracker({ steps, selectedStep, onStepSelect
                     <div className="flex min-h-[3.5rem] flex-col items-center justify-start gap-1">
                       <span className={cn('text-sm font-semibold', titleColorByStatus[step.status])}>{step.title}</span>
                       <span className={cn('text-xs font-medium', dateColorByStatus[step.status])}>
-                        {displaySubLabel ||
-                          (step.status === 'current'
-                            ? '期限: -'
-                            : step.status === 'complete'
-                              ? '-'
-                              : ' ')}
+                        {displaySubLabel || ' '}
                       </span>
                     </div>
                   </button>


### PR DESCRIPTION
## Summary
- restyle the store offer detail page header with seller info, status badge, and last updated timestamp
- surface progress tracking data with richer sub-labels and connect it to respond deadlines
- refresh the offer summary card with key metadata, comment guidance, and status badge styling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d25c13bc6c83328b382ff7c6f58321