### PR TITLE
Separate public and app areas: add `/app` entry/layout, guide pages and site footer

### DIFF
--- a/talentify-next-frontend/app/app/dashboard/page.tsx
+++ b/talentify-next-frontend/app/app/dashboard/page.tsx
@@ -1,0 +1,26 @@
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import { getUserRoleInfo } from '@/lib/getUserRole'
+
+export default async function AppDashboardPage() {
+  const supabase = await createClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+
+  if (!session) {
+    redirect('/login?redirectedFrom=/app/dashboard')
+  }
+
+  const { role, isSetupComplete } = await getUserRoleInfo(supabase, session.user.id)
+
+  if (role === 'store') {
+    redirect(isSetupComplete ? '/store/dashboard' : '/store/edit')
+  }
+
+  if (role === 'talent') {
+    redirect(isSetupComplete ? '/talent/dashboard' : '/talent/edit')
+  }
+
+  redirect('/dashboard')
+}

--- a/talentify-next-frontend/app/app/layout.tsx
+++ b/talentify-next-frontend/app/app/layout.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { redirect } from 'next/navigation'
+import Header from '@/components/Header'
+import SiteFooter from '@/components/SiteFooter'
+import { createClient } from '@/lib/supabase/server'
+import { SupabaseProvider } from '@/lib/supabase/provider'
+import { getUserRoleInfo } from '@/lib/getUserRole'
+
+export const metadata = {
+  title: 'Talentify | アプリ',
+}
+
+export default async function AppLayout({ children }: { children: React.ReactNode }) {
+  const supabase = await createClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+
+  if (!session) {
+    redirect('/login?redirectedFrom=/app')
+  }
+
+  const { role } = await getUserRoleInfo(supabase, session.user.id)
+  const sidebarRole = role === 'store' || role === 'talent' ? role : undefined
+
+  return (
+    <SupabaseProvider session={session}>
+      <div className="min-h-screen bg-[#f1f5f9] text-black flex flex-col">
+        <Header sidebarRole={sidebarRole} />
+        <main className="flex-1 overflow-y-auto bg-[#f1f5f9] p-6 pt-20">{children}</main>
+        <SiteFooter />
+      </div>
+    </SupabaseProvider>
+  )
+}

--- a/talentify-next-frontend/app/app/notifications/page.tsx
+++ b/talentify-next-frontend/app/app/notifications/page.tsx
@@ -1,0 +1,26 @@
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import { getUserRoleInfo } from '@/lib/getUserRole'
+
+export default async function AppNotificationsPage() {
+  const supabase = await createClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+
+  if (!session) {
+    redirect('/login?redirectedFrom=/app/notifications')
+  }
+
+  const { role } = await getUserRoleInfo(supabase, session.user.id)
+
+  if (role === 'store') {
+    redirect('/store/notifications')
+  }
+
+  if (role === 'talent') {
+    redirect('/talent/notifications')
+  }
+
+  redirect('/notifications')
+}

--- a/talentify-next-frontend/app/app/offers/page.tsx
+++ b/talentify-next-frontend/app/app/offers/page.tsx
@@ -1,0 +1,26 @@
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import { getUserRoleInfo } from '@/lib/getUserRole'
+
+export default async function AppOffersPage() {
+  const supabase = await createClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+
+  if (!session) {
+    redirect('/login?redirectedFrom=/app/offers')
+  }
+
+  const { role } = await getUserRoleInfo(supabase, session.user.id)
+
+  if (role === 'store') {
+    redirect('/store/offers')
+  }
+
+  if (role === 'talent') {
+    redirect('/talent/offers')
+  }
+
+  redirect('/dashboard')
+}

--- a/talentify-next-frontend/app/app/page.tsx
+++ b/talentify-next-frontend/app/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function AppIndexPage() {
+  redirect('/app/dashboard')
+}

--- a/talentify-next-frontend/app/app/talents/page.tsx
+++ b/talentify-next-frontend/app/app/talents/page.tsx
@@ -1,0 +1,26 @@
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import { getUserRoleInfo } from '@/lib/getUserRole'
+
+export default async function AppTalentsPage() {
+  const supabase = await createClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+
+  if (!session) {
+    redirect('/login?redirectedFrom=/app/talents')
+  }
+
+  const { role } = await getUserRoleInfo(supabase, session.user.id)
+
+  if (role === 'store') {
+    redirect('/store/talents')
+  }
+
+  if (role === 'talent') {
+    redirect('/talent/offers')
+  }
+
+  redirect('/talents')
+}

--- a/talentify-next-frontend/app/column/page.tsx
+++ b/talentify-next-frontend/app/column/page.tsx
@@ -1,0 +1,37 @@
+const columns = [
+  {
+    date: '2026-04-10',
+    title: '初めて依頼するときのポイント',
+    summary: '初回オファー時に確認しておきたい日程・条件・連絡体制の基本を整理します。',
+  },
+  {
+    date: '2026-04-03',
+    title: '演者選定で見るべき点',
+    summary: 'プロフィールと実績の見方、案件目的との相性の考え方を紹介します。',
+  },
+  {
+    date: '2026-03-28',
+    title: '案件進行をスムーズにする事前準備',
+    summary: 'オファー前に決めるべき情報を整理し、やり取りの往復を減らすコツをまとめました。',
+  },
+]
+
+export default function ColumnPage() {
+  return (
+    <div className="mx-auto w-full max-w-5xl px-4 py-24 text-slate-900">
+      <header className="mb-6 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h1 className="text-3xl font-bold">コラム</h1>
+        <p className="mt-2 text-sm text-slate-600">Talentifyの活用に役立つ読み物を順次掲載予定です。</p>
+      </header>
+      <div className="space-y-3">
+        {columns.map((item) => (
+          <article key={item.title} className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+            <p className="text-xs text-slate-500">{item.date}</p>
+            <h2 className="mt-1 text-lg font-semibold">{item.title}</h2>
+            <p className="mt-2 text-sm leading-6 text-slate-600">{item.summary}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/talentify-next-frontend/app/company/page.tsx
+++ b/talentify-next-frontend/app/company/page.tsx
@@ -1,0 +1,20 @@
+export default function CompanyPage() {
+  return (
+    <div className="mx-auto w-full max-w-5xl px-4 py-24 text-slate-900">
+      <header className="mb-6 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h1 className="text-3xl font-bold">会社概要</h1>
+        <p className="mt-2 text-sm text-slate-600">このページは会社情報の仮ページです。後日正式情報に差し替えます。</p>
+      </header>
+      <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <dl className="grid gap-3 text-sm sm:grid-cols-[180px_1fr]">
+          <dt className="font-semibold text-slate-700">サービス名</dt>
+          <dd className="text-slate-600">Talentify</dd>
+          <dt className="font-semibold text-slate-700">ページ種別</dt>
+          <dd className="text-slate-600">公開情報ページ（仮）</dd>
+          <dt className="font-semibold text-slate-700">用途</dt>
+          <dd className="text-slate-600">会社情報・運営情報の掲載。将来的に正式な企業情報へ置き換える想定です。</dd>
+        </dl>
+      </section>
+    </div>
+  )
+}

--- a/talentify-next-frontend/app/guide/page.tsx
+++ b/talentify-next-frontend/app/guide/page.tsx
@@ -1,0 +1,42 @@
+import Link from 'next/link'
+
+export default function GuidePage() {
+  return (
+    <div className="mx-auto w-full max-w-5xl px-4 py-24 text-slate-900">
+      <header className="mb-8 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h1 className="text-3xl font-bold">ご利用ガイド</h1>
+        <p className="mt-2 text-sm text-slate-600">Talentifyの使い方を役割ごとに整理したご案内ページです。</p>
+      </header>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {[
+          { title: 'Talentifyとは', body: 'パチンコ店と演者をつなぐマッチングプラットフォームです。案件作成から契約後のやり取りまでオンラインで管理できます。' },
+          { title: '店舗の方へ', body: '演者検索、オファー送信、進行管理、請求対応までを一つの画面で運用できます。' },
+          { title: '演者の方へ', body: 'オファー確認、スケジュール調整、メッセージ、請求提出などを効率よく進められます。' },
+          { title: '基本的な利用の流れ', body: '登録 → プロフィール設定 → 案件作成/応募 → 調整 → 契約・実施という流れで利用できます。' },
+        ].map((item) => (
+          <section key={item.title} className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+            <h2 className="text-lg font-semibold">{item.title}</h2>
+            <p className="mt-2 text-sm leading-6 text-slate-600">{item.body}</p>
+          </section>
+        ))}
+      </div>
+
+      <section className="mt-8 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="text-lg font-semibold">関連ページ</h2>
+        <div className="mt-3 flex flex-wrap gap-2 text-sm">
+          {[
+            { href: '/faq', label: 'FAQ' },
+            { href: '/news', label: 'お知らせ' },
+            { href: '/pricing', label: '料金' },
+            { href: '/company', label: '会社概要' },
+          ].map((item) => (
+            <Link key={item.href} href={item.href} className="rounded-md border border-slate-200 px-3 py-1.5 text-slate-700 hover:bg-slate-50">
+              {item.label}
+            </Link>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/talentify-next-frontend/app/layout.tsx
+++ b/talentify-next-frontend/app/layout.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import "./globals.css";
 import Header from "../components/Header";
+import SiteFooter from "../components/SiteFooter";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { createClient } from "@/lib/supabase/server";
@@ -33,6 +34,7 @@ export default async function RootLayout({
           <TooltipProvider delayDuration={200} disableHoverableContent>
             <Header />
             <main className="flex-1">{children}</main>
+            <SiteFooter />
             <Toaster />
           </TooltipProvider>
         </SupabaseProvider>

--- a/talentify-next-frontend/app/news/page.tsx
+++ b/talentify-next-frontend/app/news/page.tsx
@@ -1,0 +1,37 @@
+const newsItems = [
+  {
+    date: '2026-04-10',
+    title: '公開サイトと業務アプリ導線の整理を開始しました',
+    body: '公開ページを見ながら必要なときに業務画面へ移動できる構成への移行を進めています。',
+  },
+  {
+    date: '2026-04-07',
+    title: 'ご利用ガイドページを公開しました',
+    body: 'よくある利用フローや関連ページへの導線を集約した仮ページを公開しました。',
+  },
+  {
+    date: '2026-04-01',
+    title: 'フッター導線を追加しました',
+    body: 'FAQ・お知らせ・料金・会社概要へアクセスしやすい共通フッターを追加しました。',
+  },
+]
+
+export default function NewsPage() {
+  return (
+    <div className="mx-auto w-full max-w-5xl px-4 py-24 text-slate-900">
+      <header className="mb-6 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h1 className="text-3xl font-bold">お知らせ</h1>
+        <p className="mt-2 text-sm text-slate-600">Talentifyからのお知らせを掲載します。</p>
+      </header>
+      <div className="space-y-3">
+        {newsItems.map((item) => (
+          <article key={item.title} className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+            <p className="text-xs text-slate-500">{item.date}</p>
+            <h2 className="mt-1 text-lg font-semibold">{item.title}</h2>
+            <p className="mt-2 text-sm leading-6 text-slate-600">{item.body}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/talentify-next-frontend/app/page.tsx
+++ b/talentify-next-frontend/app/page.tsx
@@ -2,29 +2,14 @@ export const dynamic = 'auto'
 
 import Link from 'next/link';
 import Image from 'next/image';
-import { redirect } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { createClient } from '@/lib/supabase/server';
-import { getUserRoleInfo } from '@/lib/getUserRole';
 
 export default async function HomePage() {
   const supabase = await createClient();
   const {
     data: { session },
   } = await supabase.auth.getSession();
-
-  if (session) {
-    const { role, isSetupComplete } = await getUserRoleInfo(supabase, session.user.id);
-    if (role === 'store') {
-      redirect(isSetupComplete ? '/store/dashboard' : '/store/edit');
-    } else if (role === 'talent') {
-      redirect(isSetupComplete ? '/talent/dashboard' : '/talent/edit');
-    } else if (role === 'company') {
-      redirect(isSetupComplete ? '/company/dashboard' : '/company/edit');
-    } else {
-      redirect('/dashboard');
-    }
-  }
 
   return (
     <div className="flex flex-col items-center text-gray-900 bg-white">
@@ -44,11 +29,28 @@ export default async function HomePage() {
               </Button>
             </Link>
             <Link href="/register?role=talent">
-  <Button className="px-8 py-3 text-base rounded-full bg-white text-gray-900 hover:bg-gray-100 shadow-md">
-    演者として登録
-  </Button>
-</Link>
+              <Button className="px-8 py-3 text-base rounded-full bg-white text-gray-900 hover:bg-gray-100 shadow-md">
+                演者として登録
+              </Button>
+            </Link>
           </div>
+          {session && (
+            <div className="mt-6 rounded-xl bg-white/90 px-4 py-3 text-gray-900 shadow-md backdrop-blur-sm">
+              <p className="mb-3 text-sm font-medium">ログイン中です。業務アプリへ移動できます。</p>
+              <div className="flex flex-col justify-center gap-2 sm:flex-row">
+                <Link href="/app/dashboard">
+                  <Button variant="outline" className="w-full border-gray-300 bg-white text-gray-900 hover:bg-gray-50 sm:w-auto">
+                    ダッシュボードへ
+                  </Button>
+                </Link>
+                <Link href="/app/offers">
+                  <Button variant="outline" className="w-full border-gray-300 bg-white text-gray-900 hover:bg-gray-50 sm:w-auto">
+                    案件管理へ
+                  </Button>
+                </Link>
+              </div>
+            </div>
+          )}
         </div>
       </section>
 

--- a/talentify-next-frontend/app/pricing/page.tsx
+++ b/talentify-next-frontend/app/pricing/page.tsx
@@ -1,0 +1,26 @@
+export default function PricingPage() {
+  return (
+    <div className="mx-auto w-full max-w-5xl px-4 py-24 text-slate-900">
+      <header className="mb-6 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h1 className="text-3xl font-bold">料金</h1>
+        <p className="mt-2 text-sm text-slate-600">このページは仮公開中です。正式な料金情報は後日掲載します。</p>
+      </header>
+      <div className="grid gap-4 md:grid-cols-2">
+        <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+          <h2 className="text-lg font-semibold">今後掲載予定の内容</h2>
+          <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-slate-600">
+            <li>初期費用 / 月額費用</li>
+            <li>役割ごとの利用プラン</li>
+            <li>オプション機能</li>
+          </ul>
+        </section>
+        <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+          <h2 className="text-lg font-semibold">注記</h2>
+          <p className="mt-2 text-sm leading-6 text-slate-600">
+            現在は情報設計を優先しており、ここではページ構成のみ先行して公開しています。
+          </p>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/talentify-next-frontend/app/store/layout.tsx
+++ b/talentify-next-frontend/app/store/layout.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Header from "@/components/Header";
+import SiteFooter from "@/components/SiteFooter";
 import { createClient } from "@/lib/supabase/server";
 import { SupabaseProvider } from "@/lib/supabase/provider";
 
@@ -25,6 +26,7 @@ export default async function StoreLayout({
           <div className="flex flex-1 pt-16">
             <main className="flex-1 overflow-y-auto bg-[#f1f5f9] p-6">{children}</main>
           </div>
+          <SiteFooter />
         </SupabaseProvider>
       </body>
     </html>

--- a/talentify-next-frontend/app/talent/layout.tsx
+++ b/talentify-next-frontend/app/talent/layout.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Header from "@/components/Header";
+import SiteFooter from "@/components/SiteFooter";
 import { createClient } from "@/lib/supabase/server";
 import { SupabaseProvider } from "@/lib/supabase/provider";
 
@@ -25,6 +26,7 @@ export default async function TalentLayout({
           <div className="flex flex-1 pt-16">
             <main className="flex-1 overflow-y-auto bg-[#f1f5f9] p-6">{children}</main>
           </div>
+          <SiteFooter />
         </SupabaseProvider>
       </body>
     </html>

--- a/talentify-next-frontend/components/Header.tsx
+++ b/talentify-next-frontend/components/Header.tsx
@@ -117,6 +117,7 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
   const isProjectActive =
     !!roleNav &&
     roleNav.project.some((item) => pathname === item.href || pathname.startsWith(`${item.href}/`))
+  const isGuideActive = pathname === '/guide'
   const navItemBaseClass =
     'relative inline-flex h-9 items-center rounded-md px-2 text-sm font-medium text-slate-600 transition-all duration-150 hover:bg-slate-100 hover:text-slate-900'
   const navItemActiveClass = 'text-primary after:absolute after:inset-x-2 after:bottom-0 after:h-0.5 after:rounded-full after:bg-primary'
@@ -174,6 +175,15 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
                 ))}
               </DropdownMenuContent>
             </DropdownMenu>
+            <Link
+              href="/guide"
+              className={cn(
+                navItemBaseClass,
+                isGuideActive ? navItemActiveClass : '',
+              )}
+            >
+              ご利用ガイド
+            </Link>
           </div>
 
           <div className="flex items-center gap-3">

--- a/talentify-next-frontend/components/SiteFooter.tsx
+++ b/talentify-next-frontend/components/SiteFooter.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link'
+
+const footerLinks = [
+  { href: '/guide', label: 'ご利用ガイド' },
+  { href: '/faq', label: 'よくある質問' },
+  { href: '/news', label: 'お知らせ' },
+  { href: '/pricing', label: '料金' },
+  { href: '/company', label: '会社概要' },
+]
+
+export default function SiteFooter() {
+  return (
+    <footer className="mt-auto border-t border-slate-200 bg-white">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 py-4 text-xs text-slate-600 sm:flex-row sm:items-center sm:justify-between">
+        <nav className="flex flex-wrap items-center gap-x-4 gap-y-2">
+          {footerLinks.map((link) => (
+            <Link key={link.href} href={link.href} className="transition-colors hover:text-slate-900 hover:underline">
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+        <p className="text-slate-500">© Talentify</p>
+      </div>
+    </footer>
+  )
+}

--- a/talentify-next-frontend/middleware.ts
+++ b/talentify-next-frontend/middleware.ts
@@ -44,7 +44,7 @@ export async function middleware(req: NextRequest) {
 
   if (
     !session &&
-    ['/dashboard', '/store', '/talent', '/profile', '/messages', '/manage'].some(
+    ['/app', '/dashboard', '/store', '/talent', '/profile', '/messages', '/manage'].some(
       (p) => pathname.startsWith(p)
     )
   ) {
@@ -61,6 +61,7 @@ export const config = {
   matcher: [
     '/',
     '/dashboard/:path*',
+    '/app/:path*',
     '/store/:path*',
     '/talent/:path*',
     '/profile/:path*',


### PR DESCRIPTION
### Motivation
- Improve information architecture by separating public pages and the authenticated business app so public content remains discoverable even when users are logged in.
- Provide a minimal `/app` entry surface to migrate towards a unified app area without touching existing ` /store` and `/talent` pages immediately.
- Add lightweight site-wide navigational elements (`ご利用ガイド`, footer) and placeholder public pages so future content can be populated without broken links.

### Description
- Added an app-level layout and entry routes under `app/app/*` including `app/app/layout.tsx`, `app/app/page.tsx`, `app/app/dashboard`, `app/app/offers`, `app/app/talents`, and `app/app/notifications` which enforce login and redirect to role-specific pages (`/store/*` or `/talent/*`) as a bridge layer.
- Updated middleware in `middleware.ts` to include `'/app'` in the authentication-protected matcher so unauthenticated access to `/app/*` redirects to `'/login'` with `redirectedFrom`.
- Modified public home `app/page.tsx` to keep showing the LP for logged-in users and surface prominent CTAs linking to `'/app/dashboard'` and `'/app/offers'` when a session exists instead of forcing a redirect.
- Added `ご利用ガイド` link to the authenticated header via `components/Header.tsx` with active state handling for `'/guide'`.
- Added a lightweight site footer `components/SiteFooter.tsx` and integrated it into `app/layout.tsx`, `app/store/layout.tsx`, `app/talent/layout.tsx`, and the new `app/app/layout.tsx`.
- Created placeholder public pages for future content at `app/guide/page.tsx`, `app/column/page.tsx`, `app/news/page.tsx`, `app/pricing/page.tsx`, and `app/company/page.tsx` with basic UI sections for easy future replacement.
- Kept existing role-specific pages (`/store/*`, `/talent/*`) intact and treated `/app/*` as a routing/layout bridge to enable incremental migration.

### Testing
- Ran lint with `npm run lint`; it completed successfully with existing image-related ESLint warnings (`<img>` usage) but no new lint errors from the changes.
- Attempted `npm run build`; build failed at Prisma setup due to missing environment variable `DATABASE_URL` in this environment, which is an external configuration issue and not caused by the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8801f30fc8332b0e654fbd4da9055)