### PR TITLE
Add review button to store offer review step

### DIFF
--- a/talentify-next-frontend/app/store/offers/[id]/StoreOfferProgressPanel.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/StoreOfferProgressPanel.tsx
@@ -23,6 +23,8 @@ interface StoreOfferProgressPanelProps {
     invoiceStatus: 'not_submitted' | 'submitted' | 'paid'
     storeName: string
     reward: number | null
+    talentId: string | null
+    reviewCompleted: boolean
   }
   invoice?: {
     id: string
@@ -109,7 +111,7 @@ export default function StoreOfferProgressPanel({
         case 'review':
           return {
             ...step,
-            subLabel: `レビュー: ${step.status === 'complete' ? '完了' : '未実施'}`,
+            subLabel: `レビュー: ${offer.reviewCompleted ? '完了' : '未実施'}`,
           }
         default:
           return step
@@ -123,6 +125,7 @@ export default function StoreOfferProgressPanel({
     offer.invoiceStatus,
     offer.paid,
     paymentCompletedLabel,
+    offer.reviewCompleted,
   ])
 
   const activeStatus: OfferProgressStatus = useMemo(() => {

--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -22,7 +22,7 @@ export default async function StoreOfferPage({ params }: PageProps) {
   const { data } = await supabase
     .from('offers')
     .select(
-      'id,status,date,respond_deadline,reward,created_at,updated_at,message,talent_id,user_id,canceled_at,accepted_at,paid,paid_at, talents(stage_name,avatar_url), stores(store_name)'
+      'id,status,date,respond_deadline,reward,created_at,updated_at,message,talent_id,user_id,canceled_at,accepted_at,paid,paid_at,reviews(id), talents(stage_name,avatar_url), stores(store_name)'
     )
     .eq('id', params.id)
     .single()
@@ -30,6 +30,8 @@ export default async function StoreOfferPage({ params }: PageProps) {
   if (!data || !user) {
     notFound()
   }
+
+  const reviewCompleted = Array.isArray((data as any).reviews) && (data as any).reviews.length > 0
 
   const { data: invoice } = await supabase
     .from('invoices')
@@ -59,6 +61,8 @@ export default async function StoreOfferPage({ params }: PageProps) {
     paidAt: data.paid_at as string | null,
     invoiceStatus,
     reward: data.reward as number | null,
+    talentId: data.talent_id as string | null,
+    reviewCompleted,
   }
 
   const invoiceData = invoice
@@ -77,6 +81,7 @@ export default async function StoreOfferPage({ params }: PageProps) {
     status: offer.status,
     invoiceStatus: offer.invoiceStatus,
     paid: offer.paid,
+    reviewCompleted: offer.reviewCompleted,
   })
 
   const activeStep = deriveActiveStep({
@@ -138,6 +143,8 @@ export default async function StoreOfferPage({ params }: PageProps) {
             invoiceStatus: offer.invoiceStatus,
             storeName: offer.storeName,
             reward: offer.reward,
+            talentId: offer.talentId,
+            reviewCompleted: offer.reviewCompleted,
           }}
           invoice={invoiceData}
           paymentLink={paymentLink}


### PR DESCRIPTION
## Summary
- fetch review completion state for store offer pages and pass it through progress panel components
- surface a "レビューする" button in the review step that opens the existing ReviewModal when payment is complete and a review is missing
- refresh the page after submitting a review so the progress indicators update automatically

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de2ff951e88332a01faed3786c2839