### PR TITLE
Normalize offer status handling and store joins

### DIFF
--- a/talentify-next-frontend/app/api/offers/[id]/route.ts
+++ b/talentify-next-frontend/app/api/offers/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { toDbOfferStatus } from '@/app/lib/offerStatus'
 
 export async function PUT(
   req: NextRequest,
@@ -52,6 +53,12 @@ export async function PUT(
     const updates: Record<string, any> = {}
     for (const field of allowedFields) {
       if (body[field] !== undefined) updates[field] = body[field]
+    }
+
+    if (updates.status !== undefined) {
+      const normalizedStatus = toDbOfferStatus(updates.status)
+      if (normalizedStatus) updates.status = normalizedStatus
+      else delete updates.status
     }
 
     if (Object.keys(updates).length === 0) {

--- a/talentify-next-frontend/app/api/offers/route.ts
+++ b/talentify-next-frontend/app/api/offers/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { toDbOfferStatus } from '@/app/lib/offerStatus'
 
 export const runtime = 'nodejs'
 
@@ -84,7 +85,7 @@ export async function POST(req: NextRequest) {
       time_range: body.time_range,
       agreed: body.agreed,
       message: body.message ?? '',
-      status: 'pending',
+      status: toDbOfferStatus('pending') ?? 'pending',
     })
     .select()
     .single()

--- a/talentify-next-frontend/app/api/talents/search-by-date/route.ts
+++ b/talentify-next-frontend/app/api/talents/search-by-date/route.ts
@@ -3,6 +3,7 @@ import type { Database } from '@/types/supabase'
 import { NextRequest } from 'next/server'
 import { z } from 'zod'
 import type { PostgrestError } from '@supabase/supabase-js'
+import { toDbOfferStatus } from '@/app/lib/offerStatus'
 
 const querySchema = z.object({
   date: z
@@ -143,6 +144,8 @@ export async function GET(request: NextRequest) {
   const supabase = await createClient()
   const { date } = parsed.data
 
+  const confirmedStatus = toDbOfferStatus('confirmed') ?? 'confirmed'
+
   const [talentsRes, settingsRes, datesRes, offersRes] = (await Promise.all([
     supabase
       .from('talents')
@@ -158,7 +161,7 @@ export async function GET(request: NextRequest) {
     supabase
       .from('offers')
       .select('talent_id')
-      .eq('status', 'confirmed')
+      .eq('status', confirmedStatus)
       .eq('date', date),
   ])) as [
     QueryResult<TalentRow[]>,

--- a/talentify-next-frontend/app/lib/offerStatus.ts
+++ b/talentify-next-frontend/app/lib/offerStatus.ts
@@ -1,0 +1,44 @@
+export type OfferStatusDb =
+  | 'offer_created'
+  | 'proposed'
+  | 'pending'
+  | 'confirmed'
+  | 'completed'
+  | 'canceled'
+  | 'no_show'
+  | 'rejected'
+  | 'expired'
+  | 'draft'
+
+const MAP_UI_TO_DB: Record<string, OfferStatusDb> = {
+  Draft: 'draft',
+  Proposed: 'proposed',
+  Pending: 'pending',
+  Confirmed: 'confirmed',
+  Completed: 'completed',
+  Cancelled: 'canceled',
+  canceled: 'canceled',
+  cancelled: 'canceled',
+  Canceled: 'canceled',
+  NoShow: 'no_show',
+  Rejected: 'rejected',
+  Expired: 'expired',
+  OfferCreated: 'offer_created',
+}
+
+export function toDbOfferStatus(
+  v?: string | null
+): OfferStatusDb | undefined {
+  if (!v) return undefined
+  const direct = MAP_UI_TO_DB[v]
+  if (direct) return direct
+  const lower = v.toLowerCase()
+  return MAP_UI_TO_DB[lower] ?? (lower as OfferStatusDb)
+}
+
+// 表示用（任意：DB→UI）
+export function toUiOfferStatus(v?: string | null): string | undefined {
+  if (!v) return undefined
+  if (v === 'canceled') return 'Cancelled'
+  return v.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
+}

--- a/talentify-next-frontend/app/store/offers/[id]/CancelOfferSection.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/CancelOfferSection.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react"
 import { useRouter } from "next/navigation"
 import { createClient } from "@/utils/supabase/client"
+import { toDbOfferStatus } from "@/app/lib/offerStatus"
 import { Button } from "@/components/ui/button"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { toast } from "sonner"
@@ -36,7 +37,7 @@ export default function CancelOfferSection({
       const { data, error } = await supabase
         .from("offers")
         .update({
-          status: "canceled",
+          status: toDbOfferStatus("canceled"),
           canceled_at: new Date().toISOString(),
           canceled_by_role: "store",
         })

--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -22,7 +22,11 @@ export default async function StoreOfferPage({ params }: PageProps) {
   const { data } = await supabase
     .from('offers')
     .select(
-      'id,status,date,respond_deadline,reward,created_at,updated_at,message,talent_id,user_id,canceled_at,accepted_at,paid,paid_at,reviews(id), talents(stage_name,avatar_url), stores(store_name)'
+      `
+      id,status,date,respond_deadline,reward,created_at,updated_at,message,talent_id,user_id,canceled_at,accepted_at,paid,paid_at,
+      reviews(id), talents(stage_name,avatar_url),
+      store:stores!offers_store_id_fkey(id, store_name, display_name)
+    `
     )
     .eq('id', params.id)
     .single()
@@ -55,7 +59,7 @@ export default async function StoreOfferPage({ params }: PageProps) {
     performerName: data.talents?.stage_name || '',
     performerAvatarUrl: data.talents?.avatar_url || null,
     acceptedAt: data.accepted_at as string | null,
-    storeName: data.stores?.store_name || '',
+    storeName: data.store?.display_name || data.store?.store_name || '',
     updatedAt: data.updated_at as string,
     paid: data.paid as boolean,
     paidAt: data.paid_at as string | null,

--- a/talentify-next-frontend/app/store/schedule/page.tsx
+++ b/talentify-next-frontend/app/store/schedule/page.tsx
@@ -17,6 +17,7 @@ import isSameDay from 'date-fns/isSameDay'
 import addMonths from 'date-fns/addMonths'
 import subMonths from 'date-fns/subMonths'
 import { createClient } from '@/utils/supabase/client'
+import { type OfferStatusDb, toDbOfferStatus } from '@/app/lib/offerStatus'
 import 'react-big-calendar/lib/css/react-big-calendar.css'
 import OfferModal from '@/components/modals/OfferModal'
 import { Badge } from '@/components/ui/badge'
@@ -108,6 +109,9 @@ export default function StoreSchedulePage() {
 
       const statusesQuery = ['confirmed', 'canceled', 'no_show']
       if (includeCompleted) statusesQuery.push('completed')
+      const normalizedStatuses = statusesQuery
+        .map(status => toDbOfferStatus(status))
+        .filter((status): status is OfferStatusDb => Boolean(status))
 
       const { data: store } = await supabase
         .from('stores')
@@ -122,7 +126,7 @@ export default function StoreSchedulePage() {
           'id, talent_id, date, status, start_time, notes, talents(stage_name)'
         )
         .eq('store_id', store.id)
-        .in('status', statusesQuery)
+        .in('status', normalizedStatuses)
 
       if (error) {
         console.error('Failed to fetch offers', error)

--- a/talentify-next-frontend/app/talent/invoices/new/page.tsx
+++ b/talentify-next-frontend/app/talent/invoices/new/page.tsx
@@ -62,7 +62,12 @@ export default function TalentInvoiceNewPage() {
       if (!offerId) return
       const { data: offerData } = await supabase
         .from('offers')
-        .select('id, date, reward, message, stores(store_name)')
+        .select(
+          `
+          id, date, reward, message,
+          store:stores!offers_store_id_fkey(id, store_name, display_name)
+        `
+        )
         .eq('id', offerId)
         .single()
       if (offerData) setOffer(offerData)
@@ -322,7 +327,10 @@ export default function TalentInvoiceNewPage() {
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="space-y-2 text-sm">
-              <div>店舗名: {offer?.stores?.store_name}</div>
+              <div>
+                店舗名:{' '}
+                {offer?.store?.display_name ?? offer?.store?.store_name ?? ''}
+              </div>
               <div>出演日: {formattedDate}</div>
               <div>予定報酬(目安): ¥{offer?.reward?.toLocaleString?.() ?? ''}</div>
               <div className="whitespace-pre-wrap">出演内容: {offer?.message}</div>

--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'next/navigation'
 import { createClient } from '@/utils/supabase/client'
 import { getOfferProgress } from '@/utils/offerProgress'
 import { toast } from 'sonner'
+import { toDbOfferStatus } from '@/app/lib/offerStatus'
 import TalentOfferProgressPanel from './TalentOfferProgressPanel'
 
 export default function TalentOfferPage() {
@@ -20,7 +21,11 @@ export default function TalentOfferPage() {
     const { data } = await supabase
       .from('offers')
       .select(
-        'id,status,date,updated_at,created_at,message,talent_id,user_id,paid,paid_at, talents(stage_name,avatar_url), stores(store_name)'
+        `
+        id,status,date,updated_at,created_at,message,talent_id,user_id,paid,paid_at,
+        talents(stage_name,avatar_url),
+        store:stores!offers_store_id_fkey(id, store_name, display_name)
+      `
       )
       .eq('id', params.id)
       .or('and(status.eq.canceled,accepted_at.not.is.null),status.neq.canceled')
@@ -43,7 +48,8 @@ export default function TalentOfferPage() {
         message: data.message,
         performerName: data.talents?.stage_name || '',
         performerAvatarUrl: data.talents?.avatar_url || null,
-        storeName: data.stores?.store_name || '',
+        storeName:
+          data.store?.display_name || data.store?.store_name || '',
         updatedAt: data.updated_at,
         submittedAt: data.created_at,
         paid: data.paid,
@@ -81,7 +87,7 @@ export default function TalentOfferPage() {
     setOffer({ ...offer, status: 'confirmed' })
     const { error } = await supabase
       .from('offers')
-      .update({ status: 'confirmed' })
+      .update({ status: toDbOfferStatus('confirmed') })
       .eq('id', offer.id)
     if (error) {
       toast.error('承諾に失敗しました')
@@ -98,7 +104,7 @@ export default function TalentOfferPage() {
     setOffer({ ...offer, status: 'rejected' })
     const { error } = await supabase
       .from('offers')
-      .update({ status: 'rejected' })
+      .update({ status: toDbOfferStatus('rejected') })
       .eq('id', offer.id)
     if (error) {
       toast.error('辞退に失敗しました')

--- a/talentify-next-frontend/utils/getCompletedOffersForStore.ts
+++ b/talentify-next-frontend/utils/getCompletedOffersForStore.ts
@@ -1,5 +1,6 @@
 'use client'
 import { createClient } from '@/utils/supabase/client'
+import { toDbOfferStatus } from '@/app/lib/offerStatus'
 
 const supabase = createClient()
 export type CompletedOffer = {
@@ -25,11 +26,13 @@ export async function getCompletedOffersForStore() {
     .single()
   if (!store) return [] as CompletedOffer[]
 
+  const completedStatus = toDbOfferStatus('completed') ?? 'completed'
+
   const { data, error } = await supabase
     .from('offers')
     .select('id, talent_id, store_id, date, message, reviews(id), talents(stage_name)')
     .eq('store_id', store.id)
-    .eq('status', 'completed')
+    .eq('status', completedStatus)
   if (error) {
     console.error('failed to fetch completed offers', error)
     return []

--- a/talentify-next-frontend/utils/getOffersForCompany.ts
+++ b/talentify-next-frontend/utils/getOffersForCompany.ts
@@ -23,7 +23,11 @@ export async function getOffersForCompany(): Promise<CompanyOffer[]> {
   const { data, error } = await supabase
     .from('offers')
     .select(
-      'id, status, date, reward, invoice_amount, invoice_date, agreed, invoice_submitted, payments(status,paid_at), talents(stage_name), stores(store_name)'
+      `
+      id, status, date, reward, invoice_amount, invoice_date, agreed, invoice_submitted,
+      payments(status,paid_at), talents(stage_name),
+      store:stores!offers_store_id_fkey(id, store_name, display_name)
+    `
     )
     .order('created_at', { ascending: false })
 
@@ -44,6 +48,6 @@ export async function getOffersForCompany(): Promise<CompanyOffer[]> {
     paid: o.payments?.status === 'completed',
     paid_at: o.payments?.paid_at ?? null,
     talent_name: o.talents?.stage_name ?? null,
-    store_name: o.stores?.store_name ?? null,
+    store_name: o.store?.display_name ?? o.store?.store_name ?? null,
   }))
 }

--- a/talentify-next-frontend/utils/getOffersForTalent.ts
+++ b/talentify-next-frontend/utils/getOffersForTalent.ts
@@ -32,6 +32,7 @@ const offerRowSchema = z.object({
     .object({
       id: z.string(),
       store_name: z.string().nullable(),
+      display_name: z.string().nullable(),
       is_setup_complete: z.boolean().nullable(),
     })
     .nullable(),
@@ -44,7 +45,10 @@ export async function getOffersForTalent() {
   const { data, error } = await supabase
     .from('offers')
     .select(
-      'id, store_id, created_at, date, status, payments(status,paid_at), store:store_id(id, store_name, is_setup_complete)'
+      `
+      id, store_id, created_at, date, status, payments(status,paid_at),
+      store:stores!offers_store_id_fkey(id, store_name, display_name, is_setup_complete)
+    `
     )
     .eq('talent_id', talentId)
     .or('and(status.eq.canceled,accepted_at.not.is.null),status.neq.canceled')
@@ -91,7 +95,8 @@ export async function getOffersForTalent() {
     return {
       id: o.id,
       store_id: o.store_id,
-      store_name: o.store?.store_name ?? null,
+      store_name:
+        o.store?.display_name ?? o.store?.store_name ?? null,
       created_at: o.created_at,
       date: o.date,
       status: o.status,

--- a/talentify-next-frontend/utils/getTalentSchedule.ts
+++ b/talentify-next-frontend/utils/getTalentSchedule.ts
@@ -7,6 +7,7 @@ export type TalentSchedule = {
 
 import { createClient } from '@/utils/supabase/client'
 import { getTalentId } from './getTalentId'
+import { toDbOfferStatus } from '@/app/lib/offerStatus'
 
 /**
  * Fetch confirmed schedules for the current talent user
@@ -16,11 +17,18 @@ export async function getTalentSchedule(): Promise<TalentSchedule[]> {
   const talentId = await getTalentId()
   if (!talentId) return []
 
+  const confirmedStatus = toDbOfferStatus('confirmed') ?? 'confirmed'
+
   const { data, error } = await supabase
     .from('offers')
-    .select('id, date, time_range, stores(store_name)')
+    .select(
+      `
+      id, date, time_range,
+      store:stores!offers_store_id_fkey(id, store_name, display_name)
+    `
+    )
     .eq('talent_id', talentId)
-    .eq('status', 'confirmed')
+    .eq('status', confirmedStatus)
     .order('date', { ascending: true })
 
   if (error) {
@@ -34,6 +42,6 @@ export async function getTalentSchedule(): Promise<TalentSchedule[]> {
     id: o.id,
     date: o.date,
     time_range: o.time_range,
-    store_name: o.stores?.store_name ?? null,
+    store_name: o.store?.display_name ?? o.store?.store_name ?? null,
   }))
 }


### PR DESCRIPTION
## Summary
- add a shared offer status normalization helper and use it before querying or mutating offer records
- update offer- and schedule-related queries to use the normalized status values and explicit store joins with display names
- adjust client handlers to rely on the normalized status helper when cancelling or updating offers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3593b85208332b9e8b42456558627