### PR TITLE
refactor(api): migrate app/api auth lookups to getCurrentUser

### DIFF
--- a/talentify-next-frontend/app/api/availability/bulk/route.ts
+++ b/talentify-next-frontend/app/api/availability/bulk/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from 'next/server'
 import { z } from 'zod'
 
+import { getCurrentUser } from '@/lib/auth/getCurrentUser'
 import { createClient } from '@/lib/supabase/server'
 
 const payloadSchema = z.object({
@@ -32,9 +33,7 @@ export async function POST(request: NextRequest) {
 
   const supabase = createClient()
 
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  const { user } = await getCurrentUser()
 
   if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })

--- a/talentify-next-frontend/app/api/availability/route.ts
+++ b/talentify-next-frontend/app/api/availability/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from 'next/server'
 import { z } from 'zod'
 
+import { getCurrentUser } from '@/lib/auth/getCurrentUser'
 import { createClient } from '@/lib/supabase/server'
 
 const querySchema = z
@@ -32,9 +33,7 @@ export async function GET(request: NextRequest) {
 
   const supabase = createClient()
 
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  const { user } = await getCurrentUser()
 
   if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })

--- a/talentify-next-frontend/app/api/availability/settings/route.ts
+++ b/talentify-next-frontend/app/api/availability/settings/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from 'next/server'
 import { z } from 'zod'
 
+import { getCurrentUser } from '@/lib/auth/getCurrentUser'
 import { createClient } from '@/lib/supabase/server'
 
 const DEFAULT_TIMEZONE = 'Asia/Tokyo'
@@ -13,9 +14,7 @@ const payloadSchema = z.object({
 export async function GET() {
   const supabase = createClient()
 
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  const { user } = await getCurrentUser()
 
   if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -62,9 +61,7 @@ export async function GET() {
 export async function POST(request: NextRequest) {
   const supabase = createClient()
 
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  const { user } = await getCurrentUser()
 
   if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })

--- a/talentify-next-frontend/app/api/invoices/[id]/approve/route.ts
+++ b/talentify-next-frontend/app/api/invoices/[id]/approve/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { getCurrentUser } from '@/lib/auth/getCurrentUser'
 import { createClient } from '@/lib/supabase/server'
 
 export async function POST(
@@ -7,7 +8,7 @@ export async function POST(
 ) {
   try {
     const supabase = await createClient()
-    const { data: { user }, error: userError } = await supabase.auth.getUser()
+    const { user, error: userError } = await getCurrentUser()
     if (userError || !user) {
       return NextResponse.json<{ error: string }>({ error: '認証が必要です' }, { status: 401 })
     }

--- a/talentify-next-frontend/app/api/invoices/[id]/pay/route.ts
+++ b/talentify-next-frontend/app/api/invoices/[id]/pay/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { getCurrentUser } from '@/lib/auth/getCurrentUser'
 import { createClient } from '@/lib/supabase/server'
 import { createServiceClient } from '@/lib/supabase/service'
 
@@ -10,10 +11,7 @@ export async function POST(
   const { id } = params
 
   try {
-    const {
-      data: { user },
-      error: userError,
-    } = await supabase.auth.getUser()
+    const { user, error: userError } = await getCurrentUser()
     if (userError || !user) {
       return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
     }
@@ -87,4 +85,3 @@ export async function POST(
     return NextResponse.json({ error: 'unknown', code: err.code }, { status: 400 })
   }
 }
-

--- a/talentify-next-frontend/app/api/invoices/[id]/pdf/route.ts
+++ b/talentify-next-frontend/app/api/invoices/[id]/pdf/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { getCurrentUser } from '@/lib/auth/getCurrentUser'
 import { createClient } from '@/lib/supabase/server'
 import { PDFDocument, StandardFonts } from 'pdf-lib'
 
@@ -10,10 +11,7 @@ export async function GET(
   const { id } = params
 
   try {
-    const {
-      data: { user },
-      error: userError,
-    } = await supabase.auth.getUser()
+    const { user, error: userError } = await getCurrentUser()
     if (userError || !user) {
       return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
     }
@@ -114,4 +112,3 @@ export async function GET(
     return new NextResponse('Internal Server Error', { status: 500 })
   }
 }
-

--- a/talentify-next-frontend/app/api/invoices/[id]/reject/route.ts
+++ b/talentify-next-frontend/app/api/invoices/[id]/reject/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { getCurrentUser } from '@/lib/auth/getCurrentUser'
 import { createClient } from '@/lib/supabase/server'
 import { createServiceClient } from '@/lib/supabase/service'
 
@@ -8,7 +9,7 @@ export async function POST(
 ) {
   try {
     const supabase = await createClient()
-    const { data: { user }, error: userError } = await supabase.auth.getUser()
+    const { user, error: userError } = await getCurrentUser()
     if (userError || !user) {
       return NextResponse.json<{ error: string }>({ error: '認証が必要です' }, { status: 401 })
     }

--- a/talentify-next-frontend/app/api/invoices/[id]/route.ts
+++ b/talentify-next-frontend/app/api/invoices/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { getCurrentUser } from '@/lib/auth/getCurrentUser'
 import { createClient } from '@/lib/supabase/server'
 
 export async function PATCH(
@@ -7,7 +8,7 @@ export async function PATCH(
 ) {
   try {
     const supabase = await createClient()
-    const { data: { user }, error: userError } = await supabase.auth.getUser()
+    const { user, error: userError } = await getCurrentUser()
     if (userError || !user) {
       return NextResponse.json<{ error: string }>({ error: '認証が必要です' }, { status: 401 })
     }

--- a/talentify-next-frontend/app/api/invoices/[id]/submit/route.ts
+++ b/talentify-next-frontend/app/api/invoices/[id]/submit/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { getCurrentUser } from '@/lib/auth/getCurrentUser'
 import { createClient } from '@/lib/supabase/server'
 import { createServiceClient } from '@/lib/supabase/service'
 import { getSubmitStatus } from '../../utils'
@@ -11,10 +12,7 @@ export async function POST(
   const { id } = params
 
   try {
-    const {
-      data: { user },
-      error: userError,
-    } = await supabase.auth.getUser()
+    const { user, error: userError } = await getCurrentUser()
     if (userError || !user) {
       return NextResponse.json<{ error: string }>({ error: '認証が必要です' }, { status: 401 })
     }
@@ -84,4 +82,3 @@ export async function POST(
     return NextResponse.json<{ error: string }>({ error: '不明なエラー' }, { status: 400 })
   }
 }
-

--- a/talentify-next-frontend/app/api/invoices/route.ts
+++ b/talentify-next-frontend/app/api/invoices/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { getCurrentUser } from '@/lib/auth/getCurrentUser'
 import { createClient } from '@/lib/supabase/server'
 import { getSubmitStatus } from './utils'
 
@@ -7,10 +8,7 @@ export async function POST(req: NextRequest) {
   let offerId: string | undefined
 
   try {
-    const {
-      data: { user },
-      error: userError,
-    } = await supabase.auth.getUser()
+    const { user, error: userError } = await getCurrentUser()
     if (userError || !user) {
       return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
     }
@@ -125,4 +123,3 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'unknown', code: err.code }, { status: 400 })
   }
 }
-

--- a/talentify-next-frontend/app/api/messages/inbox/route.ts
+++ b/talentify-next-frontend/app/api/messages/inbox/route.ts
@@ -1,12 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { getCurrentUser } from '@/lib/auth/getCurrentUser'
 import { createClient } from '@/lib/supabase/server'
 
 export async function GET(req: NextRequest) {
   const supabase = await createClient()
-  const {
-    data: { user },
-    error: userError,
-  } = await supabase.auth.getUser()
+  const { user, error: userError } = await getCurrentUser()
   if (!user || userError) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }

--- a/talentify-next-frontend/app/api/schedule/route.ts
+++ b/talentify-next-frontend/app/api/schedule/route.ts
@@ -1,14 +1,12 @@
 import { createClient } from '@/lib/supabase/server'
+import { getCurrentUser } from '@/lib/auth/getCurrentUser'
 import { NextRequest } from 'next/server'
 
 export async function GET() {
   // awaitをつけてSupabaseクライアントを取得
   const supabase = await createClient()
 
-  const {
-    data: { user },
-    error: userError,
-  } = await supabase.auth.getUser()
+  const { user, error: userError } = await getCurrentUser()
 
   const query = supabase.from('schedules').select('*')
   if (user) query.eq('user_id', user.id)
@@ -29,10 +27,7 @@ export async function POST(req: NextRequest) {
   const body = await req.json()
   const { date, description } = body
 
-  const {
-    data: { user },
-    error: userError,
-  } = await supabase.auth.getUser()
+  const { user, error: userError } = await getCurrentUser()
 
   if (!user || userError) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })

--- a/talentify-next-frontend/app/api/talent/profile/route.ts
+++ b/talentify-next-frontend/app/api/talent/profile/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { getCurrentUser } from '@/lib/auth/getCurrentUser'
 
 export async function GET() {
   const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
+  const { user } = await getCurrentUser()
   if (!user) {
     return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
   }
@@ -20,7 +21,7 @@ export async function GET() {
 
 export async function PATCH(req: Request) {
   const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
+  const { user } = await getCurrentUser()
   if (!user) {
     return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
   }

--- a/talentify-next-frontend/app/api/talents/route.ts
+++ b/talentify-next-frontend/app/api/talents/route.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@/lib/supabase/server'
+import { getCurrentUser } from '@/lib/auth/getCurrentUser'
 import { isProfileComplete } from '@/utils/isProfileComplete'
 
 export async function GET() {
@@ -51,9 +52,7 @@ export async function POST(req: Request) {
     avatar_url,
   })
 
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  const { user } = await getCurrentUser()
 
   if (!user) {
     return new Response(JSON.stringify({ error: 'unauthenticated' }), {


### PR DESCRIPTION
### Motivation
- Unify Supabase auth retrieval across `app/api` routes by routing lookups through a single helper to make future Auth swaps simpler. 
- Keep changes minimal and non-invasive, preserving each route's existing unauthenticated responses and HTTP status codes. 

### Description
- Replaced direct `supabase.auth.getUser()` callsites with `getCurrentUser()` and added the corresponding import in the following API routes: `talents`, `talent/profile`, `schedule`, `availability`, `availability/bulk`, `availability/settings`, `messages/inbox`, `invoices`, `invoices/[id]`, `invoices/[id]/approve`, `invoices/[id]/reject`, `invoices/[id]/pay`, `invoices/[id]/pdf`, and `invoices/[id]/submit`.
- Maintained each route's original unauthenticated error messages and status codes (`401` / `'unauthorized'` / `'unauthenticated'` / `'認証が必要です'` etc.) and only changed the auth-fetch expression to return either `{ user }` or `{ user, error: userError }` as before.
- Did not modify the internals of `lib/auth/getCurrentUser.ts`; the helper still returns the same `{ user, error }` shape to keep the diff minimal and avoid over-abstraction.
- Left non-`app/api` callsites (UI components, other `app/*`, `components/*`, `lib/*`, `utils/*`) that still use `supabase.auth.getUser()` untouched as out-of-scope for this change.

### Testing
- Ran `npm run lint` in the frontend package and observed only pre-existing warnings unrelated to these changes (pass).
- Verified there are no remaining direct `auth.getUser()` calls under `app/api` using a repository search (pass).
- Performed basic file inspections of updated routes to ensure original unauthenticated branches and status codes were preserved (manual checks, pass).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d738e7c5988332aaa9ae8260814eda)