### PR TITLE
refactor: use `getCurrentUserWithClient` in server libs (getServerUserRole, contracts)

### DIFF
--- a/talentify-next-frontend/lib/contracts.ts
+++ b/talentify-next-frontend/lib/contracts.ts
@@ -7,12 +7,11 @@ export type StoreContract = {
 }
 
 import { createClient } from '@/lib/supabase/server'
+import { getCurrentUserWithClient } from '@/lib/auth/getCurrentUserWithClient'
 
 export async function getContractsForStore(): Promise<StoreContract[]> {
-  const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  const supabase = createClient()
+  const { user } = await getCurrentUserWithClient(supabase)
   if (!user) return []
 
   const { data: store } = await supabase
@@ -44,7 +43,7 @@ export async function getContractsForStore(): Promise<StoreContract[]> {
       .eq('offer_id', offer.id)
       .maybeSingle()
 
-    const url = (offer as any).contract_url || null
+    const url = offer.contract_url ?? null
 
     results.push({
       offer_id: offer.id,

--- a/talentify-next-frontend/lib/getServerUserRole.ts
+++ b/talentify-next-frontend/lib/getServerUserRole.ts
@@ -1,11 +1,10 @@
 import { createClient } from '@/lib/supabase/server'
 import { getUserRoleInfo } from '@/lib/getUserRole'
+import { getCurrentUserWithClient } from '@/lib/auth/getCurrentUserWithClient'
 
 export async function getServerUserRole() {
-  const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  const supabase = createClient()
+  const { user } = await getCurrentUserWithClient(supabase)
   if (!user) {
     return { role: null, isSetupComplete: null }
   }


### PR DESCRIPTION
### Motivation
- Reduce direct `supabase.auth.getUser()` calls in non-`app/api` common libs by routing auth reads through the shared helper `getCurrentUserWithClient`.
- Keep changes minimal to limit future Auth replacement scope and avoid breaking public API contracts.
- Remove unsafe `as any` usage where trivial to do so.

### Description
- Replaced direct `supabase.auth.getUser()` usage with `getCurrentUserWithClient(supabase)` in `lib/getServerUserRole.ts`. The public function `getServerUserRole()` signature and return shape are unchanged.
- Replaced direct `supabase.auth.getUser()` usage with `getCurrentUserWithClient(supabase)` in `lib/contracts.ts` and removed `(offer as any).contract_url` in favor of `offer.contract_url ?? null` to eliminate `as any`.
- No new helper was added or modified; existing `lib/auth/getCurrentUserWithClient.ts` was reused as-is.

### Testing
- Ran ESLint for the modified files with `pnpm -C talentify-next-frontend exec eslint lib/getServerUserRole.ts lib/contracts.ts` and it passed.
- Ran TypeScript check with `pnpm -C talentify-next-frontend exec tsc --noEmit --pretty false` which failed due to pre-existing unrelated errors in other parts of the repo (tests/pages/prisma/types), not introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d73eea294c83329e51924a5073a759)