### PR TITLE
Fix duplicate footer rendering and widen header container

### DIFF
--- a/talentify-next-frontend/app/app/layout.tsx
+++ b/talentify-next-frontend/app/app/layout.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { redirect } from 'next/navigation'
 import Header from '@/components/Header'
-import SiteFooter from '@/components/SiteFooter'
 import { createClient } from '@/lib/supabase/server'
 import { SupabaseProvider } from '@/lib/supabase/provider'
 import { getUserRoleInfo } from '@/lib/getUserRole'
@@ -28,7 +27,6 @@ export default async function AppLayout({ children }: { children: React.ReactNod
       <div className="min-h-screen bg-[#f1f5f9] text-black flex flex-col">
         <Header sidebarRole={sidebarRole} />
         <main className="flex-1 overflow-y-auto bg-[#f1f5f9] p-6 pt-20">{children}</main>
-        <SiteFooter />
       </div>
     </SupabaseProvider>
   )

--- a/talentify-next-frontend/app/store/layout.tsx
+++ b/talentify-next-frontend/app/store/layout.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import Header from "@/components/Header";
-import SiteFooter from "@/components/SiteFooter";
 import { createClient } from "@/lib/supabase/server";
 import { SupabaseProvider } from "@/lib/supabase/provider";
 
@@ -26,7 +25,6 @@ export default async function StoreLayout({
           <div className="flex flex-1 pt-16">
             <main className="flex-1 overflow-y-auto bg-[#f1f5f9] p-6">{children}</main>
           </div>
-          <SiteFooter />
         </SupabaseProvider>
       </body>
     </html>

--- a/talentify-next-frontend/app/talent/layout.tsx
+++ b/talentify-next-frontend/app/talent/layout.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import Header from "@/components/Header";
-import SiteFooter from "@/components/SiteFooter";
 import { createClient } from "@/lib/supabase/server";
 import { SupabaseProvider } from "@/lib/supabase/provider";
 
@@ -26,7 +25,6 @@ export default async function TalentLayout({
           <div className="flex flex-1 pt-16">
             <main className="flex-1 overflow-y-auto bg-[#f1f5f9] p-6">{children}</main>
           </div>
-          <SiteFooter />
         </SupabaseProvider>
       </body>
     </html>

--- a/talentify-next-frontend/components/Header.tsx
+++ b/talentify-next-frontend/components/Header.tsx
@@ -162,7 +162,7 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
 
     return (
       <header className="fixed top-0 w-full h-16 bg-white shadow-sm z-[var(--z-header)]">
-        <div className="mx-auto flex h-full max-w-6xl items-center justify-between px-4">
+        <div className="mx-auto flex h-full w-full max-w-[1600px] items-center justify-between px-6 lg:px-8">
           <div className="flex items-center gap-5">
             <Link href={homeHref} className="text-2xl font-bold tracking-tight">
               Talentify
@@ -254,7 +254,7 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
   if (isPublicPage) {
     return (
       <header className="fixed top-0 w-full h-16 bg-white shadow-sm z-[var(--z-header)]">
-        <div className="mx-auto flex h-full max-w-5xl items-center justify-between p-4">
+        <div className="mx-auto flex h-full w-full max-w-[1400px] items-center justify-between px-6 lg:px-8">
           <Link href={homeHref} className="text-2xl font-bold tracking-tight">
             Talentify
           </Link>
@@ -299,7 +299,7 @@ export default function Header({ sidebarRole }: { sidebarRole?: 'talent' | 'stor
 
   return (
     <header className="fixed top-0 w-full h-16 bg-white shadow-sm z-[var(--z-header)]">
-      <div className="mx-auto flex h-full max-w-5xl items-center justify-between p-4">
+      <div className="mx-auto flex h-full w-full max-w-[1400px] items-center justify-between px-6 lg:px-8">
         <Link href={homeHref} className="text-2xl font-bold tracking-tight">
           Talentify
         </Link>


### PR DESCRIPTION
### Motivation

- Some pages showed the footer twice due to `SiteFooter` being rendered in both root and nested Next.js layouts. 
- The header content felt overly centered with large side gaps on wide screens, making logo and account items appear cramped. 
- The goal is to ensure a single footer instance and to let the header use more horizontal space without sticking to the viewport edges.

### Description

- Removed `SiteFooter` from nested layouts so the footer rendering responsibility remains in the root layout (`app/layout.tsx`), preventing duplicate footers by keeping a single footer placement. 
- Updated header inner container sizing to use wider max widths and padding, changing the role header to `w-full max-w-[1600px] px-6 lg:px-8` and public/default headers to `w-full max-w-[1400px] px-6 lg:px-8` so the header uses more horizontal space while preserving side breathing room. 
- Kept page/body content width and reading width unchanged so only header presentation is affected. 
- Modified files: `app/app/layout.tsx`, `app/store/layout.tsx`, `app/talent/layout.tsx`, and `components/Header.tsx`.

### Testing

- Ran `npm run lint` which completed successfully (existing `no-img-element` warnings remain but are unrelated to this change). 
- Ran `npm run build` which failed in this environment because `prisma generate` could not resolve `DATABASE_URL` (environment-specific issue). 
- Ran `npx tsc --noEmit` which failed due to unrelated repository-wide TypeScript/Prisma type errors not introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d88f89b4d88332a815abf2a8708421)