### PR TITLE
Improve dashboard card design and CTA visibility for store/talent

### DIFF
--- a/talentify-next-frontend/app/store/dashboard/page.tsx
+++ b/talentify-next-frontend/app/store/dashboard/page.tsx
@@ -6,7 +6,7 @@ import NotificationListCard from '@/components/NotificationListCard'
 import { Card, CardHeader, CardTitle, CardFooter, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import Link from 'next/link'
-import { Search as SearchIcon } from 'lucide-react'
+import { Search as SearchIcon, Sparkles } from 'lucide-react'
 import { getStoreDashboardData } from '@/lib/queries/dashboard'
 
 export default async function StoreDashboard() {
@@ -15,42 +15,48 @@ export default async function StoreDashboard() {
     (Object.values(offerStats) as number[]).reduce((acc, v) => acc + v, 0) > 0
 
   return (
-    <div className='space-y-4'>
-      {!hasData ? (
-        <EmptyState
-          title='まだオファーがありません'
-          actionHref='/search'
-          actionLabel='オファーを送ってみましょう'
-        />
-      ) : (
-        <div className='grid gap-4 sm:grid-cols-2'>
-          <Card className='sm:col-span-2'>
-            <CardHeader>
-              <CardTitle>次の来店イベントを企画しませんか？</CardTitle>
-            </CardHeader>
-            <CardContent className='text-sm text-muted-foreground'>
-              演者一覧から希望に合ったタレントを探しましょう。
-            </CardContent>
-            <CardFooter>
-              <Button variant='default' size='lg' asChild>
-                <Link href='/search'>
-                  <SearchIcon className='mr-2' /> 演者を探す
-                </Link>
-              </Button>
-            </CardFooter>
-          </Card>
-          <ScheduleCard items={schedule} />
-          <OfferSummaryCard
-            pending={offerStats.pending ?? 0}
-            confirmed={offerStats.confirmed ?? 0}
-            link='/store/offers'
+    <div className='rounded-2xl bg-slate-50 p-4 sm:p-6'>
+      <div className='space-y-5'>
+        {!hasData ? (
+          <EmptyState
+            title='まだオファーがありません'
+            actionHref='/search'
+            actionLabel='オファーを送ってみましょう'
           />
-          <div className='sm:col-span-2'>
-            <MessageAlertCard count={unreadCount} link='/store/messages' />
+        ) : (
+          <div className='grid gap-5 sm:grid-cols-2'>
+            <Card className='sm:col-span-2 rounded-xl border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/60'>
+              <CardHeader className='mb-0 flex items-center gap-2 p-0'>
+                <Sparkles className='h-5 w-5 text-blue-600' />
+                <CardTitle className='text-xl font-semibold text-slate-900'>
+                  次の来店イベントを企画しませんか？
+                </CardTitle>
+              </CardHeader>
+              <CardContent className='mt-3 p-0 text-sm leading-relaxed text-slate-600'>
+                演者一覧から希望に合ったタレントを探して、集客につながるイベント企画を進めましょう。
+              </CardContent>
+              <CardFooter className='mt-5 p-0'>
+                <Button variant='default' size='lg' asChild>
+                  <Link href='/search'>
+                    <SearchIcon className='mr-2 h-4 w-4' /> 演者を探す
+                  </Link>
+                </Button>
+              </CardFooter>
+            </Card>
+
+            <ScheduleCard items={schedule} />
+            <OfferSummaryCard
+              pending={offerStats.pending ?? 0}
+              confirmed={offerStats.confirmed ?? 0}
+              link='/store/offers'
+            />
+            <div className='sm:col-span-2'>
+              <MessageAlertCard count={unreadCount} link='/store/messages' />
+            </div>
+            <NotificationListCard title='通知（最新）' className='sm:col-span-2' />
           </div>
-          <NotificationListCard className='sm:col-span-2' />
-        </div>
-      )}
+        )}
+      </div>
     </div>
   )
 }

--- a/talentify-next-frontend/app/talent/dashboard/page.tsx
+++ b/talentify-next-frontend/app/talent/dashboard/page.tsx
@@ -9,17 +9,19 @@ export default async function TalentDashboard() {
   const { schedule, pendingOffersCount, unreadMessagesCount } = await getTalentDashboardData()
 
   return (
-    <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-3'>
-      <ScheduleCard items={schedule} />
-      <OfferSummaryCard
-        pending={pendingOffersCount}
-        confirmed={schedule.length}
-        link='/talent/offers'
-      />
-      <MessageAlertCard count={unreadMessagesCount} link='/talent/messages' />
-      <NotificationListCard className='sm:col-span-2 lg:col-span-3' />
-      <div className='sm:col-span-2 lg:col-span-3'>
-        <ProfileProgressCard />
+    <div className='rounded-2xl bg-slate-50 p-4 sm:p-6'>
+      <div className='grid gap-5 sm:grid-cols-2 lg:grid-cols-3'>
+        <ScheduleCard items={schedule} />
+        <OfferSummaryCard
+          pending={pendingOffersCount}
+          confirmed={schedule.length}
+          link='/talent/offers'
+        />
+        <MessageAlertCard count={unreadMessagesCount} link='/talent/messages' />
+        <NotificationListCard title='通知（最新）' className='sm:col-span-2 lg:col-span-3' />
+        <div className='sm:col-span-2 lg:col-span-3'>
+          <ProfileProgressCard />
+        </div>
       </div>
     </div>
   )

--- a/talentify-next-frontend/components/MessageAlertCard.tsx
+++ b/talentify-next-frontend/components/MessageAlertCard.tsx
@@ -1,6 +1,5 @@
-import React from 'react'
+import { MessageSquare } from 'lucide-react'
 import { DashboardCard } from './ui/dashboard-card'
-import { Badge } from './ui/badge'
 
 interface MessageAlertCardProps {
   title?: string
@@ -18,9 +17,18 @@ export default function MessageAlertCard({
       title={title}
       ctaHref={link}
       ctaLabel={link ? 'メッセージを見る' : undefined}
+      ctaVariant='default'
     >
-      <div className="text-sm">
-        未読: <Badge variant="destructive">{count}</Badge>
+      <div className='rounded-lg border border-red-100 bg-red-50/70 p-3'>
+        <div className='flex items-center justify-between'>
+          <span className='inline-flex items-center gap-1.5 text-sm font-medium text-slate-600'>
+            <MessageSquare className='h-4 w-4 text-red-500' />
+            未読メッセージ
+          </span>
+          <span className='inline-flex min-w-10 items-center justify-center rounded-full bg-red-600 px-3 py-1 text-sm font-semibold text-white'>
+            {count}
+          </span>
+        </div>
       </div>
     </DashboardCard>
   )

--- a/talentify-next-frontend/components/OfferSummaryCard.tsx
+++ b/talentify-next-frontend/components/OfferSummaryCard.tsx
@@ -1,5 +1,4 @@
-import React from 'react'
-import Link from 'next/link'
+import { CircleCheckBig, Clock3 } from 'lucide-react'
 import { DashboardCard } from './ui/dashboard-card'
 import { Badge } from './ui/badge'
 
@@ -21,13 +20,28 @@ export default function OfferSummaryCard({
       title={title}
       ctaHref={link}
       ctaLabel={link ? '詳細を見る' : undefined}
+      ctaVariant='outline'
     >
-      <div className="text-sm space-y-1">
-        <div>
-          保留中: <Badge variant="secondary">{pending}</Badge>
+      <div className='space-y-3'>
+        <div className='rounded-lg border border-amber-100 bg-amber-50/70 p-3'>
+          <div className='flex items-center justify-between text-sm text-slate-600'>
+            <span className='inline-flex items-center gap-1.5 font-medium'>
+              <Clock3 className='h-4 w-4 text-amber-600' />
+              保留中
+            </span>
+            <Badge variant='secondary' className='text-sm font-semibold'>
+              {pending}
+            </Badge>
+          </div>
         </div>
-        <div>
-          承認済み: <Badge>{confirmed}</Badge>
+        <div className='rounded-lg border border-emerald-100 bg-emerald-50/70 p-3'>
+          <div className='flex items-center justify-between text-sm text-slate-600'>
+            <span className='inline-flex items-center gap-1.5 font-medium'>
+              <CircleCheckBig className='h-4 w-4 text-emerald-600' />
+              承認済み
+            </span>
+            <Badge className='text-sm font-semibold'>{confirmed}</Badge>
+          </div>
         </div>
       </div>
     </DashboardCard>

--- a/talentify-next-frontend/components/ScheduleCard.tsx
+++ b/talentify-next-frontend/components/ScheduleCard.tsx
@@ -1,8 +1,7 @@
 'use client'
 
-import React from 'react'
 import Link from 'next/link'
-import { CalendarCheck, Clock, AlertCircle } from 'lucide-react'
+import { CalendarCheck, Clock, AlertCircle, ChevronRight } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { DashboardCard } from './ui/dashboard-card'
 import { formatJaDateTimeWithWeekday } from '@/utils/formatJaDateTimeWithWeekday'
@@ -23,25 +22,42 @@ interface ScheduleCardProps {
 export default function ScheduleCard({ title = '今週の予定', items }: ScheduleCardProps) {
   return (
     <DashboardCard title={title}>
-      <div className="space-y-2 text-sm">
-        {items.length === 0 && <p className="text-muted-foreground">予定はありません</p>}
+      <div className='space-y-3 text-sm'>
+        {items.length === 0 && <p className='text-muted-foreground'>予定はありません</p>}
         {items.map((ev, i) => (
-          <div key={i} className="flex justify-between items-center rounded border p-2">
-            <div>
-              <div>{formatJaDateTimeWithWeekday(ev.date)}</div>
-              <div className="text-xs text-muted-foreground">{ev.performer}</div>
+          <div
+            key={i}
+            className='flex items-center justify-between gap-3 rounded-lg border border-slate-200 bg-slate-50/70 p-3'
+          >
+            <div className='min-w-0 flex-1'>
+              <div className='font-medium text-slate-800'>{formatJaDateTimeWithWeekday(ev.date)}</div>
+              <div className='truncate text-xs text-muted-foreground'>{ev.performer}</div>
             </div>
+
             {ev.status === 'confirmed' && (
-              <Badge className="flex items-center gap-1"><CalendarCheck className="w-4 h-4"/>確定</Badge>
+              <Badge className='inline-flex items-center gap-1'>
+                <CalendarCheck className='h-4 w-4' />確定
+              </Badge>
             )}
             {ev.status === 'pending' && (
-              <Badge variant="secondary" className="flex items-center gap-1"><Clock className="w-4 h-4"/>保留</Badge>
+              <Badge variant='secondary' className='inline-flex items-center gap-1'>
+                <Clock className='h-4 w-4' />保留
+              </Badge>
             )}
             {ev.status === 'cancelled' && (
-              <div className="flex items-center gap-1 text-red-600 text-xs"><AlertCircle className="w-4 h-4"/>キャンセル</div>
+              <div className='inline-flex items-center gap-1 rounded-full border border-red-200 bg-red-50 px-2.5 py-1 text-xs font-medium text-red-600'>
+                <AlertCircle className='h-3.5 w-3.5' />キャンセル
+              </div>
             )}
+
             {ev.href && (
-              <Link href={ev.href} className="text-blue-600 text-xs ml-2">詳細</Link>
+              <Link
+                href={ev.href}
+                className='inline-flex items-center gap-1 text-xs font-medium text-blue-600 hover:text-blue-700'
+              >
+                詳細
+                <ChevronRight className='h-3.5 w-3.5' />
+              </Link>
             )}
           </div>
         ))}

--- a/talentify-next-frontend/components/ui/dashboard-card.tsx
+++ b/talentify-next-frontend/components/ui/dashboard-card.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
+import { ArrowRight } from 'lucide-react'
 import { Card, CardHeader, CardTitle, CardContent, CardFooter } from './card'
 import { Button } from './button'
 import { cn } from '@/lib/utils'
@@ -10,6 +11,7 @@ export interface DashboardCardProps extends React.HTMLAttributes<HTMLDivElement>
   icon?: React.ReactNode
   ctaHref?: string
   ctaLabel?: string
+  ctaVariant?: 'default' | 'outline' | 'secondary'
 }
 
 export function DashboardCard({
@@ -18,27 +20,42 @@ export function DashboardCard({
   icon,
   ctaHref,
   ctaLabel,
+  ctaVariant = 'outline',
   className,
   children,
   ...props
 }: DashboardCardProps) {
-  const content = (
-    <Card className={cn('flex flex-col gap-2', className)} {...props}>
-      <CardHeader className="flex items-center gap-2">
+  return (
+    <Card
+      className={cn(
+        'flex h-full flex-col rounded-xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-200/60',
+        className
+      )}
+      {...props}
+    >
+      <CardHeader className='mb-0 flex items-center gap-2 p-0'>
         {icon}
-        <CardTitle className="text-base font-semibold">{title}</CardTitle>
+        <CardTitle className='text-base font-semibold text-slate-900'>{title}</CardTitle>
       </CardHeader>
-      {description && <CardContent className="text-sm text-muted-foreground">{description}</CardContent>}
-      {children && <CardContent>{children}</CardContent>}
+
+      {description && (
+        <CardContent className='mt-2 p-0 text-sm text-slate-600'>
+          {description}
+        </CardContent>
+      )}
+
+      {children && <CardContent className='mt-4 flex-1 p-0'>{children}</CardContent>}
+
       {ctaHref && ctaLabel && (
-        <CardFooter>
-          <Link href={ctaHref} className="ml-auto">
-            <Button size="sm">{ctaLabel}</Button>
+        <CardFooter className='mt-5 p-0'>
+          <Link href={ctaHref} className='ml-auto'>
+            <Button size='sm' variant={ctaVariant} className='gap-1.5'>
+              {ctaLabel}
+              <ArrowRight className='h-4 w-4' />
+            </Button>
           </Link>
         </CardFooter>
       )}
     </Card>
   )
-
-  return content
 }


### PR DESCRIPTION
### Motivation
- Improve visual separation between white cards and page background and increase hierarchy so CTAs and counts are easier to scan. 
- Make the store and talent dashboards share a consistent card tone while avoiding any changes to routes, APIs, data fetching, or business logic. 

### Description
- Wrapped store and talent dashboard content in a subtle gray container (`bg-slate-50`, rounded padding) and increased card/grid spacing for breathing room. 
- Introduced a refined reusable `DashboardCard` with soft border, radius, light shadow, stronger title styles and a CTA button that includes an arrow affordance and `ctaVariant` option. 
- Reworked `OfferSummaryCard`, `ScheduleCard`, and `MessageAlertCard` to emphasize counts/status using colored sections, badges, icons and clearer detail links while preserving original data/links. 
- Files changed: `app/store/dashboard/page.tsx`, `app/talent/dashboard/page.tsx`, `components/ui/dashboard-card.tsx`, `components/OfferSummaryCard.tsx`, `components/ScheduleCard.tsx`, `components/MessageAlertCard.tsx`. 

### Testing
- Ran `npm run lint` in `talentify-next-frontend` and lint completed successfully (only preexisting warnings reported). 
- Attempted `npm run build` but build failed in this environment due to missing environment variable `DATABASE_URL`, so full production build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d85c2aa3f483329db6655867a136e7)