### PR TITLE
Remove redundant cards from talent offer detail page

### DIFF
--- a/talentify-next-frontend/app/talent/offers/[id]/StepDetailCard.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/StepDetailCard.tsx
@@ -24,6 +24,9 @@ type StepDetailCardProps = {
   }
   invoiceId: string | null
   paymentLink?: string
+  onAcceptOffer?: () => void
+  onDeclineOffer?: () => void
+  actionLoading?: 'accept' | 'decline' | null
 }
 
 type StepDetail = {
@@ -60,7 +63,16 @@ const statusDisplay = (status: string) => {
   }
 }
 
-export default function StepDetailCard({ activeStep, activeStatus, offer, invoiceId, paymentLink }: StepDetailCardProps) {
+export default function StepDetailCard({
+  activeStep,
+  activeStatus,
+  offer,
+  invoiceId,
+  paymentLink,
+  onAcceptOffer,
+  onDeclineOffer,
+  actionLoading,
+}: StepDetailCardProps) {
   const formattedSubmittedAt = useMemo(() => {
     return offer.submittedAt
       ? format(new Date(offer.submittedAt), 'yyyy/MM/dd HH:mm', { locale: ja })
@@ -119,6 +131,40 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
             description = '承認が完了しました。次のステップに進んでください。'
             break
         }
+        const actions: ReactNode[] = []
+        if (offer.status === 'pending') {
+          if (onAcceptOffer) {
+            actions.push(
+              <Button
+                key="accept"
+                variant="default"
+                size="sm"
+                onClick={onAcceptOffer}
+                disabled={actionLoading !== null}
+              >
+                {actionLoading === 'accept' ? '承諾中...' : '承諾'}
+              </Button>,
+            )
+          }
+          if (onDeclineOffer) {
+            actions.push(
+              <Button
+                key="decline"
+                variant="outline"
+                size="sm"
+                onClick={onDeclineOffer}
+                disabled={actionLoading !== null}
+              >
+                {actionLoading === 'decline' ? '辞退中...' : '辞退'}
+              </Button>,
+            )
+          }
+        }
+        actions.push(
+          <Button key="message" variant="outline" size="sm" asChild>
+            <a href="#offer-messages">メッセージを送る</a>
+          </Button>,
+        )
         return {
           title: '承認',
           description,
@@ -127,11 +173,7 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
             { label: 'ステータス', value: status.text },
             { label: '最終更新', value: formattedUpdatedAt },
           ],
-          actions: [
-            <Button key="message" variant="outline" size="sm" asChild>
-              <a href="#offer-messages">メッセージを送る</a>
-            </Button>,
-          ],
+          actions,
         }
       }
       case 'visit': {
@@ -284,6 +326,9 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
     offer.status,
     paymentCompletedLabel,
     paymentLink,
+    onAcceptOffer,
+    onDeclineOffer,
+    actionLoading,
   ])
 
   return (

--- a/talentify-next-frontend/app/talent/offers/[id]/TalentOfferProgressPanel.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/TalentOfferProgressPanel.tsx
@@ -29,6 +29,9 @@ type TalentOfferProgressPanelProps = {
     storeName: string
     talentName: string
   }
+  onAcceptOffer?: () => void
+  onDeclineOffer?: () => void
+  actionLoading?: 'accept' | 'decline' | null
 }
 
 export default function TalentOfferProgressPanel({
@@ -38,6 +41,9 @@ export default function TalentOfferProgressPanel({
   invoiceId,
   paymentLink,
   message,
+  onAcceptOffer,
+  onDeclineOffer,
+  actionLoading,
 }: TalentOfferProgressPanelProps) {
   const [activeStep, setActiveStep] = useState<OfferStepKey>(initialActiveStep)
 
@@ -101,6 +107,9 @@ export default function TalentOfferProgressPanel({
             offer={offer}
             invoiceId={invoiceId}
             paymentLink={paymentLink}
+            onAcceptOffer={onAcceptOffer}
+            onDeclineOffer={onDeclineOffer}
+            actionLoading={actionLoading}
           />
         </div>
         <div className="lg:col-span-1">

--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -3,10 +3,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useParams } from 'next/navigation'
 import { createClient } from '@/utils/supabase/client'
-import OfferSummary from '@/components/offer/OfferSummary'
-import OfferPaymentStatusCard from '@/components/offer/OfferPaymentStatusCard'
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
 import { getOfferProgress } from '@/utils/offerProgress'
 import { toast } from 'sonner'
 import TalentOfferProgressPanel from './TalentOfferProgressPanel'
@@ -146,47 +142,10 @@ export default function TalentOfferPage() {
             storeName: offer.storeName,
             talentName: offer.performerName,
           }}
+          onAcceptOffer={handleAccept}
+          onDeclineOffer={handleDecline}
+          actionLoading={actionLoading}
         />
-
-        <div className="grid gap-6 lg:grid-cols-2">
-          <Card className="shadow-sm">
-            <CardHeader>
-              <CardTitle>オファー詳細</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <OfferSummary
-                performerName={offer.performerName}
-                performerAvatarUrl={offer.performerAvatarUrl}
-                storeName={offer.storeName}
-                date={offer.date}
-                message={offer.message}
-                invoiceStatus={offer.invoiceStatus}
-              />
-              {offer.status === 'pending' && (
-                <div className="flex flex-wrap justify-end gap-2">
-                  <Button
-                    variant="default"
-                    size="sm"
-                    onClick={handleAccept}
-                    disabled={actionLoading !== null}
-                  >
-                    {actionLoading === 'accept' ? '承諾中...' : '承諾'}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleDecline}
-                    disabled={actionLoading !== null}
-                  >
-                    {actionLoading === 'decline' ? '辞退中...' : '辞退'}
-                  </Button>
-                </div>
-              )}
-            </CardContent>
-          </Card>
-
-          <OfferPaymentStatusCard paid={offer.paid} paidAt={offer.paidAt} />
-        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- remove the redundant offer summary and payment status cards from the talent offer detail page so only the progress/detail/message layout remains
- pass offer response handlers into the progress panel so StepDetailCard now hosts the accept/decline actions for pending offers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da043896bc833285e00302800df912