### PR TITLE
Update offer progress timeline UI

### DIFF
--- a/talentify-next-frontend/app/store/offers/page.tsx
+++ b/talentify-next-frontend/app/store/offers/page.tsx
@@ -46,7 +46,7 @@ export default function StoreOffersPage() {
 
   const offersWithProgress = useMemo(() => {
     return offers.map(offer => {
-      const { steps } = getOfferProgress({
+      const { steps, badge } = getOfferProgress({
         status: offer.status ?? 'pending',
         invoiceStatus: offer.invoice_status,
         paid: Boolean(offer.paid),
@@ -56,6 +56,7 @@ export default function StoreOffersPage() {
       return {
         ...offer,
         steps,
+        badge,
       }
     })
   }, [offers])
@@ -129,7 +130,7 @@ export default function StoreOffersPage() {
                       <div className="truncate text-slate-900" title={o.talent_name ?? ''}>{o.talent_name ?? '-'}</div>
                     </TableCell>
                     <TableCell className="align-middle">
-                      <OfferProgressStatusIcons steps={o.steps} />
+                      <OfferProgressStatusIcons steps={o.steps} badge={o.badge} />
                     </TableCell>
                     <TableCell className="align-middle text-right">
                       <Button variant="ghost" size="sm" asChild className="text-[#2563EB] hover:bg-[#2563EB]/10">
@@ -155,7 +156,7 @@ export default function StoreOffersPage() {
                   {o.talent_name ?? '-'}
                 </div>
                 <div className="-mx-1 overflow-x-auto">
-                  <OfferProgressStatusIcons steps={o.steps} className="mx-1 min-w-[360px]" />
+                  <OfferProgressStatusIcons steps={o.steps} badge={o.badge} className="mx-1 min-w-[420px]" />
                 </div>
                 <div className="flex justify-end">
                   <Button variant="ghost" size="sm" asChild className="text-[#2563EB] hover:bg-[#2563EB]/10">

--- a/talentify-next-frontend/app/talent/offers/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/page.tsx
@@ -53,7 +53,7 @@ export default function TalentOffersPage() {
 
   const offersWithProgress = useMemo(() => {
     return offers.map(offer => {
-      const { steps } = getOfferProgress({
+      const { steps, badge } = getOfferProgress({
         status: offer.status ?? 'pending',
         invoiceStatus: offer.invoice_status,
         paid: Boolean(offer.paid),
@@ -62,6 +62,7 @@ export default function TalentOffersPage() {
       return {
         ...offer,
         steps,
+        badge,
       }
     })
   }, [offers])
@@ -137,7 +138,7 @@ export default function TalentOffersPage() {
                       </div>
                     </TableCell>
                     <TableCell className="align-middle">
-                      <OfferProgressStatusIcons steps={o.steps} />
+                      <OfferProgressStatusIcons steps={o.steps} badge={o.badge} />
                     </TableCell>
                     <TableCell className="align-middle text-right">
                       <Button variant="ghost" size="sm" asChild className="text-[#2563EB] hover:bg-[#2563EB]/10">
@@ -163,7 +164,7 @@ export default function TalentOffersPage() {
                   {o.store_name ?? '-'}
                 </div>
                 <div className="-mx-1 overflow-x-auto">
-                  <OfferProgressStatusIcons steps={o.steps} className="mx-1 min-w-[360px]" />
+                  <OfferProgressStatusIcons steps={o.steps} badge={o.badge} className="mx-1 min-w-[420px]" />
                 </div>
                 <div className="flex justify-end">
                   <Button variant="ghost" size="sm" asChild className="text-[#2563EB] hover:bg-[#2563EB]/10">

--- a/talentify-next-frontend/components/offer/OfferProgressStatusIcons.tsx
+++ b/talentify-next-frontend/components/offer/OfferProgressStatusIcons.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import type { ReactNode } from 'react'
-import { CheckCircle2, Circle, Loader2 } from 'lucide-react'
+import { ArrowRight, Check } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import type { OfferProgressStep } from '@/utils/offerProgress'
+import { Badge } from '@/components/ui/badge'
+import type { OfferProgressBadge, OfferProgressStep } from '@/utils/offerProgress'
 import { OFFER_STEP_LABELS } from '@/utils/offerProgress'
 import { cn } from '@/lib/utils'
 
@@ -13,50 +14,66 @@ const statusLabel: Record<OfferProgressStep['status'], string> = {
   upcoming: '未了',
 }
 
+const baseCircleStyles = 'flex h-8 w-8 items-center justify-center rounded-full'
+
 const iconContainerStyles: Record<OfferProgressStep['status'], string> = {
-  complete:
-    'border-[#16A34A] bg-[#16A34A]/10 text-[#16A34A] shadow-[0_0_0_1px_rgba(22,163,74,0.15)]',
-  current: 'border-[#2563EB] bg-[#2563EB]/10 text-[#2563EB] shadow-[0_0_0_1px_rgba(37,99,235,0.15)]',
-  upcoming: 'border-[#CBD5E1] bg-white text-[#CBD5E1]',
+  complete: 'bg-[#16A34A] text-white',
+  current: 'bg-[#2563EB] text-white',
+  upcoming: 'bg-slate-200 text-slate-500',
 }
 
 const iconByStatus: Record<OfferProgressStep['status'], ReactNode> = {
-  complete: <CheckCircle2 className="h-5 w-5" strokeWidth={2.2} />,
-  current: <Loader2 className="h-5 w-5 animate-spin" strokeWidth={2.2} />,
-  upcoming: <Circle className="h-3 w-3 fill-current" strokeWidth={2.2} />,
+  complete: <Check className="h-4 w-4" strokeWidth={2.2} />,
+  current: <ArrowRight className="h-4 w-4" strokeWidth={2.2} />,
+  upcoming: <span className="h-1.5 w-1.5 rounded-full bg-slate-500" />,
+}
+
+const STEP_SHORT_LABELS: Record<OfferProgressStep['key'], string> = {
+  offer_submitted: '提出',
+  approval: '承認',
+  visit: '来店',
+  invoice: '請求',
+  payment: '支払い',
+  review: 'レビュー',
 }
 
 type OfferProgressStatusIconsProps = {
   steps: OfferProgressStep[]
+  badge: OfferProgressBadge
   className?: string
 }
 
-export function OfferProgressStatusIcons({ steps, className }: OfferProgressStatusIconsProps) {
+export function OfferProgressStatusIcons({ steps, badge, className }: OfferProgressStatusIconsProps) {
   return (
     <TooltipProvider delayDuration={0}>
-      <div className={cn('grid grid-cols-6 gap-2 sm:gap-3', className)}>
-        {steps.map(step => (
-          <Tooltip key={step.key}>
-            <TooltipTrigger asChild>
-              <span
-                className={cn(
-                  'flex h-10 w-10 items-center justify-center rounded-full border transition-colors',
-                  iconContainerStyles[step.status],
-                )}
-                aria-label={`${OFFER_STEP_LABELS[step.key]}: ${statusLabel[step.status]}`}
-              >
-                {iconByStatus[step.status]}
-                <span className="sr-only">
-                  {OFFER_STEP_LABELS[step.key]}: {statusLabel[step.status]}
+      <div className={cn('flex items-start gap-3', className)}>
+        <Badge variant={badge.variant} className="shrink-0">
+          {badge.label}
+        </Badge>
+        <div className="grid flex-1 grid-cols-6 gap-2 sm:gap-3">
+          {steps.map(step => (
+            <Tooltip key={step.key}>
+              <TooltipTrigger asChild>
+                <span className="flex flex-col items-center gap-1">
+                  <span
+                    className={cn(baseCircleStyles, iconContainerStyles[step.status])}
+                    aria-label={`${OFFER_STEP_LABELS[step.key]}: ${statusLabel[step.status]}`}
+                  >
+                    {iconByStatus[step.status]}
+                    <span className="sr-only">
+                      {OFFER_STEP_LABELS[step.key]}: {statusLabel[step.status]}
+                    </span>
+                  </span>
+                  <span className="text-[11px] font-medium text-slate-500">{STEP_SHORT_LABELS[step.key]}</span>
                 </span>
-              </span>
-            </TooltipTrigger>
-            <TooltipContent className="text-xs">
-              <div className="font-semibold text-slate-900">{OFFER_STEP_LABELS[step.key]}</div>
-              <div className="text-slate-500">{statusLabel[step.status]}</div>
-            </TooltipContent>
-          </Tooltip>
-        ))}
+              </TooltipTrigger>
+              <TooltipContent className="text-xs">
+                <div className="font-semibold text-slate-900">{OFFER_STEP_LABELS[step.key]}</div>
+                <div className="text-slate-500">{statusLabel[step.status]}</div>
+              </TooltipContent>
+            </Tooltip>
+          ))}
+        </div>
       </div>
     </TooltipProvider>
   )

--- a/talentify-next-frontend/utils/offerProgress.ts
+++ b/talentify-next-frontend/utils/offerProgress.ts
@@ -15,6 +15,13 @@ export interface OfferProgressStep {
   subLabel?: string
 }
 
+export type OfferProgressBadgeVariant = 'default' | 'secondary' | 'success'
+
+export interface OfferProgressBadge {
+  label: string
+  variant: OfferProgressBadgeVariant
+}
+
 export const OFFER_STEP_LABELS: Record<OfferStepKey, string> = {
   offer_submitted: 'オファー提出',
   approval: '承認',
@@ -31,12 +38,59 @@ interface ProgressParams {
   reviewCompleted?: boolean
 }
 
+function resolveProgressBadge({
+  status,
+  invoiceStatus,
+  paid,
+  reviewCompleted,
+}: ProgressParams): OfferProgressBadge {
+  if ((paid || invoiceStatus === 'paid') && !reviewCompleted) {
+    return {
+      label: 'レビュー待ち',
+      variant: 'default',
+    }
+  }
+
+  if (paid || invoiceStatus === 'paid' || reviewCompleted) {
+    return {
+      label: '支払い済み',
+      variant: 'success',
+    }
+  }
+
+  if (status === 'completed') {
+    return {
+      label: '来店完了',
+      variant: 'success',
+    }
+  }
+
+  if (status === 'confirmed') {
+    return {
+      label: '来店予定',
+      variant: 'default',
+    }
+  }
+
+  if (status === 'accepted') {
+    return {
+      label: '承認済み',
+      variant: 'default',
+    }
+  }
+
+  return {
+    label: '承認待ち',
+    variant: 'secondary',
+  }
+}
+
 export function getOfferProgress({
   status,
   invoiceStatus,
   paid,
   reviewCompleted = false,
-}: ProgressParams): { steps: OfferProgressStep[]; current: OfferStepKey } {
+}: ProgressParams): { steps: OfferProgressStep[]; current: OfferStepKey; badge: OfferProgressBadge } {
   const order: OfferStepKey[] = [
     'offer_submitted',
     'approval',
@@ -80,5 +134,5 @@ export function getOfferProgress({
         : 'upcoming',
   }))
 
-  return { steps, current }
+  return { steps, current, badge: resolveProgressBadge({ status, invoiceStatus, paid, reviewCompleted }) }
 }


### PR DESCRIPTION
## Summary
- redesign the offer progress timeline with flat status indicators and step labels
- surface a contextual status badge next to the six-step progress display for store and talent offer lists
- derive shared badge metadata from offer progress state for consistent rendering

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df6dd0d8a08332955038b3742f3f4a