### PR TITLE
Fix authenticated header flicker and slightly darken post-login background

### DIFF
--- a/talentify-next-frontend/app/store/layout.tsx
+++ b/talentify-next-frontend/app/store/layout.tsx
@@ -19,11 +19,11 @@ export default async function StoreLayout({
 
   return (
     <html lang="ja" className="h-full">
-      <body className="font-sans antialiased bg-white text-black min-h-screen flex flex-col">
+      <body className="font-sans antialiased bg-[#f1f5f9] text-black min-h-screen flex flex-col">
         <SupabaseProvider session={session}>
           <Header sidebarRole="store" />
           <div className="flex flex-1 pt-16">
-            <main className="flex-1 overflow-y-auto p-6">{children}</main>
+            <main className="flex-1 overflow-y-auto bg-[#f1f5f9] p-6">{children}</main>
           </div>
         </SupabaseProvider>
       </body>

--- a/talentify-next-frontend/app/talent/layout.tsx
+++ b/talentify-next-frontend/app/talent/layout.tsx
@@ -19,11 +19,11 @@ export default async function TalentLayout({
 
   return (
     <html lang="ja" className="h-full">
-      <body className="font-sans antialiased bg-white text-black min-h-screen flex flex-col">
+      <body className="font-sans antialiased bg-[#f1f5f9] text-black min-h-screen flex flex-col">
         <SupabaseProvider session={session}>
           <Header sidebarRole="talent" />
           <div className="flex flex-1 pt-16">
-            <main className="flex-1 overflow-y-auto p-6">{children}</main>
+            <main className="flex-1 overflow-y-auto bg-[#f1f5f9] p-6">{children}</main>
           </div>
         </SupabaseProvider>
       </body>

--- a/talentify-next-frontend/components/Header.tsx
+++ b/talentify-next-frontend/components/Header.tsx
@@ -107,7 +107,9 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
     !!roleNav &&
     roleNav.project.some((item) => pathname === item.href || pathname.startsWith(`${item.href}/`))
 
-  if (roleNav && isLoggedIn) {
+  if (roleNav) {
+    const displayUserName = userName ?? 'ユーザー'
+
     return (
       <header className="fixed top-0 w-full h-16 bg-white shadow-sm z-[var(--z-header)]">
         <div className="mx-auto flex h-full max-w-6xl items-center justify-between px-4">
@@ -151,7 +153,7 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <button className="flex items-center gap-1 text-sm font-semibold focus:outline-none">
-                  {userName}
+                  {displayUserName}
                   <ChevronDown className="h-4 w-4 text-muted-foreground" />
                 </button>
               </DropdownMenuTrigger>


### PR DESCRIPTION
### Motivation
- Eliminate a visual flicker where public header briefly appears during navigation in authenticated `/store/*` and `/talent/*` areas. 
- Make the logged-in dashboard background slightly darker so white cards separate more clearly without changing overall tone. 
- Preserve existing authentication, notification, user menu, and logout behaviors while keeping the changes minimal.

### Description
- Render role-specific header immediately when `sidebarRole` is provided by changing `components/Header.tsx` so the role header is shown unconditionally and use a safe fallback display name (`ユーザー`) until profile load completes. 
- Update layouts `app/store/layout.tsx` and `app/talent/layout.tsx` to set `body` and `main` background to `#f1f5f9` for a subtle stronger gray on post-login screens. 
- Files changed: `talentify-next-frontend/components/Header.tsx`, `talentify-next-frontend/app/store/layout.tsx`, and `talentify-next-frontend/app/talent/layout.tsx`.

### Testing
- Ran `npm run lint` which completed successfully (there are unrelated existing warnings about `<img>` usage). 
- Attempted `npm run build` but it failed in this environment due to missing `DATABASE_URL` required by Prisma, which is an environment configuration issue and not related to the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d85f178b00833283fa05f50dc75ae6)