### PR TITLE
feat: add talent availability calendar

### DIFF
--- a/talentify-next-frontend/app/api/availability/bulk/route.ts
+++ b/talentify-next-frontend/app/api/availability/bulk/route.ts
@@ -1,0 +1,149 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { z } from 'zod'
+
+import { createClient } from '@/lib/supabase/server'
+
+const payloadSchema = z.object({
+  dates: z
+    .array(
+      z.object({
+        date: z
+          .string()
+          .refine((value) => !Number.isNaN(Date.parse(value)), 'date must be ISO'),
+        status: z.enum(['ok', 'ng']),
+      })
+    )
+    .min(1),
+})
+
+const DEFAULT_TIMEZONE = 'Asia/Tokyo'
+
+export async function POST(request: NextRequest) {
+  const body = await request.json().catch(() => null)
+
+  const parsed = payloadSchema.safeParse(body)
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid payload', details: parsed.error.flatten() },
+      { status: 400 }
+    )
+  }
+
+  const supabase = createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: talent, error: talentError } = await supabase
+    .from('talents')
+    .select('id')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (talentError) {
+    console.error('Failed to fetch talent for availability bulk update', talentError)
+    return NextResponse.json(
+      { error: 'Failed to fetch talent for availability bulk update' },
+      { status: 500 }
+    )
+  }
+
+  if (!talent) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const talentId = talent.id
+
+  const { data: settingsData, error: settingsError } = await supabase
+    .from('talent_availability_settings')
+    .select('default_mode')
+    .eq('talent_id', talentId)
+    .maybeSingle()
+
+  if (settingsError) {
+    console.error('Failed to load talent availability settings', settingsError)
+    return NextResponse.json(
+      { error: 'Failed to load talent availability settings' },
+      { status: 500 }
+    )
+  }
+
+  const defaultStatus =
+    (settingsData?.default_mode ?? 'default_ok') === 'default_ok' ? 'ok' : 'ng'
+
+  const toUpsert: {
+    talent_id: string
+    the_date: string
+    status: 'ok' | 'ng'
+  }[] = []
+  const toDelete: string[] = []
+
+  for (const item of parsed.data.dates) {
+    if (item.status === defaultStatus) {
+      toDelete.push(item.date)
+    } else {
+      toUpsert.push({
+        talent_id: talentId,
+        the_date: item.date,
+        status: item.status,
+      })
+    }
+  }
+
+  if (toUpsert.length > 0) {
+    const { error: upsertError } = await supabase
+      .from('talent_availability_dates')
+      .upsert(toUpsert, { onConflict: 'talent_id,the_date' })
+
+    if (upsertError) {
+      console.error('Failed to upsert availability dates', upsertError)
+      return NextResponse.json(
+        { error: 'Failed to upsert availability dates' },
+        { status: 500 }
+      )
+    }
+  }
+
+  if (toDelete.length > 0) {
+    const { error: deleteError } = await supabase
+      .from('talent_availability_dates')
+      .delete()
+      .eq('talent_id', talentId)
+      .in('the_date', toDelete)
+
+    if (deleteError) {
+      console.error('Failed to delete availability dates', deleteError)
+      return NextResponse.json(
+        { error: 'Failed to delete availability dates' },
+        { status: 500 }
+      )
+    }
+  }
+
+  // ensure default settings exist when first updating
+  if (!settingsData) {
+    const { error: insertSettingsError } = await supabase
+      .from('talent_availability_settings')
+      .upsert({
+        talent_id: talentId,
+        default_mode: 'default_ok',
+        timezone: DEFAULT_TIMEZONE,
+      })
+
+    if (insertSettingsError) {
+      console.error('Failed to initialize availability settings', insertSettingsError)
+      return NextResponse.json(
+        { error: 'Failed to initialize availability settings' },
+        { status: 500 }
+      )
+    }
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/talentify-next-frontend/app/api/availability/route.ts
+++ b/talentify-next-frontend/app/api/availability/route.ts
@@ -1,0 +1,97 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { z } from 'zod'
+
+import { createClient } from '@/lib/supabase/server'
+
+const querySchema = z.object({
+  talent_id: z.string().uuid('talent_id must be a valid UUID'),
+  from: z
+    .string()
+    .refine((value) => !Number.isNaN(Date.parse(value)), 'from must be a date'),
+  to: z
+    .string()
+    .refine((value) => !Number.isNaN(Date.parse(value)), 'to must be a date'),
+})
+
+export async function GET(request: NextRequest) {
+  const searchParams = Object.fromEntries(request.nextUrl.searchParams.entries())
+  const parsed = querySchema.safeParse(searchParams)
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid query parameters', details: parsed.error.flatten() },
+      { status: 400 }
+    )
+  }
+
+  const {
+    data: { user },
+  } = await createClient().auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { talent_id: talentId, from, to } = parsed.data
+
+  const supabase = createClient()
+
+  const { data: talent, error: talentError } = await supabase
+    .from('talents')
+    .select('id')
+    .eq('id', talentId)
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (talentError) {
+    console.error('Failed to verify talent ownership', talentError)
+    return NextResponse.json(
+      { error: 'Failed to verify talent ownership' },
+      { status: 500 }
+    )
+  }
+
+  if (!talent) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { data: settingsData, error: settingsError } = await supabase
+    .from('talent_availability_settings')
+    .select('default_mode, timezone')
+    .eq('talent_id', talentId)
+    .maybeSingle()
+
+  if (settingsError) {
+    console.error('Failed to fetch availability settings', settingsError)
+    return NextResponse.json(
+      { error: 'Failed to fetch availability settings' },
+      { status: 500 }
+    )
+  }
+
+  const { data: datesData, error: datesError } = await supabase
+    .from('talent_availability_dates')
+    .select('the_date, status')
+    .eq('talent_id', talentId)
+    .gte('the_date', from)
+    .lte('the_date', to)
+
+  if (datesError) {
+    console.error('Failed to fetch availability dates', datesError)
+    return NextResponse.json(
+      { error: 'Failed to fetch availability dates' },
+      { status: 500 }
+    )
+  }
+
+  return NextResponse.json({
+    settings: {
+      default_mode: settingsData?.default_mode ?? 'default_ok',
+      timezone: settingsData?.timezone ?? 'Asia/Tokyo',
+    },
+    dates: (datesData ?? []).map((row) => ({
+      date: row.the_date,
+      status: row.status,
+    })),
+  })
+}

--- a/talentify-next-frontend/app/api/availability/settings/route.ts
+++ b/talentify-next-frontend/app/api/availability/settings/route.ts
@@ -1,0 +1,120 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { z } from 'zod'
+
+import { createClient } from '@/lib/supabase/server'
+
+const DEFAULT_TIMEZONE = 'Asia/Tokyo'
+
+const payloadSchema = z.object({
+  default_mode: z.enum(['default_ok', 'default_ng']),
+  timezone: z.string().min(1).optional(),
+})
+
+export async function GET() {
+  const supabase = createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: talent, error: talentError } = await supabase
+    .from('talents')
+    .select('id')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (talentError) {
+    console.error('Failed to fetch talent for availability settings', talentError)
+    return NextResponse.json(
+      { error: 'Failed to fetch talent for availability settings' },
+      { status: 500 }
+    )
+  }
+
+  if (!talent) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { data: settings, error: settingsError } = await supabase
+    .from('talent_availability_settings')
+    .select('default_mode, timezone')
+    .eq('talent_id', talent.id)
+    .maybeSingle()
+
+  if (settingsError) {
+    console.error('Failed to fetch availability settings', settingsError)
+    return NextResponse.json(
+      { error: 'Failed to fetch availability settings' },
+      { status: 500 }
+    )
+  }
+
+  return NextResponse.json({
+    default_mode: settings?.default_mode ?? 'default_ok',
+    timezone: settings?.timezone ?? DEFAULT_TIMEZONE,
+  })
+}
+
+export async function POST(request: NextRequest) {
+  const supabase = createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const json = await request.json().catch(() => null)
+  const parsed = payloadSchema.safeParse(json)
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid payload', details: parsed.error.flatten() },
+      { status: 400 }
+    )
+  }
+
+  const { data: talent, error: talentError } = await supabase
+    .from('talents')
+    .select('id')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (talentError) {
+    console.error('Failed to fetch talent for availability settings update', talentError)
+    return NextResponse.json(
+      { error: 'Failed to fetch talent for availability settings update' },
+      { status: 500 }
+    )
+  }
+
+  if (!talent) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const timezone = parsed.data.timezone ?? DEFAULT_TIMEZONE
+
+  const { error: upsertError } = await supabase
+    .from('talent_availability_settings')
+    .upsert({
+      talent_id: talent.id,
+      default_mode: parsed.data.default_mode,
+      timezone,
+    })
+
+  if (upsertError) {
+    console.error('Failed to save availability settings', upsertError)
+    return NextResponse.json(
+      { error: 'Failed to save availability settings' },
+      { status: 500 }
+    )
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/talentify-next-frontend/types/supabase.ts
+++ b/talentify-next-frontend/types/supabase.ts
@@ -44,6 +44,60 @@ export type Database = {
         }
         Relationships: []
       }
+      talent_availability_dates: {
+        Row: {
+          created_at: string | null
+          id: string
+          status: 'ok' | 'ng'
+          talent_id: string
+          the_date: string
+          updated_at: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          id?: string
+          status: 'ok' | 'ng'
+          talent_id: string
+          the_date: string
+          updated_at?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          id?: string
+          status?: 'ok' | 'ng'
+          talent_id?: string
+          the_date?: string
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
+      talent_availability_settings: {
+        Row: {
+          created_at: string | null
+          default_mode: 'default_ok' | 'default_ng'
+          id: string
+          talent_id: string
+          timezone: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          default_mode: 'default_ok' | 'default_ng'
+          id?: string
+          talent_id: string
+          timezone?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          default_mode?: 'default_ok' | 'default_ng'
+          id?: string
+          talent_id?: string
+          timezone?: string | null
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
       companies: {
         Row: {
           id: string


### PR DESCRIPTION
## Summary
- replace the talent schedule page with a month calendar that overlays availability, shows offer badges, and supports optimistic toggles plus default mode controls
- add availability API routes for reading, bulk updating, and saving settings with Supabase auth checks
- extend Supabase types with talent availability tables to keep client and server logic type-safe

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df790804a48332898078275692b199