### PR TITLE
store ヘッダーに「演者を探す」を追加しダッシュボードをコンパクト化

### DIFF
--- a/talentify-next-frontend/app/search/layout.tsx
+++ b/talentify-next-frontend/app/search/layout.tsx
@@ -1,8 +1,5 @@
 import React from 'react'
 import Header from '@/components/Header'
-import Sidebar from '@/components/Sidebar'
-import { SidebarProvider } from '@/components/SidebarProvider'
-import SidebarToggle from '@/components/SidebarToggle'
 import { createClient } from '@/lib/supabase/server'
 import { SupabaseProvider } from '@/lib/supabase/provider'
 
@@ -22,19 +19,11 @@ export default async function SearchLayout({
 
   return (
     <html lang="ja" className="h-full">
-      <body className="font-sans antialiased bg-white text-black min-h-screen flex flex-col">
+      <body className="font-sans antialiased bg-[#f1f5f9] text-black min-h-screen flex flex-col">
         <SupabaseProvider session={session}>
           <Header sidebarRole="store" />
           <div className="flex flex-1 pt-16">
-            <SidebarProvider>
-              <div className="hidden md:block">
-                <Sidebar role="store" collapsible />
-              </div>
-              <div className="hidden md:block">
-                <SidebarToggle />
-              </div>
-              <main className="flex-1 overflow-y-auto p-6 transition-[margin,width]">{children}</main>
-            </SidebarProvider>
+            <main className="flex-1 overflow-y-auto bg-[#f1f5f9] p-6">{children}</main>
           </div>
         </SupabaseProvider>
       </body>

--- a/talentify-next-frontend/app/store/dashboard/page.tsx
+++ b/talentify-next-frontend/app/store/dashboard/page.tsx
@@ -15,48 +15,46 @@ export default async function StoreDashboard() {
     (Object.values(offerStats) as number[]).reduce((acc, v) => acc + v, 0) > 0
 
   return (
-    <div className='rounded-2xl bg-slate-50 p-4 sm:p-6'>
-      <div className='space-y-5'>
-        {!hasData ? (
-          <EmptyState
-            title='まだオファーがありません'
-            actionHref='/search'
-            actionLabel='オファーを送ってみましょう'
-          />
-        ) : (
-          <div className='grid gap-5 sm:grid-cols-2'>
-            <Card className='sm:col-span-2 rounded-xl border border-slate-200 bg-white p-6 shadow-sm shadow-slate-200/60'>
+    <div className='space-y-4'>
+      {!hasData ? (
+        <EmptyState
+          title='まだオファーがありません'
+          actionHref='/search'
+          actionLabel='オファーを送ってみましょう'
+        />
+      ) : (
+        <div className='grid gap-4 sm:grid-cols-2'>
+          <Card className='sm:col-span-2 rounded-xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-200/60'>
               <CardHeader className='mb-0 flex items-center gap-2 p-0'>
                 <Sparkles className='h-5 w-5 text-blue-600' />
-                <CardTitle className='text-xl font-semibold text-slate-900'>
+                <CardTitle className='text-lg font-semibold text-slate-900'>
                   次の来店イベントを企画しませんか？
                 </CardTitle>
               </CardHeader>
-              <CardContent className='mt-3 p-0 text-sm leading-relaxed text-slate-600'>
+              <CardContent className='mt-2 p-0 text-sm leading-relaxed text-slate-600'>
                 演者一覧から希望に合ったタレントを探して、集客につながるイベント企画を進めましょう。
               </CardContent>
-              <CardFooter className='mt-5 p-0'>
-                <Button variant='default' size='lg' asChild>
+              <CardFooter className='mt-4 p-0'>
+                <Button variant='default' size='default' asChild>
                   <Link href='/search'>
                     <SearchIcon className='mr-2 h-4 w-4' /> 演者を探す
                   </Link>
                 </Button>
               </CardFooter>
-            </Card>
+          </Card>
 
-            <ScheduleCard items={schedule} />
-            <OfferSummaryCard
-              pending={offerStats.pending ?? 0}
-              confirmed={offerStats.confirmed ?? 0}
-              link='/store/offers'
-            />
-            <div className='sm:col-span-2'>
-              <MessageAlertCard count={unreadCount} link='/store/messages' />
-            </div>
-            <NotificationListCard title='通知（最新）' className='sm:col-span-2' />
+          <ScheduleCard items={schedule} />
+          <OfferSummaryCard
+            pending={offerStats.pending ?? 0}
+            confirmed={offerStats.confirmed ?? 0}
+            link='/store/offers'
+          />
+          <div className='sm:col-span-2'>
+            <MessageAlertCard count={unreadCount} link='/store/messages' />
           </div>
-        )}
-      </div>
+          <NotificationListCard title='通知（最新）' className='sm:col-span-2' />
+        </div>
+      )}
     </div>
   )
 }

--- a/talentify-next-frontend/components/Header.tsx
+++ b/talentify-next-frontend/components/Header.tsx
@@ -22,9 +22,14 @@ interface MenuItem {
   label: string
 }
 
-const ROLE_MENUS: Record<'store' | 'talent', { homeHref: string; project: MenuItem[]; account: MenuItem[] }> = {
+const ROLE_MENUS: Record<
+  'store' | 'talent',
+  { homeHref: string; primaryHref?: string; primaryLabel?: string; project: MenuItem[]; account: MenuItem[] }
+> = {
   store: {
     homeHref: '/store/dashboard',
+    primaryHref: '/search',
+    primaryLabel: '演者を探す',
     project: [
       { href: '/store/offers', label: 'オファー管理' },
       { href: '/store/schedule', label: 'スケジュール管理' },
@@ -106,6 +111,9 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
   const homeHref = roleNav?.homeHref ?? '/'
 
   const isHomeActive = !!roleNav && pathname === roleNav.homeHref
+  const isPrimaryActive =
+    !!roleNav?.primaryHref &&
+    (pathname === roleNav.primaryHref || pathname.startsWith(`${roleNav.primaryHref}/`))
   const isProjectActive =
     !!roleNav &&
     roleNav.project.some((item) => pathname === item.href || pathname.startsWith(`${item.href}/`))
@@ -129,6 +137,17 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
             >
               ホーム
             </Link>
+            {roleNav.primaryHref && roleNav.primaryLabel && (
+              <Link
+                href={roleNav.primaryHref}
+                className={cn(
+                  'text-sm font-medium transition-colors hover:text-primary',
+                  isPrimaryActive ? 'text-primary' : 'text-muted-foreground',
+                )}
+              >
+                {roleNav.primaryLabel}
+              </Link>
+            )}
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <button

--- a/talentify-next-frontend/components/MessageAlertCard.tsx
+++ b/talentify-next-frontend/components/MessageAlertCard.tsx
@@ -19,7 +19,7 @@ export default function MessageAlertCard({
       ctaLabel={link ? 'メッセージを見る' : undefined}
       ctaVariant='default'
     >
-      <div className='rounded-lg border border-red-100 bg-red-50/70 p-3'>
+      <div className='rounded-lg border border-red-100 bg-red-50/70 p-2.5'>
         <div className='flex items-center justify-between'>
           <span className='inline-flex items-center gap-1.5 text-sm font-medium text-slate-600'>
             <MessageSquare className='h-4 w-4 text-red-500' />

--- a/talentify-next-frontend/components/OfferSummaryCard.tsx
+++ b/talentify-next-frontend/components/OfferSummaryCard.tsx
@@ -22,8 +22,8 @@ export default function OfferSummaryCard({
       ctaLabel={link ? '詳細を見る' : undefined}
       ctaVariant='default'
     >
-      <div className='space-y-3'>
-        <div className='rounded-lg border border-amber-100 bg-amber-50/70 p-3'>
+      <div className='space-y-2.5'>
+        <div className='rounded-lg border border-amber-100 bg-amber-50/70 p-2.5'>
           <div className='flex items-center justify-between text-sm text-slate-600'>
             <span className='inline-flex items-center gap-1.5 font-medium'>
               <Clock3 className='h-4 w-4 text-amber-600' />
@@ -34,7 +34,7 @@ export default function OfferSummaryCard({
             </Badge>
           </div>
         </div>
-        <div className='rounded-lg border border-emerald-100 bg-emerald-50/70 p-3'>
+        <div className='rounded-lg border border-emerald-100 bg-emerald-50/70 p-2.5'>
           <div className='flex items-center justify-between text-sm text-slate-600'>
             <span className='inline-flex items-center gap-1.5 font-medium'>
               <CircleCheckBig className='h-4 w-4 text-emerald-600' />

--- a/talentify-next-frontend/components/ScheduleCard.tsx
+++ b/talentify-next-frontend/components/ScheduleCard.tsx
@@ -22,12 +22,12 @@ interface ScheduleCardProps {
 export default function ScheduleCard({ title = '直近の予定', items }: ScheduleCardProps) {
   return (
     <DashboardCard title={title}>
-      <div className='space-y-3 text-sm'>
+      <div className='space-y-2.5 text-sm'>
         {items.length === 0 && <p className='text-muted-foreground'>予定はありません</p>}
         {items.map((ev, i) => (
           <div
             key={i}
-            className='flex items-center justify-between gap-3 rounded-lg border border-slate-200 bg-slate-50/70 p-3'
+            className='flex items-center justify-between gap-3 rounded-lg border border-slate-200 bg-slate-50/70 p-2.5'
           >
             <div className='min-w-0 flex-1'>
               <div className='font-medium text-slate-800'>{formatJaDateTimeWithWeekday(ev.date)}</div>

--- a/talentify-next-frontend/components/ui/dashboard-card.tsx
+++ b/talentify-next-frontend/components/ui/dashboard-card.tsx
@@ -28,7 +28,7 @@ export function DashboardCard({
   return (
     <Card
       className={cn(
-        'flex h-full flex-col rounded-xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-200/60',
+        'flex h-full flex-col rounded-xl border border-slate-200 bg-white p-4 shadow-sm shadow-slate-200/60',
         className
       )}
       {...props}
@@ -38,16 +38,12 @@ export function DashboardCard({
         <CardTitle className='text-base font-semibold text-slate-900'>{title}</CardTitle>
       </CardHeader>
 
-      {description && (
-        <CardContent className='mt-2 p-0 text-sm text-slate-600'>
-          {description}
-        </CardContent>
-      )}
+      {description && <CardContent className='mt-1.5 p-0 text-sm text-slate-600'>{description}</CardContent>}
 
-      {children && <CardContent className='mt-4 flex-1 p-0'>{children}</CardContent>}
+      {children && <CardContent className='mt-3 flex-1 p-0'>{children}</CardContent>}
 
       {ctaHref && ctaLabel && (
-        <CardFooter className='mt-5 p-0'>
+        <CardFooter className='mt-4 p-0'>
           <Link href={ctaHref} className='ml-auto'>
             <Button size='sm' variant={ctaVariant} className='gap-1.5'>
               {ctaLabel}


### PR DESCRIPTION
### Motivation

- store配下の主要導線をヘッダーに集約して UX を一貫化するため、既存のルーティングや認証に影響を出さずに UI を整理する。 
- 演者検索ページに残る旧サイドメニューを撤去してヘッダー中心レイアウトに揃える。 
- ダッシュボードのカード余白やラッパー構造を整理して全体を一段コンパクトに見せる。

### Description

- `components/Header.tsx` に store 向けの主要リンクとして `primaryHref: '/search'` / `primaryLabel: '演者を探す'` を追加し、`ホーム` の右・`案件管理` の左に表示するようにしました（アクティブ判定も追加）。
- `app/search/layout.tsx` から `Sidebar` / `SidebarProvider` / `SidebarToggle` を削除してヘッダー中心のレイアウトに統一し、背景トーンを store 側に合わせました。
- `app/store/dashboard/page.tsx` の外側の大きなラッパーを簡素化し、グリッド `gap` を縮小、ヒーローカードの `padding` / `title` / 内部マージン / CTA サイズを縮めてコンパクト化しました。
- 共通カードコンポーネント `components/ui/dashboard-card.tsx` の `p-5 -> p-4` など余白を一段縮小し、`components/ScheduleCard.tsx` / `components/OfferSummaryCard.tsx` / `components/MessageAlertCard.tsx` でも内部 padding/gap を軽く詰めました。
- ルーティング・API・認証・通知・ログアウトのロジックには手を入れておらず、既存のページ責務やデータ取得は変更していません.

### Testing

- `npm run lint` in `talentify-next-frontend` completed successfully with only existing `<img>` usage warnings. 
- `npm run build` failed in this environment due to missing environment variable `DATABASE_URL`, which is an external environment issue and not caused by code changes. 
- A quick grep confirmed `Sidebar` related references were removed from the `app/search` layout (no remaining sidebar integration for the search pages).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d86a9188488332a7feb7754712d271)