### PR TITLE
公開ページで常に未ログインヘッダーを表示するよう変更

### DIFF
--- a/talentify-next-frontend/components/Header.tsx
+++ b/talentify-next-frontend/components/Header.tsx
@@ -22,6 +22,23 @@ interface MenuItem {
   label: string
 }
 
+const PUBLIC_HEADER_PATHS = new Set([
+  '/',
+  '/about',
+  '/column',
+  '/company',
+  '/contact',
+  '/faq',
+  '/guide',
+  '/login',
+  '/manage',
+  '/news',
+  '/password-reset',
+  '/privacy',
+  '/register',
+  '/terms',
+])
+
 const GUIDE_LINKS: MenuItem[] = [
   { href: '/guide', label: 'ご利用ガイド' },
   // 将来的に /column, /news, /faq などをここへ追加してドロップダウン化できる構造
@@ -112,6 +129,16 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
   const inferredRole =
     sidebarRole ??
     (pathname?.startsWith('/store') ? 'store' : pathname?.startsWith('/talent') ? 'talent' : undefined)
+  const isPublicPage =
+    !inferredRole &&
+    !!pathname &&
+    (PUBLIC_HEADER_PATHS.has(pathname) ||
+      pathname.startsWith('/guide/') ||
+      pathname.startsWith('/column/') ||
+      pathname.startsWith('/news/') ||
+      pathname.startsWith('/company/') ||
+      pathname.startsWith('/faq/') ||
+      pathname.startsWith('/password-reset/'))
   const roleNav = inferredRole ? ROLE_MENUS[inferredRole] : null
   const homeHref = roleNav?.homeHref ?? '/'
 
@@ -219,6 +246,52 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
               </DropdownMenuContent>
             </DropdownMenu>
           </div>
+        </div>
+      </header>
+    )
+  }
+
+  if (isPublicPage) {
+    return (
+      <header className="fixed top-0 w-full h-16 bg-white shadow-sm z-[var(--z-header)]">
+        <div className="mx-auto flex h-full max-w-5xl items-center justify-between p-4">
+          <Link href={homeHref} className="text-2xl font-bold tracking-tight">
+            Talentify
+          </Link>
+
+          <nav className="hidden md:flex justify-between items-center w-full text-sm">
+            <div className="flex space-x-6 ml-6">
+              <Link href="/about" className="hover:underline">Talentifyについて</Link>
+              <Link href="/faq" className="hover:underline">FAQ</Link>
+              <Link href="/contact" className="hover:underline">お問い合わせ</Link>
+            </div>
+
+            <div className="flex items-center space-x-2 ml-auto">
+              <span className="text-black text-sm font-normal mr-2">今すぐ無料登録♬</span>
+              <Link
+                href="/register?role=store"
+                className="rounded-full bg-[#daa520] text-white font-normal px-5 py-2 hover:brightness-110 transition"
+              >
+                店舗の方はこちら
+              </Link>
+              <Link
+                href="/register?role=talent"
+                className="rounded-full bg-[#daa520] text-white font-normal px-5 py-2 hover:brightness-110 transition"
+              >
+                演者の方はこちら
+              </Link>
+              <Link
+                href="/login"
+                className="border border-[#daa520] text-[#daa520] font-normal rounded-full px-5 py-2 hover:bg-[#fef8e7] transition"
+              >
+                ログイン
+              </Link>
+            </div>
+          </nav>
+
+          <Button asChild variant="outline" size="sm" className="ml-auto md:hidden hover:bg-muted">
+            <Link href="/login">ログイン</Link>
+          </Button>
         </div>
       </header>
     )


### PR DESCRIPTION
### Motivation
- 公開ページ（`/`, `/guide`, `/column`, `/news`, `/company`, `/faq` など）ではセッションが残っていても未ログイン時と同じヘッダーUIに統一するための変更です。

### Description
- `components/Header.tsx` に公開ページ判定用のパス集合 `PUBLIC_HEADER_PATHS` を追加してルート種別ベースでヘッダーを分岐するようにしました。 
- 公開ページを判定する `isPublicPage` フラグを導入し、該当する場合は常に未ログイン向けヘッダー（登録導線 + `ログイン` ボタンが `
/login` に遷移）を返す早期リターンを追加しました。 
- `/guide` 系や `/column` `/news` `/company` `/faq` のサブパスも公開扱いになるようプレフィックス判定を追加しました。 
- アプリ側（`store` / `talent`）の既存ヘッダー（アカウント名表示、通知、案件管理等）は従来どおり維持しています（変更ファイル: `components/Header.tsx`）。

### Testing
- `npm run lint` を実行し成功しましたが、既存の `no-img-element` 警告が出ています（警告のみ）。
- `npm run build` を実行しましたが、環境変数 `DATABASE_URL` 未設定によりビルドは失敗しました（環境依存のため今回の変更が原因ではありません）。
- `npx tsc --noEmit` を実行しましたが、既存のテスト/Prisma 周辺の型エラーにより型チェックは失敗しました（今回の変更箇所によるものではありません）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d88ae004cc83328df8a710f112e8cb)