### PR TITLE
UI改善: 主要CTAの視認性向上とヘッダー責務のルート分離整理

### DIFF
--- a/talentify-next-frontend/components/Header.tsx
+++ b/talentify-next-frontend/components/Header.tsx
@@ -99,7 +99,10 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
   }
 
   const isLoggedIn = !!userName
-  const roleNav = sidebarRole ? ROLE_MENUS[sidebarRole] : null
+  const inferredRole =
+    sidebarRole ??
+    (pathname?.startsWith('/store') ? 'store' : pathname?.startsWith('/talent') ? 'talent' : undefined)
+  const roleNav = inferredRole ? ROLE_MENUS[inferredRole] : null
   const homeHref = roleNav?.homeHref ?? '/'
 
   const isHomeActive = !!roleNav && pathname === roleNav.homeHref

--- a/talentify-next-frontend/components/OfferSummaryCard.tsx
+++ b/talentify-next-frontend/components/OfferSummaryCard.tsx
@@ -20,7 +20,7 @@ export default function OfferSummaryCard({
       title={title}
       ctaHref={link}
       ctaLabel={link ? '詳細を見る' : undefined}
-      ctaVariant='outline'
+      ctaVariant='default'
     >
       <div className='space-y-3'>
         <div className='rounded-lg border border-amber-100 bg-amber-50/70 p-3'>

--- a/talentify-next-frontend/components/ProfileProgressCard.tsx
+++ b/talentify-next-frontend/components/ProfileProgressCard.tsx
@@ -3,6 +3,7 @@ import { Progress } from '@/components/ui/progress'
 import { Button } from '@/components/ui/button'
 import { AlertCircle } from 'lucide-react'
 import { createClient } from '@/lib/supabase/server'
+import Link from 'next/link'
 
 export default async function ProfileProgressCard() {
   const supabase = createClient()
@@ -55,8 +56,8 @@ export default async function ProfileProgressCard() {
           </div>
         )}
 
-        <Button variant='default' size='sm' className='w-full'>
-          プロフィールを編集する
+        <Button variant='default' size='sm' className='w-full' asChild>
+          <Link href='/talent/edit'>プロフィールを編集する</Link>
         </Button>
       </CardContent>
     </Card>

--- a/talentify-next-frontend/components/ScheduleCard.tsx
+++ b/talentify-next-frontend/components/ScheduleCard.tsx
@@ -19,7 +19,7 @@ interface ScheduleCardProps {
   items: ScheduleItem[]
 }
 
-export default function ScheduleCard({ title = '今週の予定', items }: ScheduleCardProps) {
+export default function ScheduleCard({ title = '直近の予定', items }: ScheduleCardProps) {
   return (
     <DashboardCard title={title}>
       <div className='space-y-3 text-sm'>
@@ -53,9 +53,9 @@ export default function ScheduleCard({ title = '今週の予定', items }: Sched
             {ev.href && (
               <Link
                 href={ev.href}
-                className='inline-flex items-center gap-1 text-xs font-medium text-blue-600 hover:text-blue-700'
+                className='inline-flex items-center gap-1 rounded-md border border-blue-200 bg-blue-50 px-2 py-1 text-xs font-semibold text-blue-700 transition-colors hover:border-blue-300 hover:bg-blue-100'
               >
-                詳細
+                詳細を見る
                 <ChevronRight className='h-3.5 w-3.5' />
               </Link>
             )}

--- a/talentify-next-frontend/lib/queries/dashboard.ts
+++ b/talentify-next-frontend/lib/queries/dashboard.ts
@@ -48,7 +48,9 @@ export async function getTalentDashboardData() {
         )
         .eq('talent_id', talentId)
         .eq('status', confirmedStatus)
+        .gte('date', new Date().toISOString().slice(0, 10))
         .order('date', { ascending: true })
+        .limit(5)
     : { data: [] }
 
   const schedule: ScheduleItem[] = (scheduleData ?? []).map((d: any) => ({


### PR DESCRIPTION
### Motivation
- ユーザーが主要アクションを認識しやすくするためにCTAの視認性を高め、`/store` と `/talent` 配下で不適切に公開ヘッダーが表示される挙動をルート責務で整理するため。
- talent ダッシュボードの予定カードが縦に長すぎる問題を軽減してダッシュボードのバランスを改善するため。 

### Description
- `Header` に pathname ベースのロール推定フォールバックを追加し、`sidebarRole` 未指定時でも `/store` と `/talent` 配下ではそれぞれのログイン後ヘッダーを出すようにした（`components/Header.tsx`）。
- 予定カードのデフォルトタイトルを `今週の予定` から `直近の予定` に変更した（`components/ScheduleCard.tsx`）。
- 予定カード内の詳細導線をテキストリンク風から青系のボタン風スタイルに変更し文言を `詳細を見る` に統一した（`components/ScheduleCard.tsx`）。
- talent 側の予定取得を「本日以降・日付昇順・最大5件」に限定して縦長化を抑えるようにした（`lib/queries/dashboard.ts`）。
- ダッシュボード系の主要CTAで目立たせるために `OfferSummaryCard` の CTA を `outline` から `default`（primary）に変更し、プロフィールの編集ボタンを実際の編集ページへリンクするように変更した（`components/OfferSummaryCard.tsx`, `components/ProfileProgressCard.tsx`）。
- 変更ファイル: `components/Header.tsx`, `components/ScheduleCard.tsx`, `components/OfferSummaryCard.tsx`, `components/ProfileProgressCard.tsx`, `lib/queries/dashboard.ts`。

### Testing
- `npm run lint` を実行し ESLint は警告（`no-img-element`）のみで完了した。 
- `npm test -- --runInBand` を実行し一部の自動テストが失敗し、失敗は既存の API 認証まわりのモック/テストセットアップに起因する `offers` 系テストで発生した（今回のUI変更によるものではない）。
- `npm run build` を実行したが環境の `DATABASE_URL` 未設定によりビルドは実行できなかったためビルド完了は未検証。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d862b2b4ac8332a68e36abff0f9ad8)