### PR TITLE
Update trigger documentation to reflect latest Supabase schema

### DIFF
--- a/supabase-docs/triggers.md
+++ b/supabase-docs/triggers.md
@@ -6,10 +6,10 @@
 | set_updated_at_invoices | invoices | BEFORE | UPDATE | update_updated_at_column |
 | set_updated_at_notifications | notifications | BEFORE | UPDATE | update_updated_at_column |
 | set_updated_at_on_notifications | notifications | BEFORE | UPDATE | update_updated_at_column |
+| set_participants_key | message_threads | BEFORE | INSERT OR UPDATE | normalize_participants_key |
 | set_updated_at_offers | offers | BEFORE | UPDATE | update_updated_at_column |
 | trg_notify_talent_on_offer_created | offers | AFTER | INSERT | notify_talent_on_offer_created |
-| trigger_notify_talent_on_offer_created | offers | AFTER | INSERT | notify_talent_on_offer_created |
-| trg_create_payment_on_offer_confirmed | offers | AFTER | UPDATE OF status | create_payment_on_offer_confirmed |
+| trg_create_payment_on_offer_confirmed | offers | AFTER | UPDATE | create_payment_on_offer_confirmed |
 | set_updated_at_payments | payments | BEFORE | UPDATE | update_updated_at_column |
 | trigger_notify_talent_on_payment_created | payments | AFTER | INSERT | notify_talent_on_payment_created |
 | set_updated_at_reviews | reviews | BEFORE | UPDATE | update_updated_at_column |
@@ -24,7 +24,13 @@
 | set_updated_at_talents | talents | BEFORE | UPDATE | update_updated_at_column |
 | set_updated_at_visits | visits | BEFORE | UPDATE | update_updated_at_column |
 | tr_check_filters | realtime.subscription | BEFORE | INSERT OR UPDATE | realtime.subscription_check_filters |
+| enforce_bucket_name_length_trigger | storage.buckets | BEFORE | INSERT OR UPDATE | storage.enforce_bucket_name_length |
+| objects_delete_delete_prefix | storage.objects | AFTER | DELETE | storage.delete_prefix_hierarchy_trigger |
+| objects_insert_create_prefix | storage.objects | BEFORE | INSERT | storage.objects_insert_prefix_trigger |
+| objects_update_create_prefix | storage.objects | BEFORE | UPDATE | storage.objects_update_prefix_trigger |
 | update_objects_updated_at | storage.objects | BEFORE | UPDATE | storage.update_updated_at_column |
+| prefixes_create_hierarchy | storage.prefixes | BEFORE | INSERT | storage.prefixes_insert_trigger |
+| prefixes_delete_hierarchy | storage.prefixes | AFTER | DELETE | storage.delete_prefix_hierarchy_trigger |
 
 ```
 drop trigger if exists trg_create_payment_on_offer_confirmed on public.offers;


### PR DESCRIPTION
## Summary
- document the normalize_participants_key trigger on message_threads
- update offer trigger details and list the current storage triggers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5e13298048332b63de79ae0d4bb25