### PR TITLE
Add availability filtering to talent search by date API

### DIFF
--- a/talentify-next-frontend/__tests__/search-talents-by-date.test.ts
+++ b/talentify-next-frontend/__tests__/search-talents-by-date.test.ts
@@ -9,7 +9,6 @@ describe('mergeTalentAvailability', () => {
   const baseTalent = (overrides: Partial<TalentRow> = {}): TalentRow => ({
     id: 'talent-1',
     stage_name: 'Stage Name',
-    display_name: 'Display Name',
     genre: 'Pop',
     area: 'Tokyo',
     avatar_url: 'https://example.com/avatar.png',
@@ -59,6 +58,7 @@ describe('mergeTalentAvailability', () => {
     expect(results[0]).toMatchObject({
       id: 'talent-ng-ok',
       availability_status: 'ok',
+      display_name: 'Stage Name',
       achievements: 'Recent achievements',
     })
   })

--- a/talentify-next-frontend/__tests__/search-talents-by-date.test.ts
+++ b/talentify-next-frontend/__tests__/search-talents-by-date.test.ts
@@ -1,0 +1,81 @@
+import {
+  mergeTalentAvailability,
+  type AvailabilityDateRow,
+  type AvailabilitySettingRow,
+  type TalentRow,
+} from '@/app/api/talents/search-by-date/route'
+
+describe('mergeTalentAvailability', () => {
+  const baseTalent = (overrides: Partial<TalentRow> = {}): TalentRow => ({
+    id: 'talent-1',
+    stage_name: 'Stage Name',
+    display_name: 'Display Name',
+    genre: 'Pop',
+    area: 'Tokyo',
+    avatar_url: 'https://example.com/avatar.png',
+    rate: 10000,
+    rating: 4.5,
+    bio: 'Performer bio',
+    media_appearance: 'Recent achievements',
+    ...overrides,
+  })
+
+  it('excludes talents when default_ok but the date is overridden to ng', () => {
+    const talents: TalentRow[] = [baseTalent({ id: 'talent-ok-ng' })]
+    const settings: AvailabilitySettingRow[] = [
+      { talent_id: 'talent-ok-ng', default_mode: 'default_ok' },
+    ]
+    const overrides: AvailabilityDateRow[] = [
+      { talent_id: 'talent-ok-ng', status: 'ng' },
+    ]
+
+    const results = mergeTalentAvailability({
+      talents,
+      availabilitySettings: settings,
+      availabilityDates: overrides,
+      confirmedTalentIds: new Set(),
+    })
+
+    expect(results).toHaveLength(0)
+  })
+
+  it('includes talents when default_ng but overridden to ok', () => {
+    const talents: TalentRow[] = [baseTalent({ id: 'talent-ng-ok' })]
+    const settings: AvailabilitySettingRow[] = [
+      { talent_id: 'talent-ng-ok', default_mode: 'default_ng' },
+    ]
+    const overrides: AvailabilityDateRow[] = [
+      { talent_id: 'talent-ng-ok', status: 'ok' },
+    ]
+
+    const results = mergeTalentAvailability({
+      talents,
+      availabilitySettings: settings,
+      availabilityDates: overrides,
+      confirmedTalentIds: new Set(),
+    })
+
+    expect(results).toHaveLength(1)
+    expect(results[0]).toMatchObject({
+      id: 'talent-ng-ok',
+      availability_status: 'ok',
+      achievements: 'Recent achievements',
+    })
+  })
+
+  it('excludes talents that already have a confirmed offer on the date', () => {
+    const talents: TalentRow[] = [baseTalent({ id: 'talent-confirmed' })]
+    const settings: AvailabilitySettingRow[] = [
+      { talent_id: 'talent-confirmed', default_mode: 'default_ok' },
+    ]
+
+    const results = mergeTalentAvailability({
+      talents,
+      availabilitySettings: settings,
+      availabilityDates: [],
+      confirmedTalentIds: new Set(['talent-confirmed']),
+    })
+
+    expect(results).toHaveLength(0)
+  })
+})

--- a/talentify-next-frontend/app/api/talents/search-by-date/route.ts
+++ b/talentify-next-frontend/app/api/talents/search-by-date/route.ts
@@ -14,7 +14,6 @@ export type TalentRow = Pick<
   Database['public']['Tables']['talents']['Row'],
   | 'id'
   | 'stage_name'
-  | 'display_name'
   | 'genre'
   | 'area'
   | 'avatar_url'
@@ -109,7 +108,7 @@ export function mergeTalentAvailability({
       return {
         id: talent.id,
         stage_name: talent.stage_name,
-        display_name: talent.display_name,
+        display_name: talent.stage_name ?? null,
         genre: talent.genre,
         area: talent.area,
         avatar_url: talent.avatar_url,
@@ -146,7 +145,7 @@ export async function GET(request: NextRequest) {
     supabase
       .from('talents')
       .select(
-        'id, stage_name, display_name, genre, area, avatar_url, rate, rating, bio, media_appearance'
+        'id, stage_name, genre, area, avatar_url, rate, rating, bio, media_appearance'
       )
       .eq('is_profile_complete', true),
     supabase.from('talent_availability_settings').select('talent_id, default_mode'),

--- a/talentify-next-frontend/app/api/talents/search-by-date/route.ts
+++ b/talentify-next-frontend/app/api/talents/search-by-date/route.ts
@@ -10,18 +10,20 @@ const querySchema = z.object({
     .regex(/^\d{4}-\d{2}-\d{2}$/),
 })
 
-export type TalentRow = Pick<
-  Database['public']['Tables']['talents']['Row'],
-  | 'id'
-  | 'stage_name'
-  | 'genre'
-  | 'area'
-  | 'avatar_url'
-  | 'rate'
-  | 'rating'
-  | 'bio'
-  | 'media_appearance'
->
+export type TalentRow =
+  Pick<
+    Database['public']['Tables']['talents']['Row'],
+    | 'id'
+    | 'stage_name'
+    | 'genre'
+    | 'area'
+    | 'avatar_url'
+    | 'rate'
+    | 'bio'
+    | 'media_appearance'
+  > & {
+    rating?: number | null
+  }
 
 export type AvailabilitySettingRow = Pick<
   Database['public']['Tables']['talent_availability_settings']['Row'],
@@ -113,7 +115,7 @@ export function mergeTalentAvailability({
         area: talent.area,
         avatar_url: talent.avatar_url,
         rate: talent.rate,
-        rating: talent.rating,
+        rating: talent.rating ?? null,
         bio: talent.bio,
         achievements: talent.media_appearance ?? null,
         availability_status: availabilityStatus,
@@ -145,7 +147,7 @@ export async function GET(request: NextRequest) {
     supabase
       .from('talents')
       .select(
-        'id, stage_name, genre, area, avatar_url, rate, rating, bio, media_appearance'
+        'id, stage_name, genre, area, avatar_url, rate, bio, media_appearance'
       )
       .eq('is_profile_complete', true),
     supabase.from('talent_availability_settings').select('talent_id, default_mode'),

--- a/talentify-next-frontend/app/api/talents/search-by-date/route.ts
+++ b/talentify-next-frontend/app/api/talents/search-by-date/route.ts
@@ -1,0 +1,205 @@
+import { createClient } from '@/lib/supabase/server'
+import type { Database } from '@/types/supabase'
+import { NextRequest } from 'next/server'
+import { z } from 'zod'
+import type { PostgrestError } from '@supabase/supabase-js'
+
+const querySchema = z.object({
+  date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/),
+})
+
+export type TalentRow = Pick<
+  Database['public']['Tables']['talents']['Row'],
+  | 'id'
+  | 'stage_name'
+  | 'display_name'
+  | 'genre'
+  | 'area'
+  | 'avatar_url'
+  | 'rate'
+  | 'rating'
+  | 'bio'
+  | 'media_appearance'
+>
+
+export type AvailabilitySettingRow = Pick<
+  Database['public']['Tables']['talent_availability_settings']['Row'],
+  'talent_id' | 'default_mode'
+>
+
+export type AvailabilityDateRow = Pick<
+  Database['public']['Tables']['talent_availability_dates']['Row'],
+  'talent_id' | 'status'
+>
+
+type OfferRow = Pick<
+  Database['public']['Tables']['offers']['Row'],
+  'talent_id'
+>
+
+export type TalentSearchResult = {
+  id: string
+  stage_name: string | null
+  display_name: string | null
+  genre: string | null
+  area: string | null
+  avatar_url: string | null
+  rate: number | null
+  rating: number | null
+  bio: string | null
+  achievements: string | null
+  availability_status: 'ok' | 'ng'
+}
+
+export function computeAvailabilityStatus({
+  defaultMode,
+  overrideStatus,
+  hasConfirmedOffer,
+}: {
+  defaultMode: AvailabilitySettingRow['default_mode']
+  overrideStatus?: AvailabilityDateRow['status']
+  hasConfirmedOffer: boolean
+}): 'ok' | 'ng' {
+  if (hasConfirmedOffer) {
+    return 'ng'
+  }
+
+  if (overrideStatus) {
+    return overrideStatus
+  }
+
+  return defaultMode === 'default_ok' ? 'ok' : 'ng'
+}
+
+export function mergeTalentAvailability({
+  talents,
+  availabilitySettings,
+  availabilityDates,
+  confirmedTalentIds,
+}: {
+  talents: TalentRow[]
+  availabilitySettings: AvailabilitySettingRow[]
+  availabilityDates: AvailabilityDateRow[]
+  confirmedTalentIds: Set<string>
+}): TalentSearchResult[] {
+  const settingsMap = new Map<string, AvailabilitySettingRow['default_mode']>()
+  availabilitySettings.forEach(setting => {
+    settingsMap.set(setting.talent_id, setting.default_mode)
+  })
+
+  const overridesMap = new Map<string, AvailabilityDateRow['status']>()
+  availabilityDates.forEach(override => {
+    overridesMap.set(override.talent_id, override.status)
+  })
+
+  return talents
+    .map<TalentSearchResult>(talent => {
+      const defaultMode = settingsMap.get(talent.id) ?? 'default_ok'
+      const overrideStatus = overridesMap.get(talent.id)
+      const hasConfirmedOffer = confirmedTalentIds.has(talent.id)
+
+      const availabilityStatus = computeAvailabilityStatus({
+        defaultMode,
+        overrideStatus,
+        hasConfirmedOffer,
+      })
+
+      return {
+        id: talent.id,
+        stage_name: talent.stage_name,
+        display_name: talent.display_name,
+        genre: talent.genre,
+        area: talent.area,
+        avatar_url: talent.avatar_url,
+        rate: talent.rate,
+        rating: talent.rating,
+        bio: talent.bio,
+        achievements: talent.media_appearance ?? null,
+        availability_status: availabilityStatus,
+      }
+    })
+    .filter(talent => talent.availability_status === 'ok')
+}
+
+type QueryResult<T> = {
+  data: T | null
+  error: PostgrestError | null
+}
+
+export async function GET(request: NextRequest) {
+  const searchParams = Object.fromEntries(request.nextUrl.searchParams.entries())
+  const parsed = querySchema.safeParse(searchParams)
+
+  if (!parsed.success) {
+    return new Response(JSON.stringify({ error: 'Invalid or missing date parameter' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const supabase = await createClient()
+  const { date } = parsed.data
+
+  const [talentsRes, settingsRes, datesRes, offersRes] = (await Promise.all([
+    supabase
+      .from('talents')
+      .select(
+        'id, stage_name, display_name, genre, area, avatar_url, rate, rating, bio, media_appearance'
+      )
+      .eq('is_profile_complete', true),
+    supabase.from('talent_availability_settings').select('talent_id, default_mode'),
+    supabase
+      .from('talent_availability_dates')
+      .select('talent_id, status')
+      .eq('the_date', date),
+    supabase
+      .from('offers')
+      .select('talent_id')
+      .eq('status', 'confirmed')
+      .eq('date', date),
+  ])) as [
+    QueryResult<TalentRow[]>,
+    QueryResult<AvailabilitySettingRow[]>,
+    QueryResult<AvailabilityDateRow[]>,
+    QueryResult<OfferRow[]>,
+  ]
+
+  const { data: talents, error: talentsError } = talentsRes
+  const { data: availabilitySettings, error: settingsError } = settingsRes
+  const { data: availabilityDates, error: datesError } = datesRes
+  const { data: confirmedOffers, error: offersError } = offersRes
+
+  if (talentsError || settingsError || datesError || offersError) {
+    console.error('Failed to load talents by date', {
+      talentsError,
+      settingsError,
+      datesError,
+      offersError,
+    })
+    return new Response(JSON.stringify({ error: 'Failed to load talents' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const confirmedTalentIds = new Set<string>()
+  confirmedOffers?.forEach(offer => {
+    if (offer.talent_id) {
+      confirmedTalentIds.add(offer.talent_id)
+    }
+  })
+
+  const results = mergeTalentAvailability({
+    talents: talents ?? [],
+    availabilitySettings: availabilitySettings ?? [],
+    availabilityDates: availabilityDates ?? [],
+    confirmedTalentIds,
+  })
+
+  return new Response(JSON.stringify(results), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}


### PR DESCRIPTION
## Summary
- add a `/api/talents/search-by-date` route that calculates talent availability for a requested date
- exclude talents marked as NG or holding confirmed offers while returning the availability status in the payload
- cover availability edge cases with unit tests for the merge logic

## Testing
- npm test -- --runTestsByPath __tests__/search-talents-by-date.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68df7ee3c708833285a81e5c539b4769