### PR TITLE
Adjust guide navigation UX and remove LP logged-in prompt block

### DIFF
--- a/talentify-next-frontend/app/page.tsx
+++ b/talentify-next-frontend/app/page.tsx
@@ -3,14 +3,8 @@ export const dynamic = 'auto'
 import Link from 'next/link';
 import Image from 'next/image';
 import { Button } from '@/components/ui/button';
-import { createClient } from '@/lib/supabase/server';
 
-export default async function HomePage() {
-  const supabase = await createClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-
+export default function HomePage() {
   return (
     <div className="flex flex-col items-center text-gray-900 bg-white">
       {/* Hero Section */}
@@ -34,23 +28,6 @@ export default async function HomePage() {
               </Button>
             </Link>
           </div>
-          {session && (
-            <div className="mt-6 rounded-xl bg-white/90 px-4 py-3 text-gray-900 shadow-md backdrop-blur-sm">
-              <p className="mb-3 text-sm font-medium">ログイン中です。業務アプリへ移動できます。</p>
-              <div className="flex flex-col justify-center gap-2 sm:flex-row">
-                <Link href="/app/dashboard">
-                  <Button variant="outline" className="w-full border-gray-300 bg-white text-gray-900 hover:bg-gray-50 sm:w-auto">
-                    ダッシュボードへ
-                  </Button>
-                </Link>
-                <Link href="/app/offers">
-                  <Button variant="outline" className="w-full border-gray-300 bg-white text-gray-900 hover:bg-gray-50 sm:w-auto">
-                    案件管理へ
-                  </Button>
-                </Link>
-              </div>
-            </div>
-          )}
         </div>
       </section>
 

--- a/talentify-next-frontend/components/Header.tsx
+++ b/talentify-next-frontend/components/Header.tsx
@@ -22,6 +22,11 @@ interface MenuItem {
   label: string
 }
 
+const GUIDE_LINKS: MenuItem[] = [
+  { href: '/guide', label: 'ご利用ガイド' },
+  // 将来的に /column, /news, /faq などをここへ追加してドロップダウン化できる構造
+]
+
 const ROLE_MENUS: Record<
   'store' | 'talent',
   { homeHref: string; primaryHref?: string; primaryLabel?: string; project: MenuItem[]; account: MenuItem[] }
@@ -117,7 +122,8 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
   const isProjectActive =
     !!roleNav &&
     roleNav.project.some((item) => pathname === item.href || pathname.startsWith(`${item.href}/`))
-  const isGuideActive = pathname === '/guide'
+  const primaryGuideLink = GUIDE_LINKS[0]
+  const isGuideActive = GUIDE_LINKS.some((item) => pathname === item.href || pathname.startsWith(`${item.href}/`))
   const navItemBaseClass =
     'relative inline-flex h-9 items-center rounded-md px-2 text-sm font-medium text-slate-600 transition-all duration-150 hover:bg-slate-100 hover:text-slate-900'
   const navItemActiveClass = 'text-primary after:absolute after:inset-x-2 after:bottom-0 after:h-0.5 after:rounded-full after:bg-primary'
@@ -176,13 +182,15 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
               </DropdownMenuContent>
             </DropdownMenu>
             <Link
-              href="/guide"
+              href={primaryGuideLink.href}
+              target="_blank"
+              rel="noopener noreferrer"
               className={cn(
                 navItemBaseClass,
                 isGuideActive ? navItemActiveClass : '',
               )}
             >
-              ご利用ガイド
+              {primaryGuideLink.label}
             </Link>
           </div>
 


### PR DESCRIPTION
### Motivation
- ヘッダーの「ご利用ガイド」を押して業務画面の文脈が切れてしまう問題を解消するため、`/guide` を別タブで開く導線に変更します。 
- 公開トップ（LP）に出していたログイン中向けの案内（「ログイン中です。業務アプリへ移動できます。」、`ダッシュボードへ`、`案件管理へ`）が不要なため削除してシンプルに戻します。 
- 将来的に `ご利用ガイド` をドロップダウンで拡張しやすいよう、リンクをまとめる軽量な構造にしておきます。 

### Description
- `components/Header.tsx`: `GUIDE_LINKS` 配列を追加し、現在は先頭要素を表示する形で `ご利用ガイド` を `href={primaryGuideLink.href}` に変更し `target="_blank"` と `rel="noopener noreferrer"` を付与しました。 
- `components/Header.tsx`: ガイドのアクティブ判定を単一パス判定から `GUIDE_LINKS` を参照するロジックに変更して将来の拡張を容易にしました. 
- `app/page.tsx`: パブリックトップからサーバーセッション取得とログイン中案内ブロックを削除してヒーローをシンプル化し、既存の登録CTAはそのまま維持しました。 
- 既存の案件管理ドロップダウンやその他ヘッダーの挙動には影響を与えないように実装しています。 

### Testing
- `npm run lint` was executed and completed successfully while reporting existing unrelated `<img>` warnings. 
- `npm run build` was run but failed in this environment because `prisma generate` cannot resolve `DATABASE_URL` (environment not configured). 
- `npm test -- --runInBand` was run and reported failing suites due to existing auth test setup issues (`client.auth.getUser` undefined), which appear unrelated to these UI changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d885b2074483328a4c9560c50ee0d4)