### PR TITLE
Revamp offer inbox tables with progress indicators

### DIFF
--- a/talentify-next-frontend/app/talent/offers/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/page.tsx
@@ -1,16 +1,19 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
 import { getOffersForTalent, TalentOffer } from '@/utils/getOffersForTalent'
-import { fetchStoreNamesForOffers } from '@/utils/storeName'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
-import { Badge } from '@/components/ui/badge'
-import { Input } from '@/components/ui/input'
 import { TableSkeleton } from '@/components/ui/skeleton'
 import { EmptyState } from '@/components/ui/empty-state'
-import { formatJaDateTimeWithWeekday } from '@/utils/formatJaDateTimeWithWeekday'
 import { toast } from 'sonner'
+import { format } from 'date-fns'
+import { ja } from 'date-fns/locale'
+import { ChevronDown, ChevronUp } from 'lucide-react'
+import { getOfferProgress } from '@/utils/offerProgress'
+import { OfferProgressStatusIcons } from '@/components/offer/OfferProgressStatusIcons'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
 
 const statusLabels: Record<string, string> = {
   pending: '保留中',
@@ -31,19 +34,13 @@ const statusVariants: Record<string, Parameters<typeof Badge>[0]['variant']> = {
 export default function TalentOffersPage() {
   const [offers, setOffers] = useState<TalentOffer[]>([])
   const [loading, setLoading] = useState(true)
-  const [statusFilter, setStatusFilter] = useState('all')
-  const [sortKey, setSortKey] = useState<'created_at' | 'date'>('created_at')
-  const [search, setSearch] = useState('')
-  const [storeNames, setStoreNames] = useState<Map<string, string>>(new Map())
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
 
   useEffect(() => {
     const load = async () => {
       try {
         const data = await getOffersForTalent()
         setOffers(data)
-        const ids = data.map(o => o.id)
-        const nameMap = await fetchStoreNamesForOffers(ids)
-        setStoreNames(nameMap)
       } catch (e) {
         console.error('failed to load offers', e)
         toast.error('オファーの取得に失敗しました')
@@ -54,47 +51,50 @@ export default function TalentOffersPage() {
     load()
   }, [])
 
-  const filtered = offers
-    .filter(o => (statusFilter === 'all' ? true : o.status === statusFilter))
-    .filter(o => (storeNames.get(o.id) ?? '').toLowerCase().includes(search.toLowerCase()))
+  const offersWithProgress = useMemo(() => {
+    return offers.map(offer => {
+      const { steps } = getOfferProgress({
+        status: offer.status ?? 'pending',
+        invoiceStatus: offer.invoice_status,
+        paid: Boolean(offer.paid),
+      })
 
-  const sorted = [...filtered].sort((a, b) => {
-    const aVal = a[sortKey] ? new Date(a[sortKey]!).getTime() : 0
-    const bVal = b[sortKey] ? new Date(b[sortKey]!).getTime() : 0
-    return bVal - aVal
-  })
+      return {
+        ...offer,
+        steps,
+      }
+    })
+  }, [offers])
+
+  const sorted = useMemo(() => {
+    return [...offersWithProgress].sort((a, b) => {
+      const aTime = a.date ? new Date(a.date).getTime() : sortOrder === 'asc' ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY
+      const bTime = b.date ? new Date(b.date).getTime() : sortOrder === 'asc' ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY
+
+      if (sortOrder === 'asc') {
+        return aTime - bTime
+      }
+      return bTime - aTime
+    })
+  }, [offersWithProgress, sortOrder])
+
+  const toggleSortOrder = () => {
+    setSortOrder(prev => (prev === 'asc' ? 'desc' : 'asc'))
+  }
+
+  const formatVisitDate = (value: string | null) => {
+    if (!value) return '未定'
+    try {
+      return format(new Date(value), 'yyyy/MM/dd (EEE)', { locale: ja })
+    } catch (error) {
+      console.error('failed to format visit date', error)
+      return '未定'
+    }
+  }
 
   return (
     <main className="p-4 md:p-6 space-y-4">
       <h1 className="text-xl font-bold">受信オファー一覧</h1>
-      <div className="flex flex-wrap gap-2 text-sm items-center">
-        <select
-          value={statusFilter}
-          onChange={e => setStatusFilter(e.target.value)}
-          className="border rounded p-1"
-        >
-          <option value="all">すべて</option>
-          <option value="pending">保留中</option>
-          <option value="confirmed">承諾済</option>
-          <option value="rejected">拒否</option>
-          <option value="completed">来店完</option>
-        </select>
-        <select
-          value={sortKey}
-          onChange={e => setSortKey(e.target.value as 'created_at' | 'date')}
-          className="border rounded p-1"
-        >
-          <option value="created_at">送信日</option>
-          <option value="date">来店日</option>
-        </select>
-        <Input
-          value={search}
-          onChange={e => setSearch(e.target.value)}
-          placeholder="検索"
-          className="w-40"
-        />
-      </div>
-
       {loading ? (
         <TableSkeleton rows={3} />
       ) : sorted.length === 0 ? (
@@ -105,32 +105,44 @@ export default function TalentOffersPage() {
             <Table>
               <TableHeader className="sticky top-0 bg-white">
                 <TableRow className="text-sm">
-                  <TableHead className="w-1/4">店舗名</TableHead>
-                  <TableHead className="w-1/6">オファー送信日</TableHead>
-                  <TableHead className="w-1/6">来店日</TableHead>
-                  <TableHead className="w-1/6">支払い状況</TableHead>
-                  <TableHead className="w-1/6">状態</TableHead>
-                  <TableHead className="w-1/12">操作</TableHead>
+                  <TableHead className="w-[160px]" aria-sort={sortOrder === 'asc' ? 'ascending' : 'descending'}>
+                    <button
+                      type="button"
+                      onClick={toggleSortOrder}
+                      className="inline-flex items-center gap-1 font-semibold text-slate-700 hover:text-[#2563EB]"
+                    >
+                      来店日
+                      {sortOrder === 'asc' ? (
+                        <ChevronUp className="h-4 w-4 text-[#2563EB]" aria-hidden="true" />
+                      ) : (
+                        <ChevronDown className="h-4 w-4 text-[#2563EB]" aria-hidden="true" />
+                      )}
+                      <span className="sr-only">来店日で並び替え</span>
+                    </button>
+                  </TableHead>
+                  <TableHead className="min-w-[200px]">店舗名</TableHead>
+                  <TableHead className="min-w-[320px]">オファー進捗</TableHead>
+                  <TableHead className="w-[120px] text-right">詳細</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {sorted.map(o => (
-                  <TableRow key={o.id} className="h-10">
-                    <TableCell className="truncate" title={storeNames.get(o.id) ?? ''}>{
-                      storeNames.get(o.id) ?? '-'
-                    }</TableCell>
-                    <TableCell>{formatJaDateTimeWithWeekday(o.created_at ?? '')}</TableCell>
-                    <TableCell>{o.date ? formatJaDateTimeWithWeekday(o.date) : '未定'}</TableCell>
-                    <TableCell>{o.paid ? '済' : '未'}</TableCell>
-                    <TableCell>
-                      <Badge variant={statusVariants[o.status ?? 'pending']}>
-                        {statusLabels[o.status ?? 'pending']}
-                      </Badge>
+                  <TableRow key={o.id} className="h-16 transition-colors hover:bg-slate-100/70">
+                    <TableCell className="align-middle">
+                      <div className="font-medium text-slate-900">{formatVisitDate(o.date)}</div>
                     </TableCell>
-                    <TableCell>
-                      <Link href={`/talent/offers/${o.id}`} className="text-blue-600 underline">
-                        詳細
-                      </Link>
+                    <TableCell className="align-middle">
+                      <div className="truncate text-slate-900" title={o.store_name ?? ''}>
+                        {o.store_name ?? '-'}
+                      </div>
+                    </TableCell>
+                    <TableCell className="align-middle">
+                      <OfferProgressStatusIcons steps={o.steps} />
+                    </TableCell>
+                    <TableCell className="align-middle text-right">
+                      <Button variant="ghost" size="sm" asChild className="text-[#2563EB] hover:bg-[#2563EB]/10">
+                        <Link href={`/talent/offers/${o.id}`}>詳細</Link>
+                      </Button>
                     </TableCell>
                   </TableRow>
                 ))}
@@ -138,26 +150,25 @@ export default function TalentOffersPage() {
             </Table>
           </div>
 
-          <div className="md:hidden space-y-2">
+          <div className="md:hidden space-y-3">
             {sorted.map(o => (
-              <div key={o.id} className="border rounded p-2 space-y-1">
-                <div className="flex justify-between items-center">
-                  <span className="font-medium truncate" title={storeNames.get(o.id) ?? ''}>{
-                    storeNames.get(o.id) ?? '-'
-                  }</span>
+              <div key={o.id} className="space-y-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+                <div className="flex items-center justify-between">
+                  <div className="text-sm font-medium text-slate-900">{formatVisitDate(o.date)}</div>
                   <Badge variant={statusVariants[o.status ?? 'pending']}>
                     {statusLabels[o.status ?? 'pending']}
                   </Badge>
                 </div>
-                <div className="text-sm space-y-0.5">
-                  <div>オファー送信日: {formatJaDateTimeWithWeekday(o.created_at ?? '')}</div>
-                  <div>来店日: {o.date ? formatJaDateTimeWithWeekday(o.date) : '未定'}</div>
-                  <div>支払い状況: {o.paid ? '済' : '未'}</div>
+                <div className="text-base font-semibold text-slate-900" title={o.store_name ?? ''}>
+                  {o.store_name ?? '-'}
+                </div>
+                <div className="-mx-1 overflow-x-auto">
+                  <OfferProgressStatusIcons steps={o.steps} className="mx-1 min-w-[360px]" />
                 </div>
                 <div className="flex justify-end">
-                  <Link href={`/talent/offers/${o.id}`} className="text-blue-600 underline text-sm">
-                    詳細
-                  </Link>
+                  <Button variant="ghost" size="sm" asChild className="text-[#2563EB] hover:bg-[#2563EB]/10">
+                    <Link href={`/talent/offers/${o.id}`}>詳細</Link>
+                  </Button>
                 </div>
               </div>
             ))}

--- a/talentify-next-frontend/components/offer/OfferProgressStatusIcons.tsx
+++ b/talentify-next-frontend/components/offer/OfferProgressStatusIcons.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { CheckCircle2, Circle, Loader2 } from 'lucide-react'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import type { OfferProgressStep } from '@/utils/offerProgress'
+import { OFFER_STEP_LABELS } from '@/utils/offerProgress'
+import { cn } from '@/lib/utils'
+
+const statusLabel: Record<OfferProgressStep['status'], string> = {
+  complete: '完了',
+  current: '進行中',
+  upcoming: '未了',
+}
+
+const iconContainerStyles: Record<OfferProgressStep['status'], string> = {
+  complete:
+    'border-[#16A34A] bg-[#16A34A]/10 text-[#16A34A] shadow-[0_0_0_1px_rgba(22,163,74,0.15)]',
+  current: 'border-[#2563EB] bg-[#2563EB]/10 text-[#2563EB] shadow-[0_0_0_1px_rgba(37,99,235,0.15)]',
+  upcoming: 'border-[#CBD5E1] bg-white text-[#CBD5E1]',
+}
+
+const iconByStatus: Record<OfferProgressStep['status'], ReactNode> = {
+  complete: <CheckCircle2 className="h-5 w-5" strokeWidth={2.2} />,
+  current: <Loader2 className="h-5 w-5 animate-spin" strokeWidth={2.2} />,
+  upcoming: <Circle className="h-3 w-3 fill-current" strokeWidth={2.2} />,
+}
+
+type OfferProgressStatusIconsProps = {
+  steps: OfferProgressStep[]
+  className?: string
+}
+
+export function OfferProgressStatusIcons({ steps, className }: OfferProgressStatusIconsProps) {
+  return (
+    <TooltipProvider delayDuration={0}>
+      <div className={cn('grid grid-cols-6 gap-2 sm:gap-3', className)}>
+        {steps.map(step => (
+          <Tooltip key={step.key}>
+            <TooltipTrigger asChild>
+              <span
+                className={cn(
+                  'flex h-10 w-10 items-center justify-center rounded-full border transition-colors',
+                  iconContainerStyles[step.status],
+                )}
+                aria-label={`${OFFER_STEP_LABELS[step.key]}: ${statusLabel[step.status]}`}
+              >
+                {iconByStatus[step.status]}
+                <span className="sr-only">
+                  {OFFER_STEP_LABELS[step.key]}: {statusLabel[step.status]}
+                </span>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent className="text-xs">
+              <div className="font-semibold text-slate-900">{OFFER_STEP_LABELS[step.key]}</div>
+              <div className="text-slate-500">{statusLabel[step.status]}</div>
+            </TooltipContent>
+          </Tooltip>
+        ))}
+      </div>
+    </TooltipProvider>
+  )
+}

--- a/talentify-next-frontend/utils/getOffersForStore.ts
+++ b/talentify-next-frontend/utils/getOffersForStore.ts
@@ -16,6 +16,8 @@ export type Offer = {
   paid?: boolean | null
   paid_at?: string | null
   payment_id?: string | null
+  invoice_status: 'not_submitted' | 'submitted' | 'paid'
+  review_completed: boolean
 }
 
 export async function getOffersForStore() {
@@ -34,7 +36,7 @@ export async function getOffersForStore() {
   const { data, error } = await supabase
     .from('offers')
     .select(
-      'id,user_id,store_id,talent_id,date,created_at,status,payments(id,status,paid_at),talents(stage_name)'
+      'id,user_id,store_id,talent_id,date,created_at,status,payments(id,status,paid_at),talents(stage_name),reviews(id)'
     )
     .eq('store_id', store.id)
     .order('created_at', { ascending: false })
@@ -44,17 +46,51 @@ export async function getOffersForStore() {
     return [] as Offer[]
   }
 
-  return (data ?? []).map((o: any) => ({
-    id: o.id,
-    user_id: o.user_id,
-    store_id: o.store_id,
-    talent_id: o.talent_id,
-    talent_name: o.talents?.stage_name ?? null,
-    created_at: o.created_at,
-    date: o.date,
-    status: o.status,
-    paid: o.payments?.status === 'completed',
-    paid_at: o.payments?.paid_at ?? null,
-    payment_id: o.payments?.id ?? null,
-  })) as Offer[]
+  const offers = (data ?? []) as any[]
+
+  let invoiceMap = new Map<string, { status: string | null; payment_status: string | null }>()
+  if (offers.length > 0) {
+    const { data: invoices, error: invoiceError } = await supabase
+      .from('invoices')
+      .select('offer_id,status,payment_status')
+      .in(
+        'offer_id',
+        offers.map(o => o.id)
+      )
+
+    if (invoiceError) {
+      console.error('failed to fetch invoices for store offers:', invoiceError)
+    } else if (Array.isArray(invoices)) {
+      invoiceMap = new Map(invoices.map(invoice => [invoice.offer_id, invoice]))
+    }
+  }
+
+  return offers.map(o => {
+    const payment = Array.isArray(o.payments) ? o.payments[0] : o.payments
+    const paymentStatus = payment?.status ?? null
+    const invoice = invoiceMap.get(o.id)
+    const invoiceStatus: 'not_submitted' | 'submitted' | 'paid' = invoice
+      ? paymentStatus === 'completed' || invoice.payment_status === 'paid'
+        ? 'paid'
+        : 'submitted'
+      : 'not_submitted'
+
+    const reviews = Array.isArray(o.reviews) ? o.reviews : []
+
+    return {
+      id: o.id,
+      user_id: o.user_id,
+      store_id: o.store_id,
+      talent_id: o.talent_id,
+      talent_name: o.talents?.stage_name ?? null,
+      created_at: o.created_at,
+      date: o.date,
+      status: o.status,
+      paid: paymentStatus === 'completed',
+      paid_at: payment?.paid_at ?? null,
+      payment_id: payment?.id ?? null,
+      invoice_status: invoiceStatus,
+      review_completed: reviews.length > 0,
+    }
+  }) as Offer[]
 }


### PR DESCRIPTION
## Summary
- redesign store and talent offer inbox tables to show visit date sort, progress icons, and mobile cards
- add shared offer progress status icon component for 6-step pipeline tooltips
- enrich offer fetchers with invoice and review metadata to drive progress state rendering

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df5f3177e48332ada6f233508287a6