### PR TITLE
Fix header dropdown opacity and layout shift

### DIFF
--- a/talentify-next-frontend/app/globals.css
+++ b/talentify-next-frontend/app/globals.css
@@ -19,6 +19,10 @@
   }
 }
 
+html {
+  scrollbar-gutter: stable;
+}
+
 /* body全体の基本設定 */
 body {
   margin: 0;

--- a/talentify-next-frontend/components/ui/dropdown-menu.tsx
+++ b/talentify-next-frontend/components/ui/dropdown-menu.tsx
@@ -4,7 +4,9 @@ import { Check, ChevronRight, Circle } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-const DropdownMenu = DropdownMenuPrimitive.Root
+const DropdownMenu = ({ modal = false, ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) => (
+  <DropdownMenuPrimitive.Root modal={modal} {...props} />
+)
 
 const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
 
@@ -45,7 +47,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
+      "z-[60] min-w-[8rem] overflow-hidden rounded-md border border-slate-200 bg-white p-1 text-slate-900 opacity-100 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
       className
     )}
     {...props}
@@ -63,7 +65,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
+        "z-[60] max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border border-slate-200 bg-white p-1 text-slate-900 opacity-100 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
         className
       )}
       {...props}


### PR DESCRIPTION
### Motivation
- ヘッダーのドロップダウンが背景透けや z-index の問題で本文が透けて見えたり、ドロップダウン開閉時にヘッダーが横にズレるレイアウトシフトが発生していたため、見た目とレイアウトの安定化だけを最小変更で解消するための修正です。

### Description
- `DropdownMenu` をデフォルトで `modal={false}` にして Radix のスクロールロックを抑制し、ドロップダウン開閉時に `body` のスクロール状態が変更されないようにしました (横ズレ対策)。
- 共通ドロップダウンのコンポーネントでメニュー・サブメニューに対して `bg-white`, `opacity-100`, `border border-slate-200`, `shadow-lg`, `z-[60]` を明示的に指定し、不透明な白背景と薄い境界線で透けを解消しました。
- `html { scrollbar-gutter: stable; }` を `app/globals.css` に追加してスクロールバー領域を常に確保し、表示切替での横幅変化によるレイアウトシフトを抑えました。
- 変更したファイル: `talentify-next-frontend/components/ui/dropdown-menu.tsx`, `talentify-next-frontend/app/globals.css`.

### Testing
- `npm run lint` (`next lint`) を実行し成功しました（いくつかの画像タグに関する警告は出ていますがエラーではありません）。
- `npm run build` はこの環境で `prisma generate` が `DATABASE_URL` 未設定のため失敗しましたのでフルビルドの検証は未完了です.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d858545b7c8332929b97e35ed806a5)