### PR TITLE
Refine dashboard card density and header interaction states

### DIFF
--- a/talentify-next-frontend/app/store/dashboard/page.tsx
+++ b/talentify-next-frontend/app/store/dashboard/page.tsx
@@ -23,8 +23,8 @@ export default async function StoreDashboard() {
           actionLabel='オファーを送ってみましょう'
         />
       ) : (
-        <div className='grid gap-4 sm:grid-cols-2'>
-          <Card className='sm:col-span-2 rounded-xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-200/60'>
+        <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-6'>
+          <Card className='sm:col-span-2 lg:col-span-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-200/60'>
               <CardHeader className='mb-0 flex items-center gap-2 p-0'>
                 <Sparkles className='h-5 w-5 text-blue-600' />
                 <CardTitle className='text-lg font-semibold text-slate-900'>
@@ -43,16 +43,15 @@ export default async function StoreDashboard() {
               </CardFooter>
           </Card>
 
-          <ScheduleCard items={schedule} />
+          <ScheduleCard items={schedule} className='lg:col-span-3' />
           <OfferSummaryCard
+            className='lg:col-span-2'
             pending={offerStats.pending ?? 0}
             confirmed={offerStats.confirmed ?? 0}
             link='/store/offers'
           />
-          <div className='sm:col-span-2'>
-            <MessageAlertCard count={unreadCount} link='/store/messages' />
-          </div>
-          <NotificationListCard title='通知（最新）' className='sm:col-span-2' />
+          <MessageAlertCard className='lg:col-span-1' count={unreadCount} link='/store/messages' />
+          <NotificationListCard title='通知（最新）' className='sm:col-span-2 lg:col-span-4' />
         </div>
       )}
     </div>

--- a/talentify-next-frontend/app/talent/dashboard/page.tsx
+++ b/talentify-next-frontend/app/talent/dashboard/page.tsx
@@ -1,7 +1,6 @@
 import OfferSummaryCard from '@/components/OfferSummaryCard'
 import ScheduleCard from '@/components/ScheduleCard'
 import MessageAlertCard from '@/components/MessageAlertCard'
-import ProfileProgressCard from '@/components/ProfileProgressCard'
 import NotificationListCard from '@/components/NotificationListCard'
 import { getTalentDashboardData } from '@/lib/queries/dashboard'
 
@@ -9,19 +8,17 @@ export default async function TalentDashboard() {
   const { schedule, pendingOffersCount, unreadMessagesCount } = await getTalentDashboardData()
 
   return (
-    <div className='rounded-2xl bg-slate-50 p-4 sm:p-6'>
-      <div className='grid gap-5 sm:grid-cols-2 lg:grid-cols-3'>
-        <ScheduleCard items={schedule} />
+    <div className='space-y-4'>
+      <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-6'>
+        <ScheduleCard items={schedule} className='lg:col-span-3' />
         <OfferSummaryCard
+          className='lg:col-span-2'
           pending={pendingOffersCount}
           confirmed={schedule.length}
           link='/talent/offers'
         />
-        <MessageAlertCard count={unreadMessagesCount} link='/talent/messages' />
-        <NotificationListCard title='通知（最新）' className='sm:col-span-2 lg:col-span-3' />
-        <div className='sm:col-span-2 lg:col-span-3'>
-          <ProfileProgressCard />
-        </div>
+        <MessageAlertCard className='lg:col-span-1' count={unreadMessagesCount} link='/talent/messages' />
+        <NotificationListCard title='通知（最新）' className='sm:col-span-2 lg:col-span-4' />
       </div>
     </div>
   )

--- a/talentify-next-frontend/components/Header.tsx
+++ b/talentify-next-frontend/components/Header.tsx
@@ -117,6 +117,11 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
   const isProjectActive =
     !!roleNav &&
     roleNav.project.some((item) => pathname === item.href || pathname.startsWith(`${item.href}/`))
+  const navItemBaseClass =
+    'relative inline-flex h-9 items-center rounded-md px-2 text-sm font-medium text-slate-600 transition-all duration-150 hover:bg-slate-100 hover:text-slate-900'
+  const navItemActiveClass = 'text-primary after:absolute after:inset-x-2 after:bottom-0 after:h-0.5 after:rounded-full after:bg-primary'
+  const dropdownItemClass =
+    'cursor-pointer rounded-md px-2 py-1.5 text-slate-700 transition-colors duration-150 hover:bg-slate-100 hover:text-slate-900 focus:bg-slate-100 focus:text-slate-900'
 
   if (roleNav) {
     const displayUserName = userName ?? 'ユーザー'
@@ -131,8 +136,8 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
             <Link
               href={homeHref}
               className={cn(
-                'text-sm font-medium transition-colors hover:text-primary',
-                isHomeActive ? 'text-primary' : 'text-muted-foreground',
+                navItemBaseClass,
+                isHomeActive ? navItemActiveClass : '',
               )}
             >
               ホーム
@@ -141,8 +146,8 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
               <Link
                 href={roleNav.primaryHref}
                 className={cn(
-                  'text-sm font-medium transition-colors hover:text-primary',
-                  isPrimaryActive ? 'text-primary' : 'text-muted-foreground',
+                  navItemBaseClass,
+                  isPrimaryActive ? navItemActiveClass : '',
                 )}
               >
                 {roleNav.primaryLabel}
@@ -152,8 +157,9 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
               <DropdownMenuTrigger asChild>
                 <button
                   className={cn(
-                    'flex items-center gap-1 text-sm font-medium transition-colors hover:text-primary',
-                    isProjectActive ? 'text-primary' : 'text-muted-foreground',
+                    navItemBaseClass,
+                    'gap-1',
+                    isProjectActive ? navItemActiveClass : '',
                   )}
                 >
                   案件管理
@@ -162,7 +168,7 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
               </DropdownMenuTrigger>
               <DropdownMenuContent align="start">
                 {roleNav.project.map((item) => (
-                  <DropdownMenuItem asChild key={item.href}>
+                  <DropdownMenuItem asChild key={item.href} className={dropdownItemClass}>
                     <Link href={item.href}>{item.label}</Link>
                   </DropdownMenuItem>
                 ))}
@@ -174,19 +180,22 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
             <HeaderBellLink />
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <button className="flex items-center gap-1 text-sm font-semibold focus:outline-none">
+                <button className="flex h-9 items-center gap-1 rounded-md px-2 text-sm font-semibold text-slate-700 transition-colors duration-150 hover:bg-slate-100 hover:text-slate-900 focus:outline-none">
                   {displayUserName}
                   <ChevronDown className="h-4 w-4 text-muted-foreground" />
                 </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
                 {roleNav.account.map((item) => (
-                  <DropdownMenuItem asChild key={item.href}>
+                  <DropdownMenuItem asChild key={item.href} className={dropdownItemClass}>
                     <Link href={item.href}>{item.label}</Link>
                   </DropdownMenuItem>
                 ))}
                 <DropdownMenuSeparator />
-                <DropdownMenuItem onSelect={handleLogout} className="text-destructive focus:text-destructive">
+                <DropdownMenuItem
+                  onSelect={handleLogout}
+                  className="cursor-pointer rounded-md px-2 py-1.5 text-destructive transition-colors duration-150 hover:bg-red-50 focus:bg-red-50 focus:text-destructive"
+                >
                   ログアウト
                 </DropdownMenuItem>
               </DropdownMenuContent>

--- a/talentify-next-frontend/components/MessageAlertCard.tsx
+++ b/talentify-next-frontend/components/MessageAlertCard.tsx
@@ -5,16 +5,19 @@ interface MessageAlertCardProps {
   title?: string
   count: number
   link?: string
+  className?: string
 }
 
 export default function MessageAlertCard({
   title = '新着メッセージ',
   count,
   link,
+  className,
 }: MessageAlertCardProps) {
   return (
     <DashboardCard
       title={title}
+      className={className}
       ctaHref={link}
       ctaLabel={link ? 'メッセージを見る' : undefined}
       ctaVariant='default'

--- a/talentify-next-frontend/components/OfferSummaryCard.tsx
+++ b/talentify-next-frontend/components/OfferSummaryCard.tsx
@@ -7,6 +7,7 @@ interface OfferSummaryCardProps {
   pending: number
   confirmed: number
   link?: string
+  className?: string
 }
 
 export default function OfferSummaryCard({
@@ -14,10 +15,12 @@ export default function OfferSummaryCard({
   pending,
   confirmed,
   link,
+  className,
 }: OfferSummaryCardProps) {
   return (
     <DashboardCard
       title={title}
+      className={className}
       ctaHref={link}
       ctaLabel={link ? '詳細を見る' : undefined}
       ctaVariant='default'

--- a/talentify-next-frontend/components/ScheduleCard.tsx
+++ b/talentify-next-frontend/components/ScheduleCard.tsx
@@ -17,11 +17,12 @@ export interface ScheduleItem {
 interface ScheduleCardProps {
   title?: string
   items: ScheduleItem[]
+  className?: string
 }
 
-export default function ScheduleCard({ title = '直近の予定', items }: ScheduleCardProps) {
+export default function ScheduleCard({ title = '直近の予定', items, className }: ScheduleCardProps) {
   return (
-    <DashboardCard title={title}>
+    <DashboardCard title={title} className={className}>
       <div className='space-y-2.5 text-sm'>
         {items.length === 0 && <p className='text-muted-foreground'>予定はありません</p>}
         {items.map((ev, i) => (

--- a/talentify-next-frontend/components/notifications/HeaderBellLink.tsx
+++ b/talentify-next-frontend/components/notifications/HeaderBellLink.tsx
@@ -41,7 +41,7 @@ export default function HeaderBellLink() {
     <Link
       href={href}
       aria-label="通知"
-      className="relative p-2 rounded-full hover:bg-muted focus:outline-none"
+      className="relative rounded-full p-2 text-slate-600 transition-colors duration-150 hover:bg-slate-100 hover:text-slate-900 focus:outline-none"
     >
       <Bell className="h-6 w-6" />
       {formatted && (
@@ -55,4 +55,3 @@ export default function HeaderBellLink() {
     </Link>
   )
 }
-


### PR DESCRIPTION
### Motivation
- Unify store/talent dashboard layout so white cards sit directly on the page background and remove the extra outer gray wrapper on the talent dashboard. 
- Make dashboard cards more compact and avoid unnecessarily wide notification/message cards so the dashboard reads denser and more natural. 
- Add subtle hover and pathname-based active states for header nav and dropdown items to improve affordance without changing routes/auth/data flows.

### Description
- Layout: replaced the outer talent dashboard wrapper with the same two-layer background+white-card structure used by store and aligned both dashboards to a 6-column `lg` grid for consistent spans. (`app/talent/dashboard/page.tsx`, `app/store/dashboard/page.tsx`).
- Density: tightened card spans so `Schedule` uses `lg:col-span-3`, `OfferSummary` `lg:col-span-2`, `MessageAlert` `lg:col-span-1`, and `NotificationList` uses a wider span when needed to avoid long, empty cards. (updated both dashboard pages and grid spans).
- Removed profile progress: removed the `ProfileProgressCard` rendering from the talent dashboard (import and UI only), leaving the underlying data and API intact. (`app/talent/dashboard/page.tsx`).
- Small API for layout control: extended `ScheduleCard`, `OfferSummaryCard`, and `MessageAlertCard` to accept `className` so page layouts can control grid spans without changing card internals. (`components/ScheduleCard.tsx`, `components/OfferSummaryCard.tsx`, `components/MessageAlertCard.tsx`, `components/ui/dashboard-card.tsx`).
- Header: added nav base classes and an active class (underline via pseudo-element) and hover styles for `Home`, `演者を探す`, and `案件管理` with pathname-based active detection; added hover/active for dropdown items and logout item. (`components/Header.tsx`).
- Notifications bell: added a subtle hover affordance for the header bell. (`components/notifications/HeaderBellLink.tsx`).
- All changes are CSS/class-only or small props; no route, API, auth, or data-fetching logic was changed.

### Testing
- Ran `npm run lint` in `talentify-next-frontend` which completed successfully with pre-existing `no-img-element` warnings and no new lint errors. (warnings only)
- Attempted `npm run build` in `talentify-next-frontend` but the build failed in this environment due to missing Prisma environment configuration (`DATABASE_URL`), so a full build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8708dc1ac8332b7c44af6c6173203)