### PR TITLE
Refactor talent offer detail progress layout

### DIFF
--- a/talentify-next-frontend/app/store/offers/[id]/MessageCard.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/MessageCard.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import OfferChatThread from '@/components/offer/OfferChatThread'
+
+type MessageCardProps = {
+  offerId: string
+  currentUserId: string
+  storeName: string
+  talentName: string
+}
+
+export default function MessageCard({ offerId, currentUserId, storeName, talentName }: MessageCardProps) {
+  return (
+    <div id="offer-messages">
+      <OfferChatThread
+        offerId={offerId}
+        currentUserId={currentUserId}
+        currentRole="store"
+        storeName={storeName}
+        talentName={talentName}
+        className="lg:max-h-[540px]"
+      />
+    </div>
+  )
+}

--- a/talentify-next-frontend/app/store/offers/[id]/ProgressCard.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/ProgressCard.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import OfferProgressTracker from '@/components/offer/OfferProgressTracker'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import type { OfferProgressStep, OfferStepKey } from '@/utils/offerProgress'
+
+type ProgressCardProps = {
+  steps: OfferProgressStep[]
+  activeStep: OfferStepKey
+  onStepChange: (step: OfferStepKey) => void
+}
+
+export default function ProgressCard({ steps, activeStep, onStepChange }: ProgressCardProps) {
+  return (
+    <Card className="rounded-2xl border border-slate-200 shadow-sm">
+      <CardHeader className="space-y-1">
+        <CardTitle className="text-lg font-semibold text-slate-900">進捗状況</CardTitle>
+        <p className="text-sm text-muted-foreground">オファーの進行状況と各ステップの対応内容を確認できます。</p>
+      </CardHeader>
+      <CardContent className="pt-2">
+        <OfferProgressTracker steps={steps} selectedStep={activeStep} onStepSelect={onStepChange} />
+      </CardContent>
+    </Card>
+  )
+}

--- a/talentify-next-frontend/app/store/offers/[id]/StepDetailCard.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/StepDetailCard.tsx
@@ -1,0 +1,349 @@
+'use client'
+
+import { useMemo, type ReactNode } from 'react'
+import Link from 'next/link'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import type { OfferProgressStatus, OfferStepKey } from '@/utils/offerProgress'
+import { format } from 'date-fns'
+import { ja } from 'date-fns/locale'
+import CancelOfferSection from './CancelOfferSection'
+
+type StepDetailCardProps = {
+  activeStep: OfferStepKey
+  activeStatus: OfferProgressStatus
+  offer: {
+    id: string
+    status: string
+    storeName: string
+    submittedAt: string | null
+    updatedAt: string
+    respondDeadline: string | null
+    date: string | null
+    paid: boolean
+    paidAt: string | null
+    invoiceStatus: 'not_submitted' | 'submitted' | 'paid'
+    reward: number | null
+  }
+  invoice?: {
+    id: string
+    invoiceUrl: string | null
+    amount: number | null
+    status: string
+  } | null
+  paymentLink?: string
+  cancelation?: {
+    initialStatus: string
+    initialCanceledAt: string | null
+  }
+}
+
+type StepDetail = {
+  title: string
+  description: string
+  badge?: ReactNode
+  meta?: { label: string; value: string }[]
+  actions?: ReactNode[]
+  note?: ReactNode
+  footer?: ReactNode
+}
+
+const invoiceStatusText: Record<'not_submitted' | 'submitted' | 'paid', string> = {
+  not_submitted: '未提出',
+  submitted: '提出済み',
+  paid: '支払済み',
+}
+
+const statusBadge = (status: string) => {
+  switch (status) {
+    case 'confirmed':
+    case 'accepted':
+      return <Badge>承認済み</Badge>
+    case 'rejected':
+      return <Badge variant="secondary">辞退済み</Badge>
+    case 'canceled':
+      return <Badge variant="destructive">キャンセル済み</Badge>
+    default:
+      return <Badge variant="outline">承認待ち</Badge>
+  }
+}
+
+export default function StepDetailCard({
+  activeStep,
+  activeStatus,
+  offer,
+  invoice,
+  paymentLink,
+  cancelation,
+}: StepDetailCardProps) {
+  const formattedSubmittedAt = useMemo(() => {
+    return offer.submittedAt
+      ? format(new Date(offer.submittedAt), 'yyyy/MM/dd HH:mm', { locale: ja })
+      : '未提出'
+  }, [offer.submittedAt])
+
+  const formattedUpdatedAt = useMemo(() => {
+    return format(new Date(offer.updatedAt), 'yyyy/MM/dd HH:mm', { locale: ja })
+  }, [offer.updatedAt])
+
+  const formattedVisitDate = useMemo(() => {
+    return offer.date ? format(new Date(offer.date), 'yyyy/MM/dd (EEE) HH:mm', { locale: ja }) : '未設定'
+  }, [offer.date])
+
+  const formattedRespondDeadline = useMemo(() => {
+    return offer.respondDeadline
+      ? format(new Date(offer.respondDeadline), 'yyyy/MM/dd', { locale: ja })
+      : '未設定'
+  }, [offer.respondDeadline])
+
+  const paymentCompletedLabel = useMemo(() => {
+    return offer.paidAt ? format(new Date(offer.paidAt), 'yyyy/MM/dd', { locale: ja }) : undefined
+  }, [offer.paidAt])
+
+  const buildStepDetail = useMemo<StepDetail>(() => {
+    let detail: StepDetail
+    switch (activeStep) {
+      case 'offer_submitted':
+        detail = {
+          title: 'オファー提出',
+          description: '店舗からタレントへオファーを送信しました。返信内容はメッセージで確認できます。',
+          badge: activeStatus === 'complete' ? <Badge variant="success">完了</Badge> : undefined,
+          meta: [
+            { label: '提出日時', value: formattedSubmittedAt },
+            { label: 'オファー金額', value: offer.reward != null ? `¥${offer.reward.toLocaleString('ja-JP')}` : '未設定' },
+            { label: '提出者', value: offer.storeName || '未設定' },
+          ],
+          actions: [
+            <Button key="message" variant="outline" size="sm" asChild>
+              <a href="#offer-messages">メッセージを送る</a>
+            </Button>,
+          ],
+        }
+        break
+      case 'approval': {
+        let description = ''
+        switch (offer.status) {
+          case 'pending':
+            description = 'タレントからの返答をお待ちください。必要に応じてメッセージで詳細を共有しましょう。'
+            break
+          case 'accepted':
+            description = 'タレントがオファーを承認しました。来店日時の最終確認を進めてください。'
+            break
+          case 'confirmed':
+            description = '承認が完了し、来店の段取りに進めます。訪問予定の共有を忘れずに行いましょう。'
+            break
+          case 'rejected':
+            description = 'タレントがオファーを辞退しました。別の候補者へのオファー送信をご検討ください。'
+            break
+          case 'canceled':
+            description = 'オファーはキャンセルされました。必要であれば新しいオファーを作成してください。'
+            break
+          default:
+            description = '承認手続きが進行中です。ステータスを確認して次のステップへ進みましょう。'
+            break
+        }
+        detail = {
+          title: '承認',
+          description,
+          badge: statusBadge(offer.status),
+          meta: [
+            { label: '承認期限', value: formattedRespondDeadline },
+            { label: '最終更新', value: formattedUpdatedAt },
+          ],
+          actions: [
+            <Button key="message" variant="outline" size="sm" asChild>
+              <a href="#offer-messages">メッセージを送る</a>
+            </Button>,
+          ],
+        }
+        break
+      }
+      case 'visit': {
+        let description = ''
+        if (offer.status === 'completed') {
+          description = '来店が完了しました。続けて請求内容を確認してください。'
+        } else if (offer.status === 'confirmed') {
+          description = '来店予定が確定しています。必要な持ち物や当日の流れをメッセージで共有しましょう。'
+        } else if (offer.status === 'accepted') {
+          description = 'タレントの承認を受けました。来店日時を確定し、詳細を連絡してください。'
+        } else if (offer.status === 'canceled') {
+          description = 'オファーがキャンセルされたため、来店は行われません。'
+        } else if (offer.status === 'rejected') {
+          description = '辞退済みのため来店は行われません。'
+        } else {
+          description = '来店日時の調整を進めてください。'
+        }
+        detail = {
+          title: '来店実施',
+          description,
+          badge: activeStatus === 'complete' ? <Badge variant="success">完了</Badge> : undefined,
+          meta: [
+            { label: '来店日時', value: formattedVisitDate },
+            { label: '最終更新', value: formattedUpdatedAt },
+          ],
+          actions: [
+            <Button key="message" variant="outline" size="sm" asChild>
+              <a href="#offer-messages">メッセージを送る</a>
+            </Button>,
+          ],
+        }
+        break
+      }
+      case 'invoice': {
+        let description = ''
+        if (offer.invoiceStatus === 'not_submitted') {
+          description = 'タレントからの請求書提出をお待ちください。提出されると通知されます。'
+        } else if (offer.invoiceStatus === 'submitted') {
+          description = '請求書が提出されました。内容を確認し、支払い手続きへ進みましょう。'
+        } else {
+          description = '請求の確認が完了しました。支払いステップへ進んでください。'
+        }
+        const actions: ReactNode[] = [
+          <Button key="message" variant="outline" size="sm" asChild>
+            <a href="#offer-messages">メッセージを送る</a>
+          </Button>,
+        ]
+        if (invoice) {
+          actions.push(
+            <Button key="invoice" variant="outline" size="sm" asChild>
+              <Link href={`/store/invoices/${invoice.id}`}>請求書を見る</Link>
+            </Button>,
+          )
+          if (invoice.invoiceUrl) {
+            actions.push(
+              <Button key="download" variant="outline" size="sm" asChild>
+                <a href={invoice.invoiceUrl} target="_blank" rel="noreferrer">
+                  請求書を開く
+                </a>
+              </Button>,
+            )
+          }
+        }
+        detail = {
+          title: '請求',
+          description,
+          badge: activeStatus === 'complete' ? <Badge variant="success">完了</Badge> : undefined,
+          meta: [
+            { label: '請求ステータス', value: invoiceStatusText[offer.invoiceStatus] },
+            ...(invoice?.amount != null
+              ? [{ label: '請求額', value: `¥${invoice.amount.toLocaleString('ja-JP')}` }]
+              : []),
+          ],
+          actions,
+        }
+        break
+      }
+      case 'payment': {
+        const description = offer.paid
+          ? '支払いが完了しました。必要に応じてレビューの準備を進めてください。'
+          : '請求内容を確認し、支払いを完了してください。支払いが完了するとレビューに進めます。'
+        const actions: ReactNode[] = [
+          <Button key="message" variant="outline" size="sm" asChild>
+            <a href="#offer-messages">メッセージを送る</a>
+          </Button>,
+        ]
+        if (paymentLink) {
+          actions.push(
+            <Button key="payment" size="sm" asChild>
+              <Link href={paymentLink}>支払い状況</Link>
+            </Button>,
+          )
+        }
+        detail = {
+          title: '支払い',
+          description,
+          badge: offer.paid ? <Badge variant="success">完了</Badge> : undefined,
+          meta: [
+            { label: '支払い状況', value: offer.paid ? '完了' : '未完了' },
+            ...(paymentCompletedLabel ? [{ label: '支払い日', value: paymentCompletedLabel }] : []),
+          ],
+          actions,
+        }
+        break
+      }
+      case 'review':
+      default:
+        detail = {
+          title: 'レビュー',
+          description:
+            '支払い完了後にタレントへのレビューを記入できます。来店内容を振り返って評価を準備しましょう。',
+          badge: activeStatus === 'complete' ? <Badge variant="success">完了</Badge> : undefined,
+          actions: [
+            <Button key="message" variant="outline" size="sm" asChild>
+              <a href="#offer-messages">メッセージを送る</a>
+            </Button>,
+          ],
+        }
+        break
+    }
+    if (cancelation) {
+      detail = {
+        ...detail,
+        footer: (
+          <CancelOfferSection
+            offerId={offer.id}
+            initialStatus={cancelation.initialStatus}
+            initialCanceledAt={cancelation.initialCanceledAt}
+          />
+        ),
+      }
+    }
+
+    return detail
+  }, [
+    activeStatus,
+    activeStep,
+    formattedRespondDeadline,
+    formattedSubmittedAt,
+    formattedUpdatedAt,
+    formattedVisitDate,
+    invoice,
+    offer.id,
+    offer.invoiceStatus,
+    offer.paid,
+    offer.reward,
+    offer.status,
+    offer.storeName,
+    paymentCompletedLabel,
+    paymentLink,
+    cancelation,
+  ])
+
+  return (
+    <Card className="rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <CardHeader className="flex flex-col gap-2 border-b border-slate-100 p-6">
+        <div className="flex flex-wrap items-center gap-3">
+          <CardTitle className="text-lg font-semibold text-slate-900">{buildStepDetail.title}</CardTitle>
+          {buildStepDetail.badge}
+        </div>
+        <p className="text-sm text-muted-foreground">{buildStepDetail.description}</p>
+      </CardHeader>
+      <CardContent className="space-y-6 p-6">
+        {buildStepDetail.meta && buildStepDetail.meta.length > 0 && (
+          <dl className="grid gap-4 text-sm sm:grid-cols-2">
+            {buildStepDetail.meta.map(item => (
+              <div key={item.label} className="space-y-1">
+                <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{item.label}</dt>
+                <dd className="text-base font-semibold text-slate-900">{item.value}</dd>
+              </div>
+            ))}
+          </dl>
+        )}
+        {buildStepDetail.actions && buildStepDetail.actions.length > 0 && (
+          <div className="flex flex-wrap justify-end gap-2">
+            {buildStepDetail.actions.map((action, index) => (
+              <div key={index} className="inline-flex">{action}</div>
+            ))}
+          </div>
+        )}
+        {buildStepDetail.note}
+        {buildStepDetail.footer && (
+          <div className="space-y-4 border-t border-dashed border-slate-200 pt-4">
+            {buildStepDetail.footer}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -2,13 +2,11 @@ import { notFound } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import { format } from 'date-fns'
 import { ja } from 'date-fns/locale'
-import OfferChatThread from '@/components/offer/OfferChatThread'
-import CancelOfferSection from './CancelOfferSection'
 import { Badge } from '@/components/ui/badge'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
 import { getOfferProgress } from '@/utils/offerProgress'
 import StoreOfferProgressPanel from './StoreOfferProgressPanel'
+import { deriveActiveStep } from '@/lib/offers/deriveActiveStep'
 
 type PageProps = {
   params: { id: string }
@@ -24,7 +22,7 @@ export default async function StoreOfferPage({ params }: PageProps) {
   const { data } = await supabase
     .from('offers')
     .select(
-      'id,status,date,respond_deadline,reward,created_at,updated_at,message,talent_id,user_id,canceled_at,paid,paid_at, talents(stage_name,avatar_url), stores(store_name)'
+      'id,status,date,respond_deadline,reward,created_at,updated_at,message,talent_id,user_id,canceled_at,accepted_at,paid,paid_at, talents(stage_name,avatar_url), stores(store_name)'
     )
     .eq('id', params.id)
     .single()
@@ -54,6 +52,7 @@ export default async function StoreOfferPage({ params }: PageProps) {
     message: data.message as string,
     performerName: data.talents?.stage_name || '',
     performerAvatarUrl: data.talents?.avatar_url || null,
+    acceptedAt: data.accepted_at as string | null,
     storeName: data.stores?.store_name || '',
     updatedAt: data.updated_at as string,
     paid: data.paid as boolean,
@@ -74,10 +73,19 @@ export default async function StoreOfferPage({ params }: PageProps) {
   const showActions = ['accepted', 'confirmed', 'completed'].includes(data.status as string)
   const paymentLink = showActions ? `/store/offers/${params.id}/payment` : undefined
 
-  const { steps, current } = getOfferProgress({
+  const { steps } = getOfferProgress({
     status: offer.status,
     invoiceStatus: offer.invoiceStatus,
     paid: offer.paid,
+  })
+
+  const activeStep = deriveActiveStep({
+    status: offer.status,
+    acceptedAt: offer.acceptedAt,
+    visitScheduledAt: offer.date,
+    invoiceStatus: offer.invoiceStatus,
+    paid: offer.paid,
+    paidAt: offer.paidAt,
   })
 
   const formattedUpdatedAt = format(new Date(offer.updatedAt), 'yyyy/MM/dd HH:mm', { locale: ja })
@@ -115,92 +123,32 @@ export default async function StoreOfferPage({ params }: PageProps) {
           </div>
         </section>
 
-        <section className="rounded-2xl bg-white p-6 shadow-sm">
-          <div className="space-y-3">
-            <div className="flex flex-col gap-2">
-              <h2 className="text-lg font-semibold text-slate-900">進捗状況</h2>
-              <p className="text-sm text-muted-foreground">
-                オファーの進行状況と各ステップの対応内容を確認できます。
-              </p>
-            </div>
-            <StoreOfferProgressPanel
-              steps={steps}
-              currentStep={current}
-              offer={{
-                id: offer.id,
-                status: offer.status,
-                date: offer.date,
-                respondDeadline: offer.respondDeadline,
-                updatedAt: offer.updatedAt,
-                submittedAt: offer.submittedAt,
-                paid: offer.paid,
-                paidAt: offer.paidAt,
-                invoiceStatus: offer.invoiceStatus,
-              }}
-              invoice={invoiceData}
-              paymentLink={paymentLink}
-            />
-          </div>
-        </section>
-
-        <div className="grid gap-6 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)] lg:items-start lg:gap-8">
-          <div className="flex flex-col gap-6">
-            <Card className="rounded-lg border border-slate-200 bg-white p-0 shadow-sm">
-              <CardHeader className="mb-0 flex flex-col gap-2 border-b border-slate-100 p-6 sm:flex-row sm:items-start sm:justify-between">
-                <div>
-                  <CardTitle className="text-lg">オファー提出</CardTitle>
-                  <p className="mt-1 text-sm text-slate-600">
-                    オファーが正常に提出されました。進捗に応じてタレントへ連絡を行いましょう。
-                  </p>
-                </div>
-                <Badge className={cn('self-start', statusClassName)}>{statusLabel}</Badge>
-              </CardHeader>
-              <CardContent className="space-y-6 p-6">
-                <dl className="grid gap-4 text-sm sm:grid-cols-2">
-                  <div className="space-y-1">
-                    <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">提出日時</dt>
-                    <dd className="text-base font-semibold text-slate-900">{formattedSubmittedAt}</dd>
-                  </div>
-                  <div className="space-y-1">
-                    <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">提出者</dt>
-                    <dd className="text-sm font-medium text-slate-900">{offer.storeName || '未設定'}</dd>
-                  </div>
-                  <div className="space-y-1">
-                    <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">オファー金額</dt>
-                    <dd className="text-base font-semibold text-slate-900">
-                      {offer.reward != null ? `¥${offer.reward.toLocaleString('ja-JP')}` : '未設定'}
-                    </dd>
-                  </div>
-                  <div className="space-y-1">
-                    <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">ステータス</dt>
-                    <dd>
-                      <Badge className={cn('mt-1', statusClassName)}>{statusLabel}</Badge>
-                    </dd>
-                  </div>
-                </dl>
-                <div className="rounded-lg border border-dashed border-slate-200 bg-slate-50 p-4 text-sm text-slate-600">
-                  このオファーに関する詳細についてお気軽にメッセージをお送りください。
-                </div>
-                <CancelOfferSection
-                  offerId={offer.id}
-                  initialStatus={data.status}
-                  initialCanceledAt={data.canceled_at}
-                />
-              </CardContent>
-            </Card>
-          </div>
-
-          <aside className="flex h-full flex-col" id="chat">
-            <OfferChatThread
-              offerId={offer.id}
-              currentUserId={user.id}
-              currentRole="store"
-              storeName={offer.storeName}
-              talentName={offer.performerName}
-              className="lg:h-[600px] lg:max-h-[70vh]"
-            />
-          </aside>
-        </div>
+        <StoreOfferProgressPanel
+          steps={steps}
+          initialActiveStep={activeStep}
+          offer={{
+            id: offer.id,
+            status: offer.status,
+            date: offer.date,
+            respondDeadline: offer.respondDeadline,
+            updatedAt: offer.updatedAt,
+            submittedAt: offer.submittedAt,
+            paid: offer.paid,
+            paidAt: offer.paidAt,
+            invoiceStatus: offer.invoiceStatus,
+            storeName: offer.storeName,
+            reward: offer.reward,
+          }}
+          invoice={invoiceData}
+          paymentLink={paymentLink}
+          cancelation={{ initialStatus: data.status as string, initialCanceledAt: data.canceled_at as string | null }}
+          message={{
+            offerId: offer.id,
+            currentUserId: user.id,
+            storeName: offer.storeName,
+            talentName: offer.performerName,
+          }}
+        />
       </div>
     </div>
   )

--- a/talentify-next-frontend/app/talent/offers/[id]/MessageCard.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/MessageCard.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import OfferChatThread from '@/components/offer/OfferChatThread'
+
+type MessageCardProps = {
+  offerId: string
+  currentUserId: string
+  storeName: string
+  talentName: string
+}
+
+export default function MessageCard({ offerId, currentUserId, storeName, talentName }: MessageCardProps) {
+  return (
+    <div id="offer-messages">
+      <OfferChatThread
+        offerId={offerId}
+        currentUserId={currentUserId}
+        currentRole="talent"
+        storeName={storeName}
+        talentName={talentName}
+        className="lg:max-h-[540px]"
+      />
+    </div>
+  )
+}
+

--- a/talentify-next-frontend/app/talent/offers/[id]/ProgressCard.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/ProgressCard.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import OfferProgressTracker from '@/components/offer/OfferProgressTracker'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import type { OfferProgressStep, OfferStepKey } from '@/utils/offerProgress'
+
+type ProgressCardProps = {
+  steps: OfferProgressStep[]
+  activeStep: OfferStepKey
+  onStepChange: (step: OfferStepKey) => void
+}
+
+export default function ProgressCard({ steps, activeStep, onStepChange }: ProgressCardProps) {
+  return (
+    <Card className="rounded-2xl border border-slate-200 shadow-sm">
+      <CardHeader className="space-y-1">
+        <CardTitle className="text-lg font-semibold text-slate-900">進捗状況</CardTitle>
+        <p className="text-sm text-muted-foreground">オファーの進行状況と各ステップの対応内容を確認できます。</p>
+      </CardHeader>
+      <CardContent className="pt-2">
+        <OfferProgressTracker steps={steps} selectedStep={activeStep} onStepSelect={onStepChange} />
+      </CardContent>
+    </Card>
+  )
+}
+

--- a/talentify-next-frontend/app/talent/offers/[id]/StepDetailCard.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/StepDetailCard.tsx
@@ -1,0 +1,321 @@
+'use client'
+
+import { useMemo, type ReactNode } from 'react'
+import Link from 'next/link'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import type { OfferProgressStatus, OfferStepKey } from '@/utils/offerProgress'
+import { format } from 'date-fns'
+import { ja } from 'date-fns/locale'
+
+type StepDetailCardProps = {
+  activeStep: OfferStepKey
+  activeStatus: OfferProgressStatus
+  offer: {
+    id: string
+    status: string
+    date: string | null
+    updatedAt: string
+    submittedAt: string | null
+    paid: boolean
+    paidAt: string | null
+    invoiceStatus: 'not_submitted' | 'submitted' | 'paid'
+  }
+  invoiceId: string | null
+  paymentLink?: string
+}
+
+type StepDetail = {
+  title: string
+  description: string
+  badge?: ReactNode
+  meta?: { label: string; value: string }[]
+  actions?: ReactNode[]
+  note?: ReactNode
+}
+
+const invoiceStatusText: Record<'not_submitted' | 'submitted' | 'paid', string> = {
+  not_submitted: '未提出',
+  submitted: '提出済み',
+  paid: '支払済み',
+}
+
+const statusDisplay = (status: string) => {
+  switch (status) {
+    case 'pending':
+      return { text: '承認待ち', badge: <Badge variant="outline" className="border-amber-200 bg-amber-50 text-amber-700">承認待ち</Badge> }
+    case 'accepted':
+      return { text: '承認済み', badge: <Badge variant="success">承認済み</Badge> }
+    case 'confirmed':
+      return { text: '来店予定', badge: <Badge variant="success">来店予定</Badge> }
+    case 'completed':
+      return { text: '完了', badge: <Badge variant="success">完了</Badge> }
+    case 'rejected':
+      return { text: '辞退済み', badge: <Badge variant="secondary">辞退済み</Badge> }
+    case 'canceled':
+      return { text: 'キャンセル済み', badge: <Badge variant="destructive">キャンセル済み</Badge> }
+    default:
+      return { text: '未承諾', badge: <Badge variant="secondary">未承諾</Badge> }
+  }
+}
+
+export default function StepDetailCard({ activeStep, activeStatus, offer, invoiceId, paymentLink }: StepDetailCardProps) {
+  const formattedSubmittedAt = useMemo(() => {
+    return offer.submittedAt
+      ? format(new Date(offer.submittedAt), 'yyyy/MM/dd HH:mm', { locale: ja })
+      : '未提出'
+  }, [offer.submittedAt])
+
+  const formattedUpdatedAt = useMemo(() => {
+    return format(new Date(offer.updatedAt), 'yyyy/MM/dd HH:mm', { locale: ja })
+  }, [offer.updatedAt])
+
+  const formattedVisitDate = useMemo(() => {
+    return offer.date ? format(new Date(offer.date), 'yyyy/MM/dd (EEE) HH:mm', { locale: ja }) : '未設定'
+  }, [offer.date])
+
+  const paymentCompletedLabel = useMemo(() => {
+    return offer.paidAt ? format(new Date(offer.paidAt), 'yyyy/MM/dd', { locale: ja }) : undefined
+  }, [offer.paidAt])
+
+  const detail = useMemo<StepDetail>(() => {
+    switch (activeStep) {
+      case 'offer_submitted':
+        return {
+          title: 'オファー提出',
+          description: '店舗からオファーが届きました。内容を確認して、承諾または辞退を選択してください。',
+          badge: activeStatus === 'complete' ? <Badge variant="success">完了</Badge> : undefined,
+          meta: [
+            { label: '提出日時', value: formattedSubmittedAt },
+            { label: '来店予定', value: formattedVisitDate },
+          ],
+          actions: [
+            <Button key="message" variant="outline" size="sm" asChild>
+              <a href="#offer-messages">メッセージを送る</a>
+            </Button>,
+          ],
+        }
+      case 'approval': {
+        const status = statusDisplay(offer.status)
+        let description = ''
+        switch (offer.status) {
+          case 'pending':
+            description = '承諾または辞退を選択してください。追加の質問があればメッセージで確認しましょう。'
+            break
+          case 'accepted':
+            description = '承諾済みです。店舗との連絡を取り、来店日時の最終確認を行いましょう。'
+            break
+          case 'confirmed':
+            description = '承認が完了し、来店準備へ進めます。必要事項をメッセージで共有してください。'
+            break
+          case 'rejected':
+            description = 'オファーを辞退済みです。他の案件を確認しましょう。'
+            break
+          case 'canceled':
+            description = '店舗によりオファーがキャンセルされました。状況をメッセージで確認してください。'
+            break
+          default:
+            description = '承認が完了しました。次のステップに進んでください。'
+            break
+        }
+        return {
+          title: '承認',
+          description,
+          badge: status.badge,
+          meta: [
+            { label: 'ステータス', value: status.text },
+            { label: '最終更新', value: formattedUpdatedAt },
+          ],
+          actions: [
+            <Button key="message" variant="outline" size="sm" asChild>
+              <a href="#offer-messages">メッセージを送る</a>
+            </Button>,
+          ],
+        }
+      }
+      case 'visit': {
+        let description = ''
+        if (offer.status === 'completed') {
+          description = '来店が完了しました。請求内容の作成に進みましょう。'
+        } else if (offer.status === 'confirmed') {
+          description = '来店日程が確定しています。当日の流れや準備事項を店舗と共有してください。'
+        } else if (offer.status === 'accepted') {
+          description = '承済みです。来店日時の調整を完了させ、必要事項を確認しましょう。'
+        } else if (offer.status === 'canceled') {
+          description = 'オファーがキャンセルされたため、来店は行われません。'
+        } else if (offer.status === 'rejected') {
+          description = '辞退済みのため、来店は予定されていません。'
+        } else {
+          description = '来店日時を調整し、詳細を店舗と共有しましょう。'
+        }
+        return {
+          title: '来店実施',
+          description,
+          badge: activeStatus === 'complete' ? <Badge variant="success">完了</Badge> : undefined,
+          meta: [
+            { label: '来店日時', value: formattedVisitDate },
+            { label: '最終更新', value: formattedUpdatedAt },
+          ],
+          actions: [
+            <Button key="message" variant="outline" size="sm" asChild>
+              <a href="#offer-messages">メッセージを送る</a>
+            </Button>,
+          ],
+        }
+      }
+      case 'invoice': {
+        let description = ''
+        if (!invoiceId) {
+          description = '来店が完了したら請求書を作成してください。提出が完了すると店舗に通知されます。'
+        } else if (offer.invoiceStatus === 'submitted') {
+          description = '請求書を提出済みです。支払い状況が更新されるまでお待ちください。'
+        } else if (offer.invoiceStatus === 'paid') {
+          description = '支払いが完了しました。取引内容を確認し、レビューをチェックしましょう。'
+        } else {
+          description = '請求書のステータスを確認してください。必要に応じて修正を行いましょう。'
+        }
+        const actions: ReactNode[] = []
+        if (!invoiceId) {
+          actions.push(
+            <Button key="create" size="sm" asChild>
+              <Link href={`/talent/invoices/new?offerId=${offer.id}`}>請求書を作成</Link>
+            </Button>,
+          )
+        } else {
+          actions.push(
+            <Button key="view" size="sm" variant="outline" asChild>
+              <Link href="/talent/invoices">請求書を確認</Link>
+            </Button>,
+          )
+        }
+        actions.push(
+          <Button key="message" variant="outline" size="sm" asChild>
+            <a href="#offer-messages">メッセージを送る</a>
+          </Button>,
+        )
+        let badge: ReactNode | undefined
+        if (offer.invoiceStatus === 'paid') {
+          badge = <Badge variant="success">支払済み</Badge>
+        } else if (offer.invoiceStatus === 'submitted') {
+          badge = <Badge>提出済み</Badge>
+        } else if (activeStatus === 'current') {
+          badge = (
+            <Badge variant="outline" className="border-amber-200 bg-amber-50 text-amber-700">
+              準備中
+            </Badge>
+          )
+        }
+        return {
+          title: '請求',
+          description,
+          badge,
+          meta: [
+            { label: '請求書', value: invoiceId ? '作成済み' : '未作成' },
+            { label: 'ステータス', value: invoiceStatusText[offer.invoiceStatus] },
+          ],
+          actions,
+          note:
+            invoiceId === null
+              ? '来店が完了してから請求書を作成してください。早めの提出で支払いもスムーズになります。'
+              : undefined,
+        }
+      }
+      case 'payment': {
+        const actions: ReactNode[] = []
+        if (paymentLink) {
+          actions.push(
+            <Button key="payment" size="sm" asChild>
+              <Link href={paymentLink}>支払い状況を確認</Link>
+            </Button>,
+          )
+        }
+        actions.push(
+          <Button key="message" variant="outline" size="sm" asChild>
+            <a href="#offer-messages">メッセージを送る</a>
+          </Button>,
+        )
+        let badge: ReactNode | undefined
+        if (offer.paid) {
+          badge = <Badge variant="success">完了</Badge>
+        } else if (activeStatus === 'current') {
+          badge = (
+            <Badge variant="outline" className="border-amber-200 bg-amber-50 text-amber-700">
+              支払い待ち
+            </Badge>
+          )
+        }
+        return {
+          title: '支払い',
+          description: offer.paid
+            ? '支払いが完了しました。入金内容を確認し、レビューが届くまでお待ちください。'
+            : '請求書の支払いを待っています。状況を確認し、必要であれば店舗に連絡しましょう。',
+          badge,
+          meta: [
+            { label: '支払い状況', value: offer.paid ? '完了' : '未完了' },
+            ...(paymentCompletedLabel ? [{ label: '支払い日', value: paymentCompletedLabel }] : []),
+          ],
+          actions,
+        }
+      }
+      case 'review':
+      default:
+        return {
+          title: 'レビュー',
+          description: '支払いが完了すると店舗からのレビューを確認できます。フィードバックを次回に活かしましょう。',
+          badge: activeStatus === 'complete' ? <Badge variant="success">完了</Badge> : undefined,
+          actions: [
+            <Button key="message" variant="outline" size="sm" asChild>
+              <a href="#offer-messages">メッセージを送る</a>
+            </Button>,
+          ],
+        }
+    }
+  }, [
+    activeStatus,
+    activeStep,
+    formattedSubmittedAt,
+    formattedUpdatedAt,
+    formattedVisitDate,
+    invoiceId,
+    offer.id,
+    offer.invoiceStatus,
+    offer.paid,
+    offer.status,
+    paymentCompletedLabel,
+    paymentLink,
+  ])
+
+  return (
+    <Card className="rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <CardHeader className="flex flex-col gap-2 border-b border-slate-100 p-6">
+        <div className="flex flex-wrap items-center gap-3">
+          <CardTitle className="text-lg font-semibold text-slate-900">{detail.title}</CardTitle>
+          {detail.badge}
+        </div>
+        <p className="text-sm text-muted-foreground">{detail.description}</p>
+      </CardHeader>
+      <CardContent className="space-y-6 p-6">
+        {detail.meta && detail.meta.length > 0 && (
+          <dl className="grid gap-4 text-sm sm:grid-cols-2">
+            {detail.meta.map(item => (
+              <div key={item.label} className="space-y-1">
+                <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{item.label}</dt>
+                <dd className="text-base font-semibold text-slate-900">{item.value}</dd>
+              </div>
+            ))}
+          </dl>
+        )}
+        {detail.actions && detail.actions.length > 0 && (
+          <div className="flex flex-wrap justify-end gap-2">
+            {detail.actions.map((action, index) => (
+              <div key={index} className="inline-flex">{action}</div>
+            ))}
+          </div>
+        )}
+        {detail.note && <div className="text-sm text-muted-foreground">{detail.note}</div>}
+      </CardContent>
+    </Card>
+  )
+}
+

--- a/talentify-next-frontend/app/talent/offers/[id]/TalentOfferProgressPanel.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/TalentOfferProgressPanel.tsx
@@ -1,40 +1,28 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
-import type { OfferProgressStep, OfferProgressStatus, OfferStepKey } from '@/utils/offerProgress'
 import { format } from 'date-fns'
 import { ja } from 'date-fns/locale'
+import type { OfferProgressStep, OfferProgressStatus, OfferStepKey } from '@/utils/offerProgress'
 import ProgressCard from './ProgressCard'
 import StepDetailCard from './StepDetailCard'
 import MessageCard from './MessageCard'
 
-interface StoreOfferProgressPanelProps {
+type TalentOfferProgressPanelProps = {
   steps: OfferProgressStep[]
   initialActiveStep: OfferStepKey
   offer: {
     id: string
     status: string
     date: string | null
-    respondDeadline: string | null
     updatedAt: string
     submittedAt: string | null
     paid: boolean
     paidAt: string | null
     invoiceStatus: 'not_submitted' | 'submitted' | 'paid'
-    storeName: string
-    reward: number | null
   }
-  invoice?: {
-    id: string
-    invoiceUrl: string | null
-    amount: number | null
-    status: string
-  } | null
+  invoiceId: string | null
   paymentLink?: string
-  cancelation: {
-    initialStatus: string
-    initialCanceledAt: string | null
-  }
   message: {
     offerId: string
     currentUserId: string
@@ -43,21 +31,14 @@ interface StoreOfferProgressPanelProps {
   }
 }
 
-const invoiceStatusText: Record<'not_submitted' | 'submitted' | 'paid', string> = {
-  not_submitted: '未提出',
-  submitted: '提出済み',
-  paid: '支払済み',
-}
-
-export default function StoreOfferProgressPanel({
+export default function TalentOfferProgressPanel({
   steps,
   initialActiveStep,
   offer,
-  invoice,
+  invoiceId,
   paymentLink,
-  cancelation,
   message,
-}: StoreOfferProgressPanelProps) {
+}: TalentOfferProgressPanelProps) {
   const [activeStep, setActiveStep] = useState<OfferStepKey>(initialActiveStep)
 
   useEffect(() => {
@@ -66,19 +47,13 @@ export default function StoreOfferProgressPanel({
 
   const formattedSubmittedAt = useMemo(() => {
     return offer.submittedAt
-      ? format(new Date(offer.submittedAt), 'yyyy/MM/dd HH:mm', { locale: ja })
+      ? `提出日時: ${format(new Date(offer.submittedAt), 'yyyy/MM/dd HH:mm', { locale: ja })}`
       : '提出日時: 未登録'
   }, [offer.submittedAt])
 
   const formattedVisitDate = useMemo(() => {
     return offer.date ? format(new Date(offer.date), 'yyyy/MM/dd (EEE) HH:mm', { locale: ja }) : '未設定'
   }, [offer.date])
-
-  const formattedRespondDeadline = useMemo(() => {
-    return offer.respondDeadline
-      ? format(new Date(offer.respondDeadline), 'yyyy/MM/dd', { locale: ja })
-      : null
-  }, [offer.respondDeadline])
 
   const paymentCompletedLabel = useMemo(() => {
     return offer.paidAt ? format(new Date(offer.paidAt), 'yyyy/MM/dd', { locale: ja }) : undefined
@@ -90,10 +65,7 @@ export default function StoreOfferProgressPanel({
         case 'offer_submitted':
           return { ...step, subLabel: formattedSubmittedAt }
         case 'approval':
-          return {
-            ...step,
-            subLabel: formattedRespondDeadline ? `承認期限: ${formattedRespondDeadline}` : '承認期限: 未設定',
-          }
+          return { ...step }
         case 'visit':
           return { ...step, subLabel: `来店予定: ${formattedVisitDate}` }
         case 'invoice':
@@ -107,23 +79,12 @@ export default function StoreOfferProgressPanel({
                 : `支払い状況: ${offer.paid ? '完了' : '未完了'}`,
           }
         case 'review':
-          return {
-            ...step,
-            subLabel: `レビュー: ${step.status === 'complete' ? '完了' : '未実施'}`,
-          }
+          return { ...step, subLabel: `レビュー: ${step.status === 'complete' ? '完了' : '未実施'}` }
         default:
           return step
       }
     })
-  }, [
-    steps,
-    formattedSubmittedAt,
-    formattedRespondDeadline,
-    formattedVisitDate,
-    offer.invoiceStatus,
-    offer.paid,
-    paymentCompletedLabel,
-  ])
+  }, [formattedSubmittedAt, formattedVisitDate, offer.invoiceStatus, offer.paid, paymentCompletedLabel, steps])
 
   const activeStatus: OfferProgressStatus = useMemo(() => {
     return progressSteps.find(step => step.key === activeStep)?.status ?? 'upcoming'
@@ -138,9 +99,8 @@ export default function StoreOfferProgressPanel({
             activeStep={activeStep}
             activeStatus={activeStatus}
             offer={offer}
-            invoice={invoice}
+            invoiceId={invoiceId}
             paymentLink={paymentLink}
-            cancelation={cancelation}
           />
         </div>
         <div className="lg:col-span-1">
@@ -155,3 +115,10 @@ export default function StoreOfferProgressPanel({
     </div>
   )
 }
+
+const invoiceStatusText: Record<'not_submitted' | 'submitted' | 'paid', string> = {
+  not_submitted: '未提出',
+  submitted: '提出済み',
+  paid: '支払済み',
+}
+

--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -1,21 +1,15 @@
 'use client'
 
-import { useCallback, useEffect, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useParams } from 'next/navigation'
 import { createClient } from '@/utils/supabase/client'
-import Link from 'next/link'
-import OfferChatThread from '@/components/offer/OfferChatThread'
 import OfferSummary from '@/components/offer/OfferSummary'
 import OfferPaymentStatusCard from '@/components/offer/OfferPaymentStatusCard'
-import OfferProgressTracker from '@/components/offer/OfferProgressTracker'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { getOfferProgress } from '@/utils/offerProgress'
-import type { OfferProgressStatus, OfferStepKey } from '@/utils/offerProgress'
-import { format } from 'date-fns'
-import { ja } from 'date-fns/locale'
 import { toast } from 'sonner'
+import TalentOfferProgressPanel from './TalentOfferProgressPanel'
 
 export default function TalentOfferPage() {
   const params = useParams<{ id: string }>()
@@ -25,7 +19,6 @@ export default function TalentOfferPage() {
   const [userId, setUserId] = useState<string | null>(null)
   const [actionLoading, setActionLoading] = useState<'accept' | 'decline' | null>(null)
   const [invoiceId, setInvoiceId] = useState<string | null>(null)
-  const [activeStep, setActiveStep] = useState<OfferStepKey>('offer_submitted')
 
   const loadOffer = useCallback(async () => {
     const { data } = await supabase
@@ -78,20 +71,6 @@ export default function TalentOfferPage() {
     init()
   }, [loadOffer, supabase])
 
-  useEffect(() => {
-    if (!offer) {
-      setActiveStep('offer_submitted')
-      return
-    }
-
-    const { current: currentStep } = getOfferProgress({
-      status: offer.status,
-      invoiceStatus: offer.invoiceStatus,
-      paid: offer.paid,
-    })
-    setActiveStep(currentStep)
-  }, [offer])
-
   if (!userId || !loaded) {
     return <p className="p-4">Loading...</p>
   }
@@ -110,7 +89,7 @@ export default function TalentOfferPage() {
       .eq('id', offer.id)
     if (error) {
       toast.error('承諾に失敗しました')
-      setOffer(prev => ({ ...prev, status: 'pending' }))
+      setOffer((prev: any) => ({ ...prev, status: 'pending' }))
     } else {
       await loadOffer()
     }
@@ -127,7 +106,7 @@ export default function TalentOfferPage() {
       .eq('id', offer.id)
     if (error) {
       toast.error('辞退に失敗しました')
-      setOffer(prev => ({ ...prev, status: 'pending' }))
+      setOffer((prev: any) => ({ ...prev, status: 'pending' }))
     } else {
       await loadOffer()
     }
@@ -136,401 +115,77 @@ export default function TalentOfferPage() {
 
   const showActions = ['accepted', 'confirmed', 'completed'].includes(offer.status)
   const paymentLink = showActions ? `/talent/offers/${offer.id}/payment` : undefined
-  const formattedUpdatedAt = format(new Date(offer.updatedAt), 'yyyy/MM/dd HH:mm', {
-    locale: ja,
-  })
-  const formattedSubmittedAt = offer.submittedAt
-    ? format(new Date(offer.submittedAt), 'yyyy/MM/dd HH:mm', { locale: ja })
-    : '未提出'
 
-  const statusDisplay = (() => {
-    switch (offer.status) {
-      case 'pending':
-        return {
-          text: '承認待ち',
-          badge: (
-            <Badge variant="outline" className="border-amber-200 bg-amber-50 text-amber-700">
-              承認待ち
-            </Badge>
-          ),
-        }
-      case 'accepted':
-        return { text: '承認済み', badge: <Badge variant="success">承認済み</Badge> }
-      case 'confirmed':
-        return { text: '来店予定', badge: <Badge variant="success">来店予定</Badge> }
-      case 'completed':
-        return { text: '完了', badge: <Badge variant="success">完了</Badge> }
-      case 'rejected':
-        return { text: '辞退済み', badge: <Badge variant="secondary">辞退済み</Badge> }
-      case 'canceled':
-        return { text: 'キャンセル済み', badge: <Badge variant="destructive">キャンセル済み</Badge> }
-      default:
-        return { text: '未承諾', badge: <Badge variant="secondary">未承諾</Badge> }
-    }
-  })()
-
-  const { steps } = getOfferProgress({
+  const { steps, current: currentStep } = getOfferProgress({
     status: offer.status,
     invoiceStatus: offer.invoiceStatus,
     paid: offer.paid,
   })
 
-  const formattedVisitDate = offer.date
-    ? format(new Date(offer.date), 'yyyy/MM/dd (EEE) HH:mm', { locale: ja })
-    : '未設定'
-  const submittedDateLabel = offer.submittedAt
-    ? format(new Date(offer.submittedAt), 'yyyy/MM/dd', { locale: ja })
-    : null
-  const approvalDeadlineLabel = offer.date
-    ? format(new Date(offer.date), 'yyyy/MM/dd', { locale: ja })
-    : null
-  const paymentCompletedLabel = offer.paidAt
-    ? format(new Date(offer.paidAt), 'yyyy/MM/dd', { locale: ja })
-    : undefined
-
-  type StepDetail = {
-    title: string
-    description: string
-    badge?: ReactNode
-    meta?: { label: string; value: string }[]
-    actions?: ReactNode[]
-    note?: ReactNode
-  }
-
-  const invoiceStatusText: Record<'not_submitted' | 'submitted' | 'paid', string> = {
-    not_submitted: '未提出',
-    submitted: '提出済み',
-    paid: '支払済み',
-  }
-
-  const progressSteps = steps.map(step => {
-    switch (step.key) {
-      case 'offer_submitted':
-        return { ...step, subLabel: submittedDateLabel ?? '未登録' }
-      case 'approval':
-        return {
-          ...step,
-          subLabel: approvalDeadlineLabel ? `期限: ${approvalDeadlineLabel}` : '期限: 未設定',
-        }
-      case 'visit':
-        return { ...step, subLabel: formattedVisitDate }
-      case 'invoice':
-        return { ...step, subLabel: invoiceStatusText[offer.invoiceStatus] }
-      case 'payment':
-        return {
-          ...step,
-          subLabel: paymentCompletedLabel ?? (offer.paid ? '支払済み' : '未払い'),
-        }
-      case 'review':
-        return { ...step, subLabel: step.status === 'complete' ? '完了' : '未実施' }
-      default:
-        return step
-    }
-  })
-
-  const activeStepStatus = progressSteps.find(step => step.key === activeStep)?.status ?? 'upcoming'
-
-  const buildStepDetail = (step: OfferStepKey, status: OfferProgressStatus): StepDetail => {
-    switch (step) {
-      case 'offer_submitted':
-        return {
-          title: 'オファー提出',
-          description:
-            '店舗からオファーが届きました。内容を確認して、承諾または辞退を選択してください。',
-          badge: status === 'complete' ? <Badge variant="success">完了</Badge> : undefined,
-          meta: [
-            { label: '提出日時', value: formattedSubmittedAt },
-            { label: '来店予定', value: formattedVisitDate },
-          ],
-          actions: [
-            <Button key="message" variant="outline" size="sm" asChild>
-              <a href="#chat">メッセージを送る</a>
-            </Button>,
-          ],
-        }
-      case 'approval': {
-        let description = ''
-        switch (offer.status) {
-          case 'pending':
-            description = '承諾または辞退を選択してください。追加の質問があればメッセージで確認しましょう。'
-            break
-          case 'accepted':
-            description = '承諾済みです。店舗との連絡を取り、来店日時の最終確認を行いましょう。'
-            break
-          case 'confirmed':
-            description = '承認が完了し、来店準備へ進めます。必要事項をメッセージで共有してください。'
-            break
-          case 'rejected':
-            description = 'オファーを辞退済みです。他の案件を確認しましょう。'
-            break
-          case 'canceled':
-            description = '店舗によりオファーがキャンセルされました。状況をメッセージで確認してください。'
-            break
-          default:
-            description = '承認が完了しました。次のステップに進んでください。'
-            break
-        }
-        return {
-          title: '承認',
-          description,
-          badge: statusDisplay.badge,
-          meta: [
-            { label: 'ステータス', value: statusDisplay.text },
-            { label: '最終更新', value: formattedUpdatedAt },
-          ],
-          actions: [
-            <Button key="message" variant="outline" size="sm" asChild>
-              <a href="#chat">メッセージを送る</a>
-            </Button>,
-          ],
-        }
-      }
-      case 'visit': {
-        let description = ''
-        if (offer.status === 'completed') {
-          description = '来店が完了しました。請求内容の作成に進みましょう。'
-        } else if (offer.status === 'confirmed') {
-          description = '来店日程が確定しています。当日の流れや準備事項を店舗と共有してください。'
-        } else if (offer.status === 'accepted') {
-          description = '承諾済みです。来店日時の調整を完了させ、必要事項を確認しましょう。'
-        } else if (offer.status === 'canceled') {
-          description = 'オファーがキャンセルされたため、来店は行われません。'
-        } else if (offer.status === 'rejected') {
-          description = '辞退済みのため、来店は予定されていません。'
-        } else {
-          description = '来店日時を調整し、詳細を店舗と共有しましょう。'
-        }
-        return {
-          title: '来店実施',
-          description,
-          badge: status === 'complete' ? <Badge variant="success">完了</Badge> : undefined,
-          meta: [
-            { label: '来店日時', value: formattedVisitDate },
-            { label: '最終更新', value: formattedUpdatedAt },
-          ],
-          actions: [
-            <Button key="message" variant="outline" size="sm" asChild>
-              <a href="#chat">メッセージを送る</a>
-            </Button>,
-          ],
-        }
-      }
-      case 'invoice': {
-        let description = ''
-        if (!invoiceId) {
-          description = '来店が完了したら請求書を作成してください。提出が完了すると店舗に通知されます。'
-        } else if (offer.invoiceStatus === 'submitted') {
-          description = '請求書を提出済みです。支払い状況が更新されるまでお待ちください。'
-        } else if (offer.invoiceStatus === 'paid') {
-          description = '支払いが完了しました。取引内容を確認し、レビューをチェックしましょう。'
-        } else {
-          description = '請求書のステータスを確認してください。必要に応じて修正を行いましょう。'
-        }
-        const actions: ReactNode[] = []
-        if (!invoiceId) {
-          actions.push(
-            <Button key="create" size="sm" asChild>
-              <Link href={`/talent/invoices/new?offerId=${offer.id}`}>請求書を作成</Link>
-            </Button>,
-          )
-        } else {
-          actions.push(
-            <Button key="view" size="sm" variant="outline" asChild>
-              <Link href="/talent/invoices">請求書を確認</Link>
-            </Button>,
-          )
-        }
-        actions.push(
-          <Button key="message" variant="outline" size="sm" asChild>
-            <a href="#chat">メッセージを送る</a>
-          </Button>,
-        )
-        let badge: ReactNode | undefined
-        if (offer.invoiceStatus === 'paid') {
-          badge = <Badge variant="success">支払済み</Badge>
-        } else if (offer.invoiceStatus === 'submitted') {
-          badge = <Badge>提出済み</Badge>
-        } else if (status === 'current') {
-          badge = (
-            <Badge variant="outline" className="border-amber-200 bg-amber-50 text-amber-700">
-              準備中
-            </Badge>
-          )
-        }
-        return {
-          title: '請求',
-          description,
-          badge,
-          meta: [
-            { label: '請求書', value: invoiceId ? '作成済み' : '未作成' },
-            { label: 'ステータス', value: invoiceStatusText[offer.invoiceStatus] },
-          ],
-          actions,
-          note:
-            invoiceId === null
-              ? '来店が完了してから請求書を作成してください。早めの提出で支払いもスムーズになります。'
-              : undefined,
-        }
-      }
-      case 'payment': {
-        const actions: ReactNode[] = []
-        if (paymentLink) {
-          actions.push(
-            <Button key="payment" size="sm" asChild>
-              <Link href={paymentLink}>支払い状況を確認</Link>
-            </Button>,
-          )
-        }
-        actions.push(
-          <Button key="message" variant="outline" size="sm" asChild>
-            <a href="#chat">メッセージを送る</a>
-          </Button>,
-        )
-        let badge: ReactNode | undefined
-        if (offer.paid) {
-          badge = <Badge variant="success">完了</Badge>
-        } else if (status === 'current') {
-          badge = (
-            <Badge variant="outline" className="border-amber-200 bg-amber-50 text-amber-700">
-              支払い待ち
-            </Badge>
-          )
-        }
-        return {
-          title: '支払い',
-          description: offer.paid
-            ? '支払いが完了しました。入金内容を確認し、レビューが届くまでお待ちください。'
-            : '請求書の支払いを待っています。状況を確認し、必要であれば店舗に連絡しましょう。',
-          badge,
-          meta: [
-            { label: '支払い状況', value: offer.paid ? '完了' : '未完了' },
-            ...(offer.paidAt
-              ? [{ label: '支払い日', value: format(new Date(offer.paidAt), 'yyyy/MM/dd', { locale: ja }) }]
-              : []),
-          ],
-          actions,
-        }
-      }
-      case 'review':
-      default:
-        return {
-          title: 'レビュー',
-          description: '支払いが完了すると店舗からのレビューを確認できます。フィードバックを次回に活かしましょう。',
-          badge: status === 'complete' ? <Badge variant="success">完了</Badge> : undefined,
-          actions: [
-            <Button key="message" variant="outline" size="sm" asChild>
-              <a href="#chat">メッセージを送る</a>
-            </Button>,
-          ],
-        }
-    }
-  }
-
-  const detail = buildStepDetail(activeStep, activeStepStatus)
-
-
   return (
     <div className="p-4 sm:p-6 lg:p-8">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 lg:gap-8">
-        <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-          <div className="space-y-6">
-            <div className="space-y-2">
-              <h2 className="text-lg font-semibold text-slate-900">進捗状況</h2>
-              <p className="text-sm text-muted-foreground">オファーの進行状況と次に行うアクションを確認できます。</p>
-            </div>
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <div className="flex items-center gap-2">
-                {statusDisplay.badge}
-                <span className="text-xs text-muted-foreground">最終更新: {formattedUpdatedAt}</span>
-              </div>
-              <span className="text-xs text-muted-foreground">提出日時: {formattedSubmittedAt}</span>
-            </div>
-            <div className="w-full">
-              <OfferProgressTracker
-                steps={progressSteps}
-                selectedStep={activeStep}
-                onStepSelect={setActiveStep}
+        <TalentOfferProgressPanel
+          steps={steps}
+          initialActiveStep={currentStep}
+          offer={{
+            id: offer.id,
+            status: offer.status,
+            date: offer.date,
+            updatedAt: offer.updatedAt,
+            submittedAt: offer.submittedAt,
+            paid: offer.paid,
+            paidAt: offer.paidAt,
+            invoiceStatus: offer.invoiceStatus,
+          }}
+          invoiceId={invoiceId}
+          paymentLink={paymentLink}
+          message={{
+            offerId: offer.id,
+            currentUserId: userId,
+            storeName: offer.storeName,
+            talentName: offer.performerName,
+          }}
+        />
+
+        <div className="grid gap-6 lg:grid-cols-2">
+          <Card className="shadow-sm">
+            <CardHeader>
+              <CardTitle>オファー詳細</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <OfferSummary
+                performerName={offer.performerName}
+                performerAvatarUrl={offer.performerAvatarUrl}
+                storeName={offer.storeName}
+                date={offer.date}
+                message={offer.message}
+                invoiceStatus={offer.invoiceStatus}
               />
-            </div>
-            <div className="rounded-2xl border bg-card p-6 shadow-md">
-              <div className="flex flex-wrap items-center gap-2">
-                <h3 className="text-base font-semibold text-foreground">{detail.title}</h3>
-                {detail.badge}
-              </div>
-              <p className="mt-3 text-sm leading-relaxed text-muted-foreground">{detail.description}</p>
-              {detail.meta && detail.meta.length > 0 && (
-                <dl className="mt-4 grid gap-4 sm:grid-cols-2">
-                  {detail.meta.map(item => (
-                    <div key={item.label} className="space-y-1">
-                      <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{item.label}</dt>
-                      <dd className="text-sm font-semibold text-foreground">{item.value}</dd>
-                    </div>
-                  ))}
-                </dl>
-              )}
-              {detail.actions && detail.actions.length > 0 && (
-                <div className="mt-6 flex flex-wrap justify-end gap-2">
-                  {detail.actions.map((action, index) => (
-                    <div key={index} className="inline-flex">{action}</div>
-                  ))}
+              {offer.status === 'pending' && (
+                <div className="flex flex-wrap justify-end gap-2">
+                  <Button
+                    variant="default"
+                    size="sm"
+                    onClick={handleAccept}
+                    disabled={actionLoading !== null}
+                  >
+                    {actionLoading === 'accept' ? '承諾中...' : '承諾'}
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleDecline}
+                    disabled={actionLoading !== null}
+                  >
+                    {actionLoading === 'decline' ? '辞退中...' : '辞退'}
+                  </Button>
                 </div>
               )}
-              {detail.note && <div className="mt-4 text-sm text-muted-foreground">{detail.note}</div>}
-            </div>
-          </div>
-        </section>
+            </CardContent>
+          </Card>
 
-        <div className="grid gap-6 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)] lg:items-start lg:gap-8">
-          <div className="flex flex-col gap-6">
-            <Card className="shadow-sm">
-              <CardHeader>
-                <CardTitle>オファー詳細</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <OfferSummary
-                  performerName={offer.performerName}
-                  performerAvatarUrl={offer.performerAvatarUrl}
-                  storeName={offer.storeName}
-                  date={offer.date}
-                  message={offer.message}
-                  invoiceStatus={offer.invoiceStatus}
-                />
-                {offer.status === 'pending' && (
-                  <div className="flex flex-wrap justify-end gap-2">
-                    <Button
-                      variant="default"
-                      size="sm"
-                      onClick={handleAccept}
-                      disabled={actionLoading !== null}
-                    >
-                      {actionLoading === 'accept' ? '承諾中...' : '承諾'}
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={handleDecline}
-                      disabled={actionLoading !== null}
-                    >
-                      {actionLoading === 'decline' ? '辞退中...' : '辞退'}
-                    </Button>
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-
-            <OfferPaymentStatusCard paid={offer.paid} paidAt={offer.paidAt} />
-          </div>
-
-          <aside className="flex h-full flex-col" id="chat">
-            <OfferChatThread
-              offerId={offer.id}
-              currentUserId={userId}
-              currentRole="talent"
-              storeName={offer.storeName}
-              talentName={offer.performerName}
-              className="lg:h-[600px] lg:max-h-[70vh]"
-            />
-          </aside>
+          <OfferPaymentStatusCard paid={offer.paid} paidAt={offer.paidAt} />
         </div>
       </div>
     </div>

--- a/talentify-next-frontend/lib/offers/deriveActiveStep.ts
+++ b/talentify-next-frontend/lib/offers/deriveActiveStep.ts
@@ -1,0 +1,56 @@
+import type { OfferStepKey } from '@/utils/offerProgress'
+
+export type DeriveActiveStepParams = {
+  status: string
+  submittedAt?: string | null
+  acceptedAt?: string | null
+  visitScheduledAt?: string | null
+  visitDoneAt?: string | null
+  invoiceStatus: 'not_submitted' | 'submitted' | 'paid'
+  invoiceIssuedAt?: string | null
+  paid: boolean
+  paidAt?: string | null
+  reviewedAt?: string | null
+}
+
+/**
+ * Derives the most relevant active step for an offer based on the
+ * progression timestamps and status.
+ */
+export function deriveActiveStep({
+  status,
+  acceptedAt,
+  visitDoneAt,
+  visitScheduledAt,
+  invoiceStatus,
+  invoiceIssuedAt,
+  paid,
+  paidAt,
+  reviewedAt,
+}: DeriveActiveStepParams): OfferStepKey {
+  if (reviewedAt) {
+    return 'review'
+  }
+
+  if (paidAt || paid || invoiceStatus === 'paid') {
+    return 'payment'
+  }
+
+  if (invoiceIssuedAt || invoiceStatus === 'submitted') {
+    return 'invoice'
+  }
+
+  if (visitDoneAt || status === 'completed') {
+    return 'visit'
+  }
+
+  if (acceptedAt || ['accepted', 'confirmed'].includes(status)) {
+    return 'approval'
+  }
+
+  if (visitScheduledAt) {
+    return 'visit'
+  }
+
+  return 'offer_submitted'
+}


### PR DESCRIPTION
## Summary
- mirror the store-side progress panel refactor on the talent offer detail page with dedicated progress, detail, and message cards
- add a talent offer progress panel that derives the active step once and feeds the tracker, detail card, and chat message card
- simplify the talent offer page layout to use the new panel and keep a single source of truth for offer step messaging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9eca077948332a3407ab47359034c