### PR TITLE
Fix offer store name selection

### DIFF
--- a/talentify-next-frontend/utils/getOffersForTalent.ts
+++ b/talentify-next-frontend/utils/getOffersForTalent.ts
@@ -31,7 +31,7 @@ const offerRowSchema = z.object({
   store: z
     .object({
       id: z.string(),
-      name: z.string().nullable(),
+      store_name: z.string().nullable(),
       is_setup_complete: z.boolean().nullable(),
     })
     .nullable(),
@@ -46,7 +46,7 @@ export async function getOffersForTalent() {
     .select(
       `
       id, store_id, created_at, date, status, payments(status,paid_at),
-      store:stores!offers_store_id_fkey(id, name, is_setup_complete)
+      store:stores!offers_store_id_fkey(id, store_name, is_setup_complete)
     `
     )
     .eq('talent_id', talentId)
@@ -91,7 +91,7 @@ export async function getOffersForTalent() {
         : 'submitted'
       : 'not_submitted'
 
-    const storeName = o.store?.name ?? null
+    const storeName = o.store?.store_name ?? null
 
     return {
       id: o.id,


### PR DESCRIPTION
## Summary
- update the offers query to select the stores.store_name field
- align the row schema and mapping with the store_name property so talent offers display a store label

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4857abcc083328d97a6f38ec54583