### PR TITLE
Handle Supabase error codes in invoice PATCH API

### DIFF
--- a/talentify-next-frontend/app/api/invoices/[id]/route.ts
+++ b/talentify-next-frontend/app/api/invoices/[id]/route.ts
@@ -54,7 +54,33 @@ export async function PATCH(
 
     return NextResponse.json(data, { status: 200 })
   } catch (e) {
-    console.error('[PATCH /invoices/:id]', e)
+    const error = e as { code?: string; message?: string; hint?: string }
+    const code = error?.code ?? 'UNKNOWN'
+    const message = error?.message ?? 'Internal Server Error'
+    const hint = error?.hint
+
+    console.error('[PATCH /invoices/:id]', { code, message, hint })
+
+    if (error?.code) {
+      const status =
+        error.code === '42501'
+          ? 403
+          : error.code === '23502' || error.code === '22007' || error.code === '22008'
+            ? 400
+            : 500
+
+      return NextResponse.json(
+        {
+          error: {
+            code: error.code,
+            message: error.message,
+            hint: error.hint ?? null,
+          },
+        },
+        { status },
+      )
+    }
+
     return new NextResponse('Internal Server Error', { status: 500 })
   }
 }


### PR DESCRIPTION
## Summary
- capture Supabase error code/message/hint when invoice updates fail
- map specific database error codes to 403/400 responses and log details

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de16991a2083329b4e15d13c59a568