### PR TITLE
Add due date selection to talent invoice flow

### DIFF
--- a/talentify-next-frontend/app/talent/invoices/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/invoices/[id]/page.tsx
@@ -45,7 +45,6 @@ export default function TalentInvoiceDetailPage() {
   const [loading, setLoading] = useState(true)
 
   const [invoiceNumber, setInvoiceNumber] = useState('')
-  const [dueDate, setDueDate] = useState('')
   const [notes, setNotes] = useState('')
 
   const [saving, setSaving] = useState(false)
@@ -63,7 +62,6 @@ export default function TalentInvoiceDetailPage() {
       const inv = data as Invoice | null
       setInvoice(inv)
       setInvoiceNumber(inv?.invoice_number ?? '')
-      setDueDate(inv?.due_date ?? '')
       setNotes(inv?.notes ?? '')
       setLoading(false)
     }
@@ -81,7 +79,6 @@ export default function TalentInvoiceDetailPage() {
       .from('invoices')
       .update({
         invoice_number: invoiceNumber || null,
-        due_date: dueDate || null,
         notes: notes || null,
       })
       .eq('id', id)
@@ -100,7 +97,6 @@ export default function TalentInvoiceDetailPage() {
       .from('invoices')
       .update({
         invoice_number: invoiceNumber || null,
-        due_date: dueDate || null,
         notes: notes || null,
       })
       .eq('id', id)
@@ -139,13 +135,7 @@ export default function TalentInvoiceDetailPage() {
           </div>
           <div>
             支払期限:{' '}
-            {invoice.status === 'draft' ? (
-              <Input type='date' value={dueDate} onChange={e => setDueDate(e.target.value)} />
-            ) : invoice.due_date ? (
-              formatJaDateTimeWithWeekday(invoice.due_date)
-            ) : (
-              '-'
-            )}
+            {invoice.due_date ? formatJaDateTimeWithWeekday(invoice.due_date) : '-'}
           </div>
           <div>
             ステータス:{' '}


### PR DESCRIPTION
## Summary
- add a due date pattern selector on the talent invoice creation screen and display the computed deadline
- send the calculated due_date to the invoice API for both draft/submit flows and PDF uploads
- keep the due date read-only on the invoice detail screen, including for draft invoices

## Testing
- npm run lint *(emits existing @next/next/no-img-element warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68de0122eb4c833280beb3b562dd2a9a