### PR TITLE
refactor(auth): consolidate shared P0 auth.getUser() via current-user helpers

### DIFF
--- a/talentify-next-frontend/lib/auth/getCurrentUser.ts
+++ b/talentify-next-frontend/lib/auth/getCurrentUser.ts
@@ -1,20 +1,12 @@
-import type { AuthError, User } from '@supabase/supabase-js'
 import { createClient } from '@/lib/supabase/server'
+import {
+  getCurrentUserWithClient,
+  type CurrentUserResult,
+} from '@/lib/auth/getCurrentUserWithClient'
 
-export type CurrentUserResult = {
-  user: User | null
-  error: AuthError | null
-}
+export type { CurrentUserResult }
 
 export async function getCurrentUser(): Promise<CurrentUserResult> {
   const supabase = createClient()
-  const {
-    data: { user },
-    error,
-  } = await supabase.auth.getUser()
-
-  return {
-    user,
-    error,
-  }
+  return getCurrentUserWithClient(supabase)
 }

--- a/talentify-next-frontend/lib/auth/getCurrentUserWithClient.ts
+++ b/talentify-next-frontend/lib/auth/getCurrentUserWithClient.ts
@@ -1,0 +1,20 @@
+import type { AuthError, SupabaseClient, User } from '@supabase/supabase-js'
+
+type AuthClient = Pick<SupabaseClient, 'auth'>
+
+export type CurrentUserResult = {
+  user: User | null
+  error: AuthError | null
+}
+
+export async function getCurrentUserWithClient(client: AuthClient): Promise<CurrentUserResult> {
+  const {
+    data: { user },
+    error,
+  } = await client.auth.getUser()
+
+  return {
+    user,
+    error,
+  }
+}

--- a/talentify-next-frontend/lib/getUserRole.ts
+++ b/talentify-next-frontend/lib/getUserRole.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import type { Database } from '@/types/supabase'
+import { getCurrentUserWithClient } from '@/lib/auth/getCurrentUserWithClient'
 
 export type UserRole = 'store' | 'talent' | 'company'
 
@@ -8,9 +9,7 @@ export async function getUserRoleInfo(
   userId: string,
 ): Promise<{ role: UserRole | null; name: string | null; isSetupComplete: boolean | null }> {
   // user_metadata に role が設定されている場合はそれを優先
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  const { user } = await getCurrentUserWithClient(supabase)
   const metaRole = (user?.user_metadata as any)?.role as UserRole | undefined
 
   const fetchRole = (

--- a/talentify-next-frontend/lib/queries/dashboard.ts
+++ b/talentify-next-frontend/lib/queries/dashboard.ts
@@ -2,12 +2,11 @@ import { createClient } from '@/lib/supabase/server'
 import type { ScheduleItem } from '@/components/ScheduleCard'
 import { toDbOfferStatus } from '@/app/lib/offerStatus'
 import { countUnreadNotificationsByUser } from '@/lib/repositories/notifications'
+import { getCurrentUser } from '@/lib/auth/getCurrentUser'
 
 export async function getTalentDashboardData() {
   const supabase = createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  const { user } = await getCurrentUser()
 
   if (!user) {
     return { pendingOffersCount: 0, unreadMessagesCount: 0, schedule: [] as ScheduleItem[] }
@@ -69,10 +68,7 @@ export async function getTalentDashboardData() {
 export async function getStoreDashboardData() {
   const supabase = createClient()
 
-  const {
-    data: { user },
-    error: userError,
-  } = await supabase.auth.getUser()
+  const { user, error: userError } = await getCurrentUser()
 
   if (userError || !user) {
     throw new Error('failed to fetch user session')

--- a/talentify-next-frontend/lib/supabase/offerMessages.ts
+++ b/talentify-next-frontend/lib/supabase/offerMessages.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient, RealtimeChannel } from '@supabase/supabase-js'
+import { getCurrentUserWithClient } from '@/lib/auth/getCurrentUserWithClient'
 
 export type Attachment = {
   path: string
@@ -44,9 +45,7 @@ export async function sendOfferMessage(
     attachments: Attachment[]
   }
 ): Promise<OfferMessage> {
-  const {
-    data: { user },
-  } = await client.auth.getUser()
+  const { user } = await getCurrentUserWithClient(client)
   if (!user) throw new Error('Not authenticated')
   const { data, error } = await client
     .from('offer_messages')
@@ -82,9 +81,7 @@ export function subscribeOfferMessages(
 }
 
 export async function upsertReadReceipt(client: SupabaseClient, offerId: string) {
-  const {
-    data: { user },
-  } = await client.auth.getUser()
+  const { user } = await getCurrentUserWithClient(client)
   if (!user) return
   await client.from('offer_read_receipts').upsert(
     {


### PR DESCRIPTION
### Motivation
- Reduce duplicated `auth.getUser()` calls in non-`app/api` common layers to make future Auth replacement points smaller while keeping API contracts stable. 
- Apply a minimal, low-risk change only to P0 shared files without touching Realtime logic or public function signatures. 

### Description
- Add a thin client-agnostic helper `lib/auth/getCurrentUserWithClient.ts` that accepts a Supabase client and returns `{ user, error }`. 
- Make existing `lib/auth/getCurrentUser.ts` delegate to the new `getCurrentUserWithClient` helper while preserving its `CurrentUserResult` export and external contract. 
- Replace direct `auth.getUser()` calls with helper usage in the three P0 shared files: `lib/getUserRole.ts`, `lib/queries/dashboard.ts`, and `lib/supabase/offerMessages.ts`, keeping all exported function signatures and return shapes unchanged. 
- Only authentication resolution was centralized; Realtime subscription logic in `offerMessages` and other query behaviors were left intact. 

### Testing
- Ran targeted lint on the changed files with `npm run lint -- --file lib/auth/getCurrentUser.ts --file lib/auth/getCurrentUserWithClient.ts --file lib/getUserRole.ts --file lib/queries/dashboard.ts --file lib/supabase/offerMessages.ts`, which produced no ESLint warnings or errors. 
- No other automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d73cc8fad8833283db4e417d7213e5)