### PR TITLE
Implement availability merge helper

### DIFF
--- a/talentify-next-frontend/__tests__/mergeAvailability.test.ts
+++ b/talentify-next-frontend/__tests__/mergeAvailability.test.ts
@@ -1,0 +1,78 @@
+import { mergeAvailability } from '../lib/availability/mergeAvailability';
+
+describe('mergeAvailability', () => {
+  it('returns ok for each day when default mode is default_ok without exceptions', () => {
+    const from = new Date('2024-01-01T00:00:00+09:00');
+    const to = new Date('2024-01-03T00:00:00+09:00');
+
+    expect(
+      mergeAvailability({
+        defaultMode: 'default_ok',
+        dates: {},
+        from,
+        to,
+      }),
+    ).toEqual([
+      { date: '2024-01-01', status: 'ok' },
+      { date: '2024-01-02', status: 'ok' },
+      { date: '2024-01-03', status: 'ok' },
+    ]);
+  });
+
+  it('returns ng for each day when default mode is default_ng without exceptions', () => {
+    const from = new Date('2024-05-10T12:00:00+09:00');
+    const to = new Date('2024-05-11T12:00:00+09:00');
+
+    expect(
+      mergeAvailability({
+        defaultMode: 'default_ng',
+        dates: {},
+        from,
+        to,
+      }),
+    ).toEqual([
+      { date: '2024-05-10', status: 'ng' },
+      { date: '2024-05-11', status: 'ng' },
+    ]);
+  });
+
+  it('overrides default mode with provided date exceptions', () => {
+    const from = new Date('2024-06-01T00:00:00+09:00');
+    const to = new Date('2024-06-03T00:00:00+09:00');
+
+    expect(
+      mergeAvailability({
+        defaultMode: 'default_ok',
+        dates: {
+          '2024-06-02': 'ng',
+          '2024-06-03': 'ok',
+        },
+        from,
+        to,
+      }),
+    ).toEqual([
+      { date: '2024-06-01', status: 'ok' },
+      { date: '2024-06-02', status: 'ng' },
+      { date: '2024-06-03', status: 'ok' },
+    ]);
+  });
+
+  it('includes boundary days and handles timezone conversion to Asia/Tokyo', () => {
+    const from = new Date('2024-03-31T15:00:00Z'); // 2024-04-01T00:00:00+09:00
+    const to = new Date('2024-04-02T14:59:59Z'); // 2024-04-02T23:59:59+09:00
+
+    expect(
+      mergeAvailability({
+        defaultMode: 'default_ng',
+        dates: {
+          '2024-04-01': 'ok',
+        },
+        from,
+        to,
+      }),
+    ).toEqual([
+      { date: '2024-04-01', status: 'ok' },
+      { date: '2024-04-02', status: 'ng' },
+    ]);
+  });
+});

--- a/talentify-next-frontend/lib/availability/mergeAvailability.ts
+++ b/talentify-next-frontend/lib/availability/mergeAvailability.ts
@@ -1,0 +1,51 @@
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+
+export type IsoDateString = `${number}-${number}-${number}`;
+
+export type MergeAvailabilityParams = {
+  defaultMode: 'default_ok' | 'default_ng';
+  dates: Record<IsoDateString, 'ok' | 'ng'>;
+  from: Date;
+  to: Date;
+};
+
+export type MergedAvailabilityEntry = {
+  date: IsoDateString;
+  status: 'ok' | 'ng';
+};
+
+export type MergedAvailability = MergedAvailabilityEntry[];
+
+const TOKYO_TZ = 'Asia/Tokyo';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+export const mergeAvailability = ({
+  defaultMode,
+  dates,
+  from,
+  to,
+}: MergeAvailabilityParams): MergedAvailability => {
+  const defaultStatus: 'ok' | 'ng' = defaultMode === 'default_ok' ? 'ok' : 'ng';
+  const start = dayjs(from).tz(TOKYO_TZ).startOf('day');
+  const end = dayjs(to).tz(TOKYO_TZ).startOf('day');
+
+  const merged: MergedAvailability = [];
+
+  for (let current = start; !current.isAfter(end, 'day'); current = current.add(1, 'day')) {
+    const dateKey = current.format('YYYY-MM-DD') as IsoDateString;
+    const status = dates[dateKey] ?? defaultStatus;
+
+    merged.push({
+      date: dateKey,
+      status,
+    });
+  }
+
+  return merged;
+};
+
+export default mergeAvailability;

--- a/talentify-next-frontend/package-lock.json
+++ b/talentify-next-frontend/package-lock.json
@@ -22,6 +22,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^2.30.0",
+        "dayjs": "^1.11.18",
         "jspdf": "^2.5.1",
         "lucide-react": "^0.525.0",
         "next": "^13.5.11",
@@ -4865,9 +4866,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.13",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
-      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "version": "1.11.18",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.18.tgz",
+      "integrity": "sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==",
       "license": "MIT"
     },
     "node_modules/debug": {

--- a/talentify-next-frontend/package.json
+++ b/talentify-next-frontend/package.json
@@ -24,6 +24,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^2.30.0",
+    "dayjs": "^1.11.18",
     "jspdf": "^2.5.1",
     "lucide-react": "^0.525.0",
     "next": "^13.5.11",


### PR DESCRIPTION
## Summary
- add a reusable `mergeAvailability` helper that merges default modes with per-day overrides in the Asia/Tokyo timezone
- cover default, override, and boundary scenarios with dedicated Jest tests
- add the dayjs dependency to support timezone-aware date handling

## Testing
- npm test -- mergeAvailability

------
https://chatgpt.com/codex/tasks/task_e_68df7c56b8348332a1a760f0849f1479