### PR TITLE
オファー一覧UIをstore/talentで統一し視認性を改善

### DIFF
--- a/talentify-next-frontend/app/store/offers/page.tsx
+++ b/talentify-next-frontend/app/store/offers/page.tsx
@@ -8,7 +8,7 @@ import { TableSkeleton } from '@/components/ui/skeleton'
 import { EmptyState } from '@/components/ui/empty-state'
 import { format } from 'date-fns'
 import { ja } from 'date-fns/locale'
-import { ChevronDown, ChevronUp } from 'lucide-react'
+import { ChevronDown, ChevronRight, ChevronUp } from 'lucide-react'
 import { getOfferProgress } from '@/utils/offerProgress'
 import { OfferProgressStatusIcons } from '@/components/offer/OfferProgressStatusIcons'
 import { Button } from '@/components/ui/button'
@@ -23,11 +23,19 @@ const statusLabels: Record<string, string> = {
 }
 
 const statusVariants: Record<string, Parameters<typeof Badge>[0]['variant']> = {
-  pending: 'secondary',
-  confirmed: 'default',
-  rejected: 'destructive',
-  completed: 'success',
-  expired: 'secondary',
+  pending: 'outline',
+  confirmed: 'outline',
+  rejected: 'outline',
+  completed: 'outline',
+  expired: 'outline',
+}
+
+const statusToneClasses: Record<string, string> = {
+  pending: 'border-amber-200 bg-amber-50 text-amber-800',
+  confirmed: 'border-blue-200 bg-blue-50 text-blue-800',
+  rejected: 'border-rose-200 bg-rose-50 text-rose-800',
+  completed: 'border-emerald-200 bg-emerald-50 text-emerald-800',
+  expired: 'border-slate-200 bg-slate-100 text-slate-700',
 }
 
 export default function StoreOffersPage() {
@@ -88,67 +96,82 @@ export default function StoreOffersPage() {
   }
 
   return (
-    <main className="p-4 md:p-6 space-y-4">
-      <h1 className="text-xl font-bold">オファー一覧</h1>
+    <main className="space-y-4 p-4 md:p-6">
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900">オファー管理</h1>
+        <p className="mt-1 text-sm text-slate-500">来店予定・進捗状況を一覧で確認できます。</p>
+      </div>
       {loading ? (
         <TableSkeleton rows={3} />
       ) : sorted.length === 0 ? (
         <EmptyState title="対象のオファーがありません" />
       ) : (
         <>
-          <div className="hidden md:block overflow-x-auto">
+          <section className="hidden overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm md:block">
             <Table>
-              <TableHeader className="sticky top-0 bg-white">
-                <TableRow className="text-sm">
-                  <TableHead className="w-[160px]" aria-sort={sortOrder === 'asc' ? 'ascending' : 'descending'}>
+              <TableHeader className="sticky top-0 bg-slate-50">
+                <TableRow className="h-12 border-b border-slate-200 text-sm">
+                  <TableHead className="w-[180px] px-6 text-xs font-semibold tracking-wide text-slate-600" aria-sort={sortOrder === 'asc' ? 'ascending' : 'descending'}>
                     <button
                       type="button"
                       onClick={toggleSortOrder}
-                      className="inline-flex items-center gap-1 font-semibold text-slate-700 hover:text-[#2563EB]"
+                      className="inline-flex items-center gap-1 font-semibold text-slate-700 hover:text-blue-700"
                     >
                       来店日
                       {sortOrder === 'asc' ? (
-                        <ChevronUp className="h-4 w-4 text-[#2563EB]" aria-hidden="true" />
+                        <ChevronUp className="h-4 w-4 text-blue-700" aria-hidden="true" />
                       ) : (
-                        <ChevronDown className="h-4 w-4 text-[#2563EB]" aria-hidden="true" />
+                        <ChevronDown className="h-4 w-4 text-blue-700" aria-hidden="true" />
                       )}
                       <span className="sr-only">来店日で並び替え</span>
                     </button>
                   </TableHead>
-                  <TableHead className="min-w-[200px]">演者名</TableHead>
-                  <TableHead className="min-w-[320px]">オファー進捗</TableHead>
-                  <TableHead className="w-[120px] text-right">詳細</TableHead>
+                  <TableHead className="min-w-[220px] px-4 text-xs font-semibold tracking-wide text-slate-600">演者名</TableHead>
+                  <TableHead className="w-[150px] px-4 text-xs font-semibold tracking-wide text-slate-600">現在ステータス</TableHead>
+                  <TableHead className="min-w-[360px] px-4 text-xs font-semibold tracking-wide text-slate-600">進捗</TableHead>
+                  <TableHead className="w-[120px] px-6 text-right text-xs font-semibold tracking-wide text-slate-600">詳細</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {sorted.map(o => (
-                  <TableRow key={o.id} className="h-16 transition-colors hover:bg-slate-100/70">
-                    <TableCell className="align-middle">
+                  <TableRow key={o.id} className="h-[76px] border-b border-slate-100 transition-colors hover:bg-slate-50/80">
+                    <TableCell className="px-6 align-middle">
                       <div className="font-medium text-slate-900">{formatVisitDate(o.date)}</div>
                     </TableCell>
-                    <TableCell className="align-middle">
+                    <TableCell className="px-4 align-middle">
                       <div className="truncate text-slate-900" title={o.talent_name ?? ''}>{o.talent_name ?? '-'}</div>
                     </TableCell>
-                    <TableCell className="align-middle">
+                    <TableCell className="px-4 align-middle">
+                      <Badge
+                        variant={statusVariants[o.status ?? 'pending']}
+                        className={`rounded-md px-2.5 py-1 text-[11px] font-semibold ${statusToneClasses[o.status ?? 'pending'] ?? statusToneClasses.pending}`}
+                      >
+                        {statusLabels[o.status ?? 'pending']}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="px-4 align-middle">
                       <OfferProgressStatusIcons steps={o.steps} badge={o.badge} />
                     </TableCell>
-                    <TableCell className="align-middle text-right">
-                      <Button variant="ghost" size="sm" asChild className="text-[#2563EB] hover:bg-[#2563EB]/10">
-                        <Link href={`/store/offers/${o.id}`}>詳細</Link>
+                    <TableCell className="px-6 align-middle text-right">
+                      <Button variant="ghost" size="sm" asChild className="text-blue-700 hover:bg-blue-50 hover:text-blue-800">
+                        <Link href={`/store/offers/${o.id}`} className="inline-flex items-center gap-1">
+                          詳細
+                          <ChevronRight className="h-4 w-4" />
+                        </Link>
                       </Button>
                     </TableCell>
                   </TableRow>
                 ))}
               </TableBody>
             </Table>
-          </div>
+          </section>
 
           <div className="md:hidden space-y-3">
             {sorted.map(o => (
               <div key={o.id} className="space-y-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
                 <div className="flex items-center justify-between">
                   <div className="text-sm font-medium text-slate-900">{formatVisitDate(o.date)}</div>
-                  <Badge variant={statusVariants[o.status ?? 'pending']}>
+                  <Badge variant={statusVariants[o.status ?? 'pending']} className={`rounded-md px-2.5 py-1 text-[11px] font-semibold ${statusToneClasses[o.status ?? 'pending'] ?? statusToneClasses.pending}`}>
                     {statusLabels[o.status ?? 'pending']}
                   </Badge>
                 </div>
@@ -159,8 +182,11 @@ export default function StoreOffersPage() {
                   <OfferProgressStatusIcons steps={o.steps} badge={o.badge} className="mx-1 min-w-[420px]" />
                 </div>
                 <div className="flex justify-end">
-                  <Button variant="ghost" size="sm" asChild className="text-[#2563EB] hover:bg-[#2563EB]/10">
-                    <Link href={`/store/offers/${o.id}`}>詳細</Link>
+                  <Button variant="ghost" size="sm" asChild className="text-blue-700 hover:bg-blue-50 hover:text-blue-800">
+                    <Link href={`/store/offers/${o.id}`} className="inline-flex items-center gap-1">
+                      詳細
+                      <ChevronRight className="h-4 w-4" />
+                    </Link>
                   </Button>
                 </div>
               </div>

--- a/talentify-next-frontend/app/talent/offers/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/page.tsx
@@ -9,7 +9,7 @@ import { EmptyState } from '@/components/ui/empty-state'
 import { toast } from 'sonner'
 import { format } from 'date-fns'
 import { ja } from 'date-fns/locale'
-import { ChevronDown, ChevronUp } from 'lucide-react'
+import { ChevronDown, ChevronRight, ChevronUp } from 'lucide-react'
 import { getOfferProgress } from '@/utils/offerProgress'
 import { OfferProgressStatusIcons } from '@/components/offer/OfferProgressStatusIcons'
 import { Button } from '@/components/ui/button'
@@ -24,11 +24,19 @@ const statusLabels: Record<string, string> = {
 }
 
 const statusVariants: Record<string, Parameters<typeof Badge>[0]['variant']> = {
-  pending: 'secondary',
-  confirmed: 'default',
-  rejected: 'destructive',
-  completed: 'success',
-  expired: 'secondary',
+  pending: 'outline',
+  confirmed: 'outline',
+  rejected: 'outline',
+  completed: 'outline',
+  expired: 'outline',
+}
+
+const statusToneClasses: Record<string, string> = {
+  pending: 'border-amber-200 bg-amber-50 text-amber-800',
+  confirmed: 'border-blue-200 bg-blue-50 text-blue-800',
+  rejected: 'border-rose-200 bg-rose-50 text-rose-800',
+  completed: 'border-emerald-200 bg-emerald-50 text-emerald-800',
+  expired: 'border-slate-200 bg-slate-100 text-slate-700',
 }
 
 export default function TalentOffersPage() {
@@ -94,69 +102,84 @@ export default function TalentOffersPage() {
   }
 
   return (
-    <main className="p-4 md:p-6 space-y-4">
-      <h1 className="text-xl font-bold">受信オファー一覧</h1>
+    <main className="space-y-4 p-4 md:p-6">
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900">オファー管理</h1>
+        <p className="mt-1 text-sm text-slate-500">受信したオファーと進捗を一覧で確認できます。</p>
+      </div>
       {loading ? (
         <TableSkeleton rows={3} />
       ) : sorted.length === 0 ? (
         <EmptyState title="対象のオファーがありません" />
       ) : (
         <>
-          <div className="hidden md:block overflow-x-auto">
+          <section className="hidden overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm md:block">
             <Table>
-              <TableHeader className="sticky top-0 bg-white">
-                <TableRow className="text-sm">
-                  <TableHead className="w-[160px]" aria-sort={sortOrder === 'asc' ? 'ascending' : 'descending'}>
+              <TableHeader className="sticky top-0 bg-slate-50">
+                <TableRow className="h-12 border-b border-slate-200 text-sm">
+                  <TableHead className="w-[180px] px-6 text-xs font-semibold tracking-wide text-slate-600" aria-sort={sortOrder === 'asc' ? 'ascending' : 'descending'}>
                     <button
                       type="button"
                       onClick={toggleSortOrder}
-                      className="inline-flex items-center gap-1 font-semibold text-slate-700 hover:text-[#2563EB]"
+                      className="inline-flex items-center gap-1 font-semibold text-slate-700 hover:text-blue-700"
                     >
                       来店日
                       {sortOrder === 'asc' ? (
-                        <ChevronUp className="h-4 w-4 text-[#2563EB]" aria-hidden="true" />
+                        <ChevronUp className="h-4 w-4 text-blue-700" aria-hidden="true" />
                       ) : (
-                        <ChevronDown className="h-4 w-4 text-[#2563EB]" aria-hidden="true" />
+                        <ChevronDown className="h-4 w-4 text-blue-700" aria-hidden="true" />
                       )}
                       <span className="sr-only">来店日で並び替え</span>
                     </button>
                   </TableHead>
-                  <TableHead className="min-w-[200px]">店舗名</TableHead>
-                  <TableHead className="min-w-[320px]">オファー進捗</TableHead>
-                  <TableHead className="w-[120px] text-right">詳細</TableHead>
+                  <TableHead className="min-w-[220px] px-4 text-xs font-semibold tracking-wide text-slate-600">店舗名</TableHead>
+                  <TableHead className="w-[150px] px-4 text-xs font-semibold tracking-wide text-slate-600">現在ステータス</TableHead>
+                  <TableHead className="min-w-[360px] px-4 text-xs font-semibold tracking-wide text-slate-600">進捗</TableHead>
+                  <TableHead className="w-[120px] px-6 text-right text-xs font-semibold tracking-wide text-slate-600">詳細</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {sorted.map(o => (
-                  <TableRow key={o.id} className="h-16 transition-colors hover:bg-slate-100/70">
-                    <TableCell className="align-middle">
+                  <TableRow key={o.id} className="h-[76px] border-b border-slate-100 transition-colors hover:bg-slate-50/80">
+                    <TableCell className="px-6 align-middle">
                       <div className="font-medium text-slate-900">{formatVisitDate(o.date)}</div>
                     </TableCell>
-                    <TableCell className="align-middle">
+                    <TableCell className="px-4 align-middle">
                       <div className="truncate text-slate-900" title={o.store_name ?? ''}>
                         {o.store_name ?? '-'}
                       </div>
                     </TableCell>
-                    <TableCell className="align-middle">
+                    <TableCell className="px-4 align-middle">
+                      <Badge
+                        variant={statusVariants[o.status ?? 'pending']}
+                        className={`rounded-md px-2.5 py-1 text-[11px] font-semibold ${statusToneClasses[o.status ?? 'pending'] ?? statusToneClasses.pending}`}
+                      >
+                        {statusLabels[o.status ?? 'pending']}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="px-4 align-middle">
                       <OfferProgressStatusIcons steps={o.steps} badge={o.badge} />
                     </TableCell>
-                    <TableCell className="align-middle text-right">
-                      <Button variant="ghost" size="sm" asChild className="text-[#2563EB] hover:bg-[#2563EB]/10">
-                        <Link href={`/talent/offers/${o.id}`}>詳細</Link>
+                    <TableCell className="px-6 align-middle text-right">
+                      <Button variant="ghost" size="sm" asChild className="text-blue-700 hover:bg-blue-50 hover:text-blue-800">
+                        <Link href={`/talent/offers/${o.id}`} className="inline-flex items-center gap-1">
+                          詳細
+                          <ChevronRight className="h-4 w-4" />
+                        </Link>
                       </Button>
                     </TableCell>
                   </TableRow>
                 ))}
               </TableBody>
             </Table>
-          </div>
+          </section>
 
           <div className="md:hidden space-y-3">
             {sorted.map(o => (
               <div key={o.id} className="space-y-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
                 <div className="flex items-center justify-between">
                   <div className="text-sm font-medium text-slate-900">{formatVisitDate(o.date)}</div>
-                  <Badge variant={statusVariants[o.status ?? 'pending']}>
+                  <Badge variant={statusVariants[o.status ?? 'pending']} className={`rounded-md px-2.5 py-1 text-[11px] font-semibold ${statusToneClasses[o.status ?? 'pending'] ?? statusToneClasses.pending}`}>
                     {statusLabels[o.status ?? 'pending']}
                   </Badge>
                 </div>
@@ -167,8 +190,11 @@ export default function TalentOffersPage() {
                   <OfferProgressStatusIcons steps={o.steps} badge={o.badge} className="mx-1 min-w-[420px]" />
                 </div>
                 <div className="flex justify-end">
-                  <Button variant="ghost" size="sm" asChild className="text-[#2563EB] hover:bg-[#2563EB]/10">
-                    <Link href={`/talent/offers/${o.id}`}>詳細</Link>
+                  <Button variant="ghost" size="sm" asChild className="text-blue-700 hover:bg-blue-50 hover:text-blue-800">
+                    <Link href={`/talent/offers/${o.id}`} className="inline-flex items-center gap-1">
+                      詳細
+                      <ChevronRight className="h-4 w-4" />
+                    </Link>
                   </Button>
                 </div>
               </div>

--- a/talentify-next-frontend/components/offer/OfferProgressStatusIcons.tsx
+++ b/talentify-next-frontend/components/offer/OfferProgressStatusIcons.tsx
@@ -17,15 +17,15 @@ const statusLabel: Record<OfferProgressStep['status'], string> = {
 const baseCircleStyles = 'flex h-8 w-8 items-center justify-center rounded-full'
 
 const iconContainerStyles: Record<OfferProgressStep['status'], string> = {
-  complete: 'bg-[#E8F5EE] text-[#16A34A]',
-  current: 'bg-[#E8F1FD] text-[#3B82F6]',
-  upcoming: 'bg-[#EEF2F7] text-slate-400',
+  complete: 'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-100',
+  current: 'bg-blue-50 text-blue-700 ring-1 ring-blue-100',
+  upcoming: 'bg-slate-100 text-slate-400 ring-1 ring-slate-200',
 }
 
 const iconByStatus: Record<OfferProgressStep['status'], ReactNode> = {
   complete: <Check className="h-4 w-4" strokeWidth={2.2} />,
   current: <ArrowRight className="h-4 w-4" strokeWidth={2.2} />,
-  upcoming: <span className="h-1.5 w-1.5 rounded-full bg-[#94A3B8]" />,
+  upcoming: <span className="h-1.5 w-1.5 rounded-full bg-slate-400" />,
 }
 
 const STEP_SHORT_LABELS: Record<OfferProgressStep['key'], string> = {
@@ -44,9 +44,9 @@ type OfferProgressStatusIconsProps = {
 }
 
 const badgeVariantStyles: Record<OfferProgressBadge['variant'], string> = {
-  default: 'border-blue-200 text-blue-700 bg-blue-50',
-  secondary: 'border-slate-200 text-slate-600 bg-white',
-  success: 'border-emerald-200 text-emerald-600 bg-emerald-50',
+  default: 'border-blue-200 text-blue-800 bg-blue-50',
+  secondary: 'border-amber-200 text-amber-800 bg-amber-50',
+  success: 'border-emerald-200 text-emerald-800 bg-emerald-50',
 }
 
 export function OfferProgressStatusIcons({ steps, badge, className }: OfferProgressStatusIconsProps) {
@@ -61,7 +61,7 @@ export function OfferProgressStatusIcons({ steps, badge, className }: OfferProgr
         <div className="w-full md:w-[160px]">
           <Badge
             variant="outline"
-            className={cn('w-full truncate', badgeVariantStyles[badge.variant])}
+          className={cn('w-full truncate justify-center rounded-md py-1 font-semibold', badgeVariantStyles[badge.variant])}
             title={badge.label}
           >
             {badge.label}
@@ -72,7 +72,7 @@ export function OfferProgressStatusIcons({ steps, badge, className }: OfferProgr
             <Tooltip key={step.key}>
               <TooltipTrigger asChild>
                 <span
-                  className="flex flex-col items-center gap-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#3B82F6]/30 focus-visible:ring-offset-2"
+                  className="flex flex-col items-center gap-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/40 focus-visible:ring-offset-2"
                   tabIndex={0}
                 >
                   <span


### PR DESCRIPTION
### Motivation
- store / talent のオファー一覧で見出し・表示トーンがばらついていたため、管理画面として見やすく統一したい。
- テーブルが背景に埋もれて読みづらいので、白カードとして独立させ視認性を上げたい。
- ステータス・進捗の色味が派手で業務利用に馴染まないため落ち着いたトーンに調整したい。

### Description
- ページタイトルを store / talent 両方で `オファー管理` に統一し、説明文を追加して文脈を揃えました (`app/store/offers/page.tsx`, `app/talent/offers/page.tsx`).
- 一覧テーブルを `rounded + border + shadow + bg-white` のカード風コンテナに変更し、ヘッダー行のトーン・セル余白・行高さを調整して読みやすさを改善しました (`app/store/offers/page.tsx`, `app/talent/offers/page.tsx`).
- デスクトップ表に「現在ステータス」列を追加し、ステータス表示を派手さを抑えたアウトライン＋落ち着いた色味のクラスに切り替え（`statusToneClasses`を導入）してバッジの見た目を調整しました (`app/store/offers/page.tsx`, `app/talent/offers/page.tsx`).
- 進捗表示コンポーネントの色・リング・バッジスタイルを抑えた業務UI寄りにリファインし、バッジの配置やフォーカスリングを微調整しました (`components/offer/OfferProgressStatusIcons.tsx`).
- モバイルカード側のステータスバッジ/詳細リンクも同様のトーンに合わせ、行末の詳細リンクに矢印アイコンを追加して導線を強化しました (`app/store/offers/page.tsx`, `app/talent/offers/page.tsx`).

### Testing
- 実行したLint: `cd talentify-next-frontend && npm run lint`; 実行は成功し、既存の `@next/next/no-img-element` 警告のみで問題は発生しませんでした（今回の変更による新たなLintエラーは無し）。
- 実行したBuild: `cd talentify-next-frontend && npm run build`; ビルドは環境変数 `DATABASE_URL` が未設定のため失敗しましたが、これは環境起因のため変更起因のビルドエラーは確認できませんでした.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d87ed3074883328ed5730bbdaa4b14)