### PR TITLE
統一カラーパレットでオファー管理UIを落ち着いたSaaSトーンに刷新

### DIFF
--- a/talentify-next-frontend/app/company/offers/page.tsx
+++ b/talentify-next-frontend/app/company/offers/page.tsx
@@ -76,12 +76,12 @@ export default function CompanyOffersPage() {
   }
 
   return (
-    <main className='p-6 space-y-4'>
-      <h1 className='text-xl font-bold'>オファー管理</h1>
-      <div className='flex flex-wrap gap-2 text-sm items-end'>
+    <main className='space-y-4 bg-[#f8fafc] p-6'>
+      <h1 className='text-xl font-bold text-[#334155]'>オファー管理</h1>
+      <div className='flex flex-wrap items-end gap-2 text-sm text-[#334155]'>
         <div>
-          <label className='block'>ステータス</label>
-          <select value={status} onChange={e=>setStatus(e.target.value)} className='border rounded p-1'>
+          <label className='block text-[#64748b]'>ステータス</label>
+          <select value={status} onChange={e=>setStatus(e.target.value)} className='rounded border border-[#e2e8f0] bg-white p-1 text-[#334155]'>
             <option value='all'>すべて</option>
             <option value='pending'>保留中</option>
             <option value='confirmed'>承諾済み</option>
@@ -90,32 +90,32 @@ export default function CompanyOffersPage() {
           </select>
         </div>
         <div>
-          <label className='block'>名前検索</label>
-          <input type='text' value={keyword} onChange={e=>setKeyword(e.target.value)} className='border rounded p-1'/>
+          <label className='block text-[#64748b]'>名前検索</label>
+          <input type='text' value={keyword} onChange={e=>setKeyword(e.target.value)} className='rounded border border-[#e2e8f0] bg-white p-1 text-[#334155]'/>
         </div>
         <div>
-          <label className='block'>来店日From</label>
-          <input type='date' value={visitFrom} onChange={e=>setVisitFrom(e.target.value)} className='border rounded p-1'/>
+          <label className='block text-[#64748b]'>来店日From</label>
+          <input type='date' value={visitFrom} onChange={e=>setVisitFrom(e.target.value)} className='rounded border border-[#e2e8f0] bg-white p-1 text-[#334155]'/>
         </div>
         <div>
-          <label className='block'>来店日To</label>
-          <input type='date' value={visitTo} onChange={e=>setVisitTo(e.target.value)} className='border rounded p-1'/>
+          <label className='block text-[#64748b]'>来店日To</label>
+          <input type='date' value={visitTo} onChange={e=>setVisitTo(e.target.value)} className='rounded border border-[#e2e8f0] bg-white p-1 text-[#334155]'/>
         </div>
         <div>
-          <label className='block'>請求日From</label>
-          <input type='date' value={invoiceFrom} onChange={e=>setInvoiceFrom(e.target.value)} className='border rounded p-1'/>
+          <label className='block text-[#64748b]'>請求日From</label>
+          <input type='date' value={invoiceFrom} onChange={e=>setInvoiceFrom(e.target.value)} className='rounded border border-[#e2e8f0] bg-white p-1 text-[#334155]'/>
         </div>
         <div>
-          <label className='block'>請求日To</label>
-          <input type='date' value={invoiceTo} onChange={e=>setInvoiceTo(e.target.value)} className='border rounded p-1'/>
+          <label className='block text-[#64748b]'>請求日To</label>
+          <input type='date' value={invoiceTo} onChange={e=>setInvoiceTo(e.target.value)} className='rounded border border-[#e2e8f0] bg-white p-1 text-[#334155]'/>
         </div>
         <div>
-          <label className='block'>支払日From</label>
-          <input type='date' value={paidFrom} onChange={e=>setPaidFrom(e.target.value)} className='border rounded p-1'/>
+          <label className='block text-[#64748b]'>支払日From</label>
+          <input type='date' value={paidFrom} onChange={e=>setPaidFrom(e.target.value)} className='rounded border border-[#e2e8f0] bg-white p-1 text-[#334155]'/>
         </div>
         <div>
-          <label className='block'>支払日To</label>
-          <input type='date' value={paidTo} onChange={e=>setPaidTo(e.target.value)} className='border rounded p-1'/>
+          <label className='block text-[#64748b]'>支払日To</label>
+          <input type='date' value={paidTo} onChange={e=>setPaidTo(e.target.value)} className='rounded border border-[#e2e8f0] bg-white p-1 text-[#334155]'/>
         </div>
         <div className='ml-auto'>
           <Button size='sm' onClick={downloadCsv}>CSV出力</Button>
@@ -127,48 +127,48 @@ export default function CompanyOffersPage() {
       ) : filtered.length === 0 ? (
         <EmptyState title='該当するオファーがありません' />
       ) : (
-        <Table>
+        <Table className='overflow-hidden rounded-xl border border-[#e2e8f0] bg-white'>
           <TableHeader>
-            <TableRow>
-              <TableHead>オファーID</TableHead>
-              <TableHead>タレント名</TableHead>
-              <TableHead>店舗名</TableHead>
-              <TableHead>ステータス</TableHead>
-              <TableHead>来店日</TableHead>
-              <TableHead>報酬金額</TableHead>
-              <TableHead>契約確認</TableHead>
-              <TableHead>請求済</TableHead>
-              <TableHead>支払済</TableHead>
-              <TableHead>支払日</TableHead>
+            <TableRow className='border-b border-[#e2e8f0] bg-white'>
+              <TableHead className='text-[#334155]'>オファーID</TableHead>
+              <TableHead className='text-[#334155]'>タレント名</TableHead>
+              <TableHead className='text-[#334155]'>店舗名</TableHead>
+              <TableHead className='text-[#334155]'>ステータス</TableHead>
+              <TableHead className='text-[#334155]'>来店日</TableHead>
+              <TableHead className='text-[#334155]'>報酬金額</TableHead>
+              <TableHead className='text-[#334155]'>契約確認</TableHead>
+              <TableHead className='text-[#334155]'>請求済</TableHead>
+              <TableHead className='text-[#334155]'>支払済</TableHead>
+              <TableHead className='text-[#334155]'>支払日</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {filtered.map(o => (
-              <TableRow key={o.id}>
-                <TableCell>{o.id}</TableCell>
-                <TableCell>{o.talent_name}</TableCell>
-                <TableCell>{o.store_name}</TableCell>
-                <TableCell>{statusLabels[o.status ?? 'pending']}</TableCell>
-                <TableCell>{o.date ?? ''}</TableCell>
-                <TableCell>¥{(o.invoice_amount ?? o.reward ?? 0).toLocaleString()}</TableCell>
+              <TableRow key={o.id} className='border-b border-[#e2e8f0] hover:bg-[#f8fafc]'>
+                <TableCell className='text-[#334155]'>{o.id}</TableCell>
+                <TableCell className='text-[#334155]'>{o.talent_name}</TableCell>
+                <TableCell className='text-[#334155]'>{o.store_name}</TableCell>
+                <TableCell className='text-[#334155]'>{statusLabels[o.status ?? 'pending']}</TableCell>
+                <TableCell className='text-[#334155]'>{o.date ?? ''}</TableCell>
+                <TableCell className='text-[#334155]'>¥{(o.invoice_amount ?? o.reward ?? 0).toLocaleString()}</TableCell>
                 <TableCell>
-                  {o.agreed ? <Badge>確認済</Badge> : <Badge variant='destructive'>未確認</Badge>}
+                  {o.agreed ? <Badge className='border-[#2f4da0]/35 bg-[#eef2ff] text-[#2f4da0]' variant='outline'>確認済</Badge> : <Badge variant='outline' className='border-[#e2e8f0] bg-white text-[#64748b]'>未確認</Badge>}
                 </TableCell>
                 <TableCell>
                   {o.invoice_submitted ? (
-                    <Badge className='bg-green-600'>請求済</Badge>
+                    <Badge className='border-[#2f4da0]/35 bg-[#eef2ff] text-[#2f4da0]' variant='outline'>請求済</Badge>
                   ) : (
-                    <Badge className='bg-red-600'>未請求</Badge>
+                    <Badge variant='outline' className='border-[#e2e8f0] bg-white text-[#64748b]'>未請求</Badge>
                   )}
                 </TableCell>
                 <TableCell>
                   {o.paid ? (
-                    <Badge className='bg-green-600'>支払済</Badge>
+                    <Badge className='border-[#1f6b4f]/35 bg-[#ecfdf3] text-[#1f6b4f]' variant='outline'>支払済</Badge>
                   ) : (
-                    <Badge className='bg-yellow-500 text-white'>未支払</Badge>
+                    <Badge variant='outline' className='border-[#e2e8f0] bg-white text-[#64748b]'>未支払</Badge>
                   )}
                 </TableCell>
-                <TableCell>{o.paid_at ?? ''}</TableCell>
+                <TableCell className='text-[#334155]'>{o.paid_at ?? ''}</TableCell>
               </TableRow>
             ))}
           </TableBody>

--- a/talentify-next-frontend/app/store/offers/page.tsx
+++ b/talentify-next-frontend/app/store/offers/page.tsx
@@ -35,12 +35,12 @@ const statusVariants: Record<string, Parameters<typeof Badge>[0]['variant']> = {
 }
 
 const statusToneClasses: Record<string, string> = {
-  pending: 'border-[#a15c00]/45 bg-[#fff3e2] text-[#a15c00]',
-  confirmed: 'border-[#2f4da0]/45 bg-[#e9eefc] text-[#2f4da0]',
-  canceled: 'border-[#b42318]/45 bg-[#fff1f0] text-[#b42318]',
-  rejected: 'border-[#64748b]/45 bg-[#f1f5f9] text-[#64748b]',
-  completed: 'border-[#1f6b4f]/45 bg-[#e8f5ef] text-[#1f6b4f]',
-  expired: 'border-[#64748b]/45 bg-[#f1f5f9] text-[#64748b]',
+  pending: 'border-[#e2e8f0] bg-white text-[#64748b]',
+  confirmed: 'border-[#2f4da0]/35 bg-[#eef2ff] text-[#2f4da0]',
+  canceled: 'border-[#7f1d1d]/35 bg-[#fef2f2] text-[#7f1d1d]',
+  rejected: 'border-[#7f1d1d]/35 bg-[#fef2f2] text-[#7f1d1d]',
+  completed: 'border-[#1f6b4f]/35 bg-[#ecfdf3] text-[#1f6b4f]',
+  expired: 'border-[#7f1d1d]/35 bg-[#fef2f2] text-[#7f1d1d]',
 }
 
 type OfferTab = 'active' | 'history' | 'cancel'
@@ -124,28 +124,28 @@ export default function StoreOffersPage() {
   }
 
   return (
-    <main className="space-y-4 p-4 md:p-6">
+    <main className="space-y-4 bg-[#f8fafc] p-4 md:p-6">
       <div>
-        <h1 className="text-2xl font-bold text-slate-900">オファー管理</h1>
-        <p className="mt-1 text-sm text-slate-500">来店予定・進捗状況を一覧で確認できます。</p>
+        <h1 className="text-2xl font-bold text-[#334155]">オファー管理</h1>
+        <p className="mt-1 text-sm text-[#64748b]">来店予定・進捗状況を一覧で確認できます。</p>
       </div>
       <Tabs value={tab} onValueChange={value => setTab(value as OfferTab)}>
         <TabsList className="h-auto rounded-none border-b border-slate-200 bg-transparent p-0">
           <TabsTrigger
             value="active"
-            className="relative rounded-none border-b-2 border-transparent px-4 pb-3 pt-2 text-sm font-semibold text-slate-500 transition-colors hover:text-slate-800 data-[state=active]:border-slate-900 data-[state=active]:text-slate-900 data-[state=active]:shadow-none"
+            className="relative rounded-none border-b-2 border-transparent px-4 pb-3 pt-2 text-sm font-semibold text-[#64748b] transition-colors hover:text-[#334155] data-[state=active]:border-[#2f4da0] data-[state=active]:text-[#2f4da0] data-[state=active]:shadow-none"
           >
             進行中
           </TabsTrigger>
           <TabsTrigger
             value="history"
-            className="relative rounded-none border-b-2 border-transparent px-4 pb-3 pt-2 text-sm font-semibold text-slate-500 transition-colors hover:text-slate-800 data-[state=active]:border-slate-900 data-[state=active]:text-slate-900 data-[state=active]:shadow-none"
+            className="relative rounded-none border-b-2 border-transparent px-4 pb-3 pt-2 text-sm font-semibold text-[#64748b] transition-colors hover:text-[#334155] data-[state=active]:border-[#2f4da0] data-[state=active]:text-[#2f4da0] data-[state=active]:shadow-none"
           >
             履歴
           </TabsTrigger>
           <TabsTrigger
             value="cancel"
-            className="relative rounded-none border-b-2 border-transparent px-4 pb-3 pt-2 text-sm font-semibold text-slate-500 transition-colors hover:text-slate-800 data-[state=active]:border-slate-900 data-[state=active]:text-slate-900 data-[state=active]:shadow-none"
+            className="relative rounded-none border-b-2 border-transparent px-4 pb-3 pt-2 text-sm font-semibold text-[#64748b] transition-colors hover:text-[#334155] data-[state=active]:border-[#2f4da0] data-[state=active]:text-[#2f4da0] data-[state=active]:shadow-none"
           >
             キャンセル
           </TabsTrigger>
@@ -157,43 +157,43 @@ export default function StoreOffersPage() {
         <EmptyState title="対象のオファーがありません" />
       ) : (
         <>
-          <section className="hidden overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm md:block">
+          <section className="hidden overflow-x-auto rounded-xl border border-[#e2e8f0] bg-white shadow-sm md:block">
             <Table>
               <TableHeader className="sticky top-0 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/90">
-                <TableRow className="h-11 border-b border-slate-200 text-sm">
-                  <TableHead className="w-[180px] px-6 text-xs font-semibold tracking-wide text-slate-700" aria-sort={sortOrder === 'asc' ? 'ascending' : 'descending'}>
+                <TableRow className="h-11 border-b border-[#e2e8f0] text-sm">
+                  <TableHead className="w-[180px] px-6 text-xs font-semibold tracking-wide text-[#334155]" aria-sort={sortOrder === 'asc' ? 'ascending' : 'descending'}>
                     <button
                       type="button"
                       onClick={toggleSortOrder}
-                      className="inline-flex items-center gap-1 font-semibold text-slate-700 transition-colors hover:text-slate-900"
+                      className="inline-flex items-center gap-1 font-semibold text-[#334155] transition-colors hover:text-[#2f4da0]"
                     >
                       来店日
                       {sortOrder === 'asc' ? (
-                        <ChevronUp className="h-4 w-4 text-blue-700" aria-hidden="true" />
+                        <ChevronUp className="h-4 w-4 text-[#2f4da0]" aria-hidden="true" />
                       ) : (
-                        <ChevronDown className="h-4 w-4 text-blue-700" aria-hidden="true" />
+                        <ChevronDown className="h-4 w-4 text-[#2f4da0]" aria-hidden="true" />
                       )}
                       <span className="sr-only">来店日で並び替え</span>
                     </button>
                   </TableHead>
-                  <TableHead className="min-w-[220px] px-4 text-xs font-semibold tracking-wide text-slate-700">演者名</TableHead>
-                  <TableHead className="w-[150px] px-4 text-xs font-semibold tracking-wide text-slate-700">現在ステータス</TableHead>
-                  <TableHead className="min-w-[360px] px-4 text-xs font-semibold tracking-wide text-slate-700">進捗</TableHead>
-                  <TableHead className="w-[120px] px-6 text-right text-xs font-semibold tracking-wide text-slate-700">詳細</TableHead>
+                  <TableHead className="min-w-[220px] px-4 text-xs font-semibold tracking-wide text-[#334155]">演者名</TableHead>
+                  <TableHead className="w-[150px] px-4 text-xs font-semibold tracking-wide text-[#334155]">現在ステータス</TableHead>
+                  <TableHead className="min-w-[360px] px-4 text-xs font-semibold tracking-wide text-[#334155]">進捗</TableHead>
+                  <TableHead className="w-[120px] px-6 text-right text-xs font-semibold tracking-wide text-[#334155]">詳細</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {filtered.map(o => (
                   <TableRow
                     key={o.id}
-                    className="h-[68px] cursor-pointer border-b border-slate-300 transition-colors hover:bg-slate-100"
+                    className="h-[68px] cursor-pointer border-b border-[#e2e8f0] transition-colors hover:bg-[#f8fafc]"
                     onClick={() => handleRowClick(o.id)}
                   >
                     <TableCell className="px-6 align-middle">
-                      <div className="font-medium text-slate-900">{formatVisitDate(o.date)}</div>
+                      <div className="font-medium text-[#334155]">{formatVisitDate(o.date)}</div>
                     </TableCell>
                     <TableCell className="px-4 align-middle">
-                      <div className="truncate text-slate-900" title={o.talent_name ?? ''}>{o.talent_name ?? '-'}</div>
+                      <div className="truncate text-[#334155]" title={o.talent_name ?? ''}>{o.talent_name ?? '-'}</div>
                     </TableCell>
                     <TableCell className="px-4 align-middle">
                       <Badge
@@ -205,7 +205,7 @@ export default function StoreOffersPage() {
                     </TableCell>
                     <TableCell className="px-4 align-middle">
                       {CANCEL_STATUSES.has(o.status ?? '') ? (
-                        <Badge variant="outline" className="border-[#b42318]/45 bg-[#fff1f0] px-2.5 py-1 font-semibold text-[#b42318]">
+                        <Badge variant="outline" className="border-[#7f1d1d]/35 bg-[#fef2f2] px-2.5 py-1 font-semibold text-[#7f1d1d]">
                           キャンセル済み
                         </Badge>
                       ) : (
@@ -213,7 +213,7 @@ export default function StoreOffersPage() {
                       )}
                     </TableCell>
                     <TableCell className="px-6 align-middle text-right">
-                      <Button variant="ghost" size="sm" asChild className="text-blue-700 hover:bg-blue-50 hover:text-blue-800">
+                      <Button variant="ghost" size="sm" asChild className="text-[#2f4da0] hover:bg-[#eef2ff] hover:text-[#233a7a]">
                         <Link href={`/store/offers/${o.id}`} className="inline-flex items-center gap-1" onClick={event => event.stopPropagation()}>
                           詳細
                           <ChevronRight className="h-4 w-4" />
@@ -230,22 +230,22 @@ export default function StoreOffersPage() {
             {filtered.map(o => (
               <div
                 key={o.id}
-                className="space-y-3 rounded-2xl border border-slate-300 bg-white p-4 shadow-sm transition-colors hover:bg-slate-100"
+                className="space-y-3 rounded-2xl border border-[#e2e8f0] bg-white p-4 shadow-sm transition-colors hover:bg-[#f8fafc]"
                 onClick={() => handleRowClick(o.id)}
               >
                 <div className="flex items-center justify-between">
-                  <div className="text-sm font-medium text-slate-900">{formatVisitDate(o.date)}</div>
+                  <div className="text-sm font-medium text-[#334155]">{formatVisitDate(o.date)}</div>
                   <Badge variant={statusVariants[o.status ?? 'pending']} className={`rounded-md px-2.5 py-1 text-[11px] font-semibold ${statusToneClasses[o.status ?? 'pending'] ?? statusToneClasses.pending}`}>
                     {statusLabels[o.status ?? 'pending']}
                   </Badge>
                 </div>
-                <div className="text-base font-semibold text-slate-900" title={o.talent_name ?? ''}>
+                <div className="text-base font-semibold text-[#334155]" title={o.talent_name ?? ''}>
                   {o.talent_name ?? '-'}
                 </div>
                 <div className="-mx-1 overflow-x-auto">
                   {CANCEL_STATUSES.has(o.status ?? '') ? (
                     <div className="mx-1">
-                      <Badge variant="outline" className="border-[#b42318]/45 bg-[#fff1f0] px-2.5 py-1 font-semibold text-[#b42318]">
+                      <Badge variant="outline" className="border-[#7f1d1d]/35 bg-[#fef2f2] px-2.5 py-1 font-semibold text-[#7f1d1d]">
                         キャンセル済み
                       </Badge>
                     </div>
@@ -254,7 +254,7 @@ export default function StoreOffersPage() {
                   )}
                 </div>
                 <div className="flex justify-end">
-                  <Button variant="ghost" size="sm" asChild className="text-blue-700 hover:bg-blue-50 hover:text-blue-800">
+                  <Button variant="ghost" size="sm" asChild className="text-[#2f4da0] hover:bg-[#eef2ff] hover:text-[#233a7a]">
                     <Link href={`/store/offers/${o.id}`} className="inline-flex items-center gap-1" onClick={event => event.stopPropagation()}>
                       詳細
                       <ChevronRight className="h-4 w-4" />

--- a/talentify-next-frontend/app/talent/offers/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/page.tsx
@@ -36,12 +36,12 @@ const statusVariants: Record<string, Parameters<typeof Badge>[0]['variant']> = {
 }
 
 const statusToneClasses: Record<string, string> = {
-  pending: 'border-[#a15c00]/45 bg-[#fff3e2] text-[#a15c00]',
-  confirmed: 'border-[#2f4da0]/45 bg-[#e9eefc] text-[#2f4da0]',
-  canceled: 'border-[#b42318]/45 bg-[#fff1f0] text-[#b42318]',
-  rejected: 'border-[#64748b]/45 bg-[#f1f5f9] text-[#64748b]',
-  completed: 'border-[#1f6b4f]/45 bg-[#e8f5ef] text-[#1f6b4f]',
-  expired: 'border-[#64748b]/45 bg-[#f1f5f9] text-[#64748b]',
+  pending: 'border-[#e2e8f0] bg-white text-[#64748b]',
+  confirmed: 'border-[#2f4da0]/35 bg-[#eef2ff] text-[#2f4da0]',
+  canceled: 'border-[#7f1d1d]/35 bg-[#fef2f2] text-[#7f1d1d]',
+  rejected: 'border-[#7f1d1d]/35 bg-[#fef2f2] text-[#7f1d1d]',
+  completed: 'border-[#1f6b4f]/35 bg-[#ecfdf3] text-[#1f6b4f]',
+  expired: 'border-[#7f1d1d]/35 bg-[#fef2f2] text-[#7f1d1d]',
 }
 
 type OfferTab = 'active' | 'history' | 'cancel'
@@ -130,28 +130,28 @@ export default function TalentOffersPage() {
   }
 
   return (
-    <main className="space-y-4 p-4 md:p-6">
+    <main className="space-y-4 bg-[#f8fafc] p-4 md:p-6">
       <div>
-        <h1 className="text-2xl font-bold text-slate-900">オファー管理</h1>
-        <p className="mt-1 text-sm text-slate-500">受信したオファーと進捗を一覧で確認できます。</p>
+        <h1 className="text-2xl font-bold text-[#334155]">オファー管理</h1>
+        <p className="mt-1 text-sm text-[#64748b]">受信したオファーと進捗を一覧で確認できます。</p>
       </div>
       <Tabs value={tab} onValueChange={value => setTab(value as OfferTab)}>
         <TabsList className="h-auto rounded-none border-b border-slate-200 bg-transparent p-0">
           <TabsTrigger
             value="active"
-            className="relative rounded-none border-b-2 border-transparent px-4 pb-3 pt-2 text-sm font-semibold text-slate-500 transition-colors hover:text-slate-800 data-[state=active]:border-slate-900 data-[state=active]:text-slate-900 data-[state=active]:shadow-none"
+            className="relative rounded-none border-b-2 border-transparent px-4 pb-3 pt-2 text-sm font-semibold text-[#64748b] transition-colors hover:text-[#334155] data-[state=active]:border-[#2f4da0] data-[state=active]:text-[#2f4da0] data-[state=active]:shadow-none"
           >
             進行中
           </TabsTrigger>
           <TabsTrigger
             value="history"
-            className="relative rounded-none border-b-2 border-transparent px-4 pb-3 pt-2 text-sm font-semibold text-slate-500 transition-colors hover:text-slate-800 data-[state=active]:border-slate-900 data-[state=active]:text-slate-900 data-[state=active]:shadow-none"
+            className="relative rounded-none border-b-2 border-transparent px-4 pb-3 pt-2 text-sm font-semibold text-[#64748b] transition-colors hover:text-[#334155] data-[state=active]:border-[#2f4da0] data-[state=active]:text-[#2f4da0] data-[state=active]:shadow-none"
           >
             履歴
           </TabsTrigger>
           <TabsTrigger
             value="cancel"
-            className="relative rounded-none border-b-2 border-transparent px-4 pb-3 pt-2 text-sm font-semibold text-slate-500 transition-colors hover:text-slate-800 data-[state=active]:border-slate-900 data-[state=active]:text-slate-900 data-[state=active]:shadow-none"
+            className="relative rounded-none border-b-2 border-transparent px-4 pb-3 pt-2 text-sm font-semibold text-[#64748b] transition-colors hover:text-[#334155] data-[state=active]:border-[#2f4da0] data-[state=active]:text-[#2f4da0] data-[state=active]:shadow-none"
           >
             キャンセル
           </TabsTrigger>
@@ -163,43 +163,43 @@ export default function TalentOffersPage() {
         <EmptyState title="対象のオファーがありません" />
       ) : (
         <>
-          <section className="hidden overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm md:block">
+          <section className="hidden overflow-x-auto rounded-xl border border-[#e2e8f0] bg-white shadow-sm md:block">
             <Table>
               <TableHeader className="sticky top-0 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/90">
-                <TableRow className="h-11 border-b border-slate-200 text-sm">
-                  <TableHead className="w-[180px] px-6 text-xs font-semibold tracking-wide text-slate-700" aria-sort={sortOrder === 'asc' ? 'ascending' : 'descending'}>
+                <TableRow className="h-11 border-b border-[#e2e8f0] text-sm">
+                  <TableHead className="w-[180px] px-6 text-xs font-semibold tracking-wide text-[#334155]" aria-sort={sortOrder === 'asc' ? 'ascending' : 'descending'}>
                     <button
                       type="button"
                       onClick={toggleSortOrder}
-                      className="inline-flex items-center gap-1 font-semibold text-slate-700 transition-colors hover:text-slate-900"
+                      className="inline-flex items-center gap-1 font-semibold text-[#334155] transition-colors hover:text-[#2f4da0]"
                     >
                       来店日
                       {sortOrder === 'asc' ? (
-                        <ChevronUp className="h-4 w-4 text-blue-700" aria-hidden="true" />
+                        <ChevronUp className="h-4 w-4 text-[#2f4da0]" aria-hidden="true" />
                       ) : (
-                        <ChevronDown className="h-4 w-4 text-blue-700" aria-hidden="true" />
+                        <ChevronDown className="h-4 w-4 text-[#2f4da0]" aria-hidden="true" />
                       )}
                       <span className="sr-only">来店日で並び替え</span>
                     </button>
                   </TableHead>
-                  <TableHead className="min-w-[220px] px-4 text-xs font-semibold tracking-wide text-slate-700">店舗名</TableHead>
-                  <TableHead className="w-[150px] px-4 text-xs font-semibold tracking-wide text-slate-700">現在ステータス</TableHead>
-                  <TableHead className="min-w-[360px] px-4 text-xs font-semibold tracking-wide text-slate-700">進捗</TableHead>
-                  <TableHead className="w-[120px] px-6 text-right text-xs font-semibold tracking-wide text-slate-700">詳細</TableHead>
+                  <TableHead className="min-w-[220px] px-4 text-xs font-semibold tracking-wide text-[#334155]">店舗名</TableHead>
+                  <TableHead className="w-[150px] px-4 text-xs font-semibold tracking-wide text-[#334155]">現在ステータス</TableHead>
+                  <TableHead className="min-w-[360px] px-4 text-xs font-semibold tracking-wide text-[#334155]">進捗</TableHead>
+                  <TableHead className="w-[120px] px-6 text-right text-xs font-semibold tracking-wide text-[#334155]">詳細</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {filtered.map(o => (
                   <TableRow
                     key={o.id}
-                    className="h-[68px] cursor-pointer border-b border-slate-300 transition-colors hover:bg-slate-100"
+                    className="h-[68px] cursor-pointer border-b border-[#e2e8f0] transition-colors hover:bg-[#f8fafc]"
                     onClick={() => handleRowClick(o.id)}
                   >
                     <TableCell className="px-6 align-middle">
-                      <div className="font-medium text-slate-900">{formatVisitDate(o.date)}</div>
+                      <div className="font-medium text-[#334155]">{formatVisitDate(o.date)}</div>
                     </TableCell>
                     <TableCell className="px-4 align-middle">
-                      <div className="truncate text-slate-900" title={o.store_name ?? ''}>
+                      <div className="truncate text-[#334155]" title={o.store_name ?? ''}>
                         {o.store_name ?? '-'}
                       </div>
                     </TableCell>
@@ -213,7 +213,7 @@ export default function TalentOffersPage() {
                     </TableCell>
                     <TableCell className="px-4 align-middle">
                       {CANCEL_STATUSES.has(o.status ?? '') ? (
-                        <Badge variant="outline" className="border-[#b42318]/45 bg-[#fff1f0] px-2.5 py-1 font-semibold text-[#b42318]">
+                        <Badge variant="outline" className="border-[#7f1d1d]/35 bg-[#fef2f2] px-2.5 py-1 font-semibold text-[#7f1d1d]">
                           キャンセル済み
                         </Badge>
                       ) : (
@@ -221,7 +221,7 @@ export default function TalentOffersPage() {
                       )}
                     </TableCell>
                     <TableCell className="px-6 align-middle text-right">
-                      <Button variant="ghost" size="sm" asChild className="text-blue-700 hover:bg-blue-50 hover:text-blue-800">
+                      <Button variant="ghost" size="sm" asChild className="text-[#2f4da0] hover:bg-[#eef2ff] hover:text-[#233a7a]">
                         <Link href={`/talent/offers/${o.id}`} className="inline-flex items-center gap-1" onClick={event => event.stopPropagation()}>
                           詳細
                           <ChevronRight className="h-4 w-4" />
@@ -238,22 +238,22 @@ export default function TalentOffersPage() {
             {filtered.map(o => (
               <div
                 key={o.id}
-                className="space-y-3 rounded-2xl border border-slate-300 bg-white p-4 shadow-sm transition-colors hover:bg-slate-100"
+                className="space-y-3 rounded-2xl border border-[#e2e8f0] bg-white p-4 shadow-sm transition-colors hover:bg-[#f8fafc]"
                 onClick={() => handleRowClick(o.id)}
               >
                 <div className="flex items-center justify-between">
-                  <div className="text-sm font-medium text-slate-900">{formatVisitDate(o.date)}</div>
+                  <div className="text-sm font-medium text-[#334155]">{formatVisitDate(o.date)}</div>
                   <Badge variant={statusVariants[o.status ?? 'pending']} className={`rounded-md px-2.5 py-1 text-[11px] font-semibold ${statusToneClasses[o.status ?? 'pending'] ?? statusToneClasses.pending}`}>
                     {statusLabels[o.status ?? 'pending']}
                   </Badge>
                 </div>
-                <div className="text-base font-semibold text-slate-900" title={o.store_name ?? ''}>
+                <div className="text-base font-semibold text-[#334155]" title={o.store_name ?? ''}>
                   {o.store_name ?? '-'}
                 </div>
                 <div className="-mx-1 overflow-x-auto">
                   {CANCEL_STATUSES.has(o.status ?? '') ? (
                     <div className="mx-1">
-                      <Badge variant="outline" className="border-[#b42318]/45 bg-[#fff1f0] px-2.5 py-1 font-semibold text-[#b42318]">
+                      <Badge variant="outline" className="border-[#7f1d1d]/35 bg-[#fef2f2] px-2.5 py-1 font-semibold text-[#7f1d1d]">
                         キャンセル済み
                       </Badge>
                     </div>
@@ -262,7 +262,7 @@ export default function TalentOffersPage() {
                   )}
                 </div>
                 <div className="flex justify-end">
-                  <Button variant="ghost" size="sm" asChild className="text-blue-700 hover:bg-blue-50 hover:text-blue-800">
+                  <Button variant="ghost" size="sm" asChild className="text-[#2f4da0] hover:bg-[#eef2ff] hover:text-[#233a7a]">
                     <Link href={`/talent/offers/${o.id}`} className="inline-flex items-center gap-1" onClick={event => event.stopPropagation()}>
                       詳細
                       <ChevronRight className="h-4 w-4" />

--- a/talentify-next-frontend/components/offer/OfferProgressStatusIcons.tsx
+++ b/talentify-next-frontend/components/offer/OfferProgressStatusIcons.tsx
@@ -17,15 +17,15 @@ const statusLabel: Record<OfferProgressStep['status'], string> = {
 const baseCircleStyles = 'flex h-8 w-8 items-center justify-center rounded-full'
 
 const iconContainerStyles: Record<OfferProgressStep['status'], string> = {
-  complete: 'bg-[#e8f5ef] text-[#1f6b4f] ring-1 ring-[#1f6b4f]/30',
-  current: 'bg-[#e9eefc] text-[#2f4da0] ring-1 ring-[#2f4da0]/30',
-  upcoming: 'bg-[#f1f5f9] text-[#64748b] ring-1 ring-[#cbd5e1]',
+  complete: 'bg-[#eef2ff] text-[#2f4da0] ring-1 ring-[#2f4da0]/35',
+  current: 'bg-[#eef2ff] text-[#2f4da0] ring-1 ring-[#2f4da0]/35',
+  upcoming: 'bg-white text-[#64748b] ring-1 ring-[#e2e8f0]',
 }
 
 const iconByStatus: Record<OfferProgressStep['status'], ReactNode> = {
   complete: <Check className="h-4 w-4" strokeWidth={2.2} />,
   current: <ArrowRight className="h-4 w-4" strokeWidth={2.2} />,
-  upcoming: <span className="h-1.5 w-1.5 rounded-full bg-slate-400" />,
+  upcoming: <span className="h-1.5 w-1.5 rounded-full bg-[#94a3b8]" />,
 }
 
 const STEP_SHORT_LABELS: Record<OfferProgressStep['key'], string> = {
@@ -44,9 +44,9 @@ type OfferProgressStatusIconsProps = {
 }
 
 const badgeVariantStyles: Record<OfferProgressBadge['variant'], string> = {
-  default: 'border-[#2f4da0]/45 text-[#2f4da0] bg-[#e9eefc]',
-  secondary: 'border-[#a15c00]/45 text-[#a15c00] bg-[#fff3e2]',
-  success: 'border-[#1f6b4f]/45 text-[#1f6b4f] bg-[#e8f5ef]',
+  default: 'border-[#2f4da0]/35 text-[#2f4da0] bg-[#eef2ff]',
+  secondary: 'border-[#e2e8f0] text-[#64748b] bg-white',
+  success: 'border-[#1f6b4f]/35 text-[#1f6b4f] bg-[#ecfdf3]',
 }
 
 export function OfferProgressStatusIcons({ steps, badge, className }: OfferProgressStatusIconsProps) {
@@ -72,7 +72,7 @@ export function OfferProgressStatusIcons({ steps, badge, className }: OfferProgr
             <Tooltip key={step.key}>
               <TooltipTrigger asChild>
                 <span
-                  className="flex flex-col items-center gap-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300/40 focus-visible:ring-offset-2"
+                  className="flex flex-col items-center gap-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#2f4da0]/35 focus-visible:ring-offset-2"
                   tabIndex={0}
                 >
                   <span
@@ -84,17 +84,17 @@ export function OfferProgressStatusIcons({ steps, badge, className }: OfferProgr
                       {OFFER_STEP_LABELS[step.key]}: {statusLabel[step.status]}
                     </span>
                   </span>
-                  <span className="mt-1 text-[11px] font-medium text-slate-500">
+                  <span className="mt-1 text-[11px] font-medium text-[#64748b]">
                     {STEP_SHORT_LABELS[step.key]}
                   </span>
                 </span>
               </TooltipTrigger>
               <TooltipContent
                 role="tooltip"
-                className="z-50 rounded-md border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700 shadow-md"
+                className="z-50 rounded-md border border-[#e2e8f0] bg-white px-2 py-1 text-xs text-[#334155] shadow-md"
               >
-                <div className="font-semibold text-slate-900">{OFFER_STEP_LABELS[step.key]}</div>
-                <div className="text-slate-600">{statusLabel[step.status]}</div>
+                <div className="font-semibold text-[#334155]">{OFFER_STEP_LABELS[step.key]}</div>
+                <div className="text-[#64748b]">{statusLabel[step.status]}</div>
               </TooltipContent>
             </Tooltip>
           ))}

--- a/talentify-next-frontend/components/offer/OfferProgressTracker.tsx
+++ b/talentify-next-frontend/components/offer/OfferProgressTracker.tsx
@@ -12,29 +12,29 @@ interface OfferProgressTrackerProps {
 }
 
 const titleColorByStatus: Record<OfferProgressStep['status'], string> = {
-  complete: 'text-[#00B26F]',
-  current: 'text-[#1976D2]',
-  upcoming: 'text-slate-400',
+  complete: 'text-[#2f4da0]',
+  current: 'text-[#2f4da0]',
+  upcoming: 'text-[#64748b]',
 }
 
 const dateColorByStatus: Record<OfferProgressStep['status'], string> = {
-  complete: 'text-slate-500',
-  current: 'text-[#1976D2]',
-  upcoming: 'text-slate-400',
+  complete: 'text-[#64748b]',
+  current: 'text-[#64748b]',
+  upcoming: 'text-[#64748b]',
 }
 
 const iconStylesByStatus: Record<OfferProgressStep['status'], { outer: string; inner: string }> = {
   complete: {
-    outer: 'border-2 border-[#00B26F]',
-    inner: 'bg-[#00B26F] text-white',
+    outer: 'border-2 border-[#2f4da0]',
+    inner: 'bg-[#2f4da0] text-white',
   },
   current: {
     outer: 'border-2 border-transparent',
-    inner: 'bg-[#1976D2] text-white',
+    inner: 'bg-[#2f4da0] text-white',
   },
   upcoming: {
-    outer: 'border border-[#BDBDBD]',
-    inner: 'bg-white text-[#BDBDBD]',
+    outer: 'border border-[#e2e8f0]',
+    inner: 'bg-white text-[#94a3b8]',
   },
 }
 
@@ -46,7 +46,7 @@ export default function OfferProgressTracker({ steps, selectedStep, onStepSelect
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-end">
-        <span className="text-xs font-medium text-slate-500">
+        <span className="text-xs font-medium text-[#64748b]">
           {completedCount}/{steps.length}ステップ完了
         </span>
       </div>
@@ -67,14 +67,14 @@ export default function OfferProgressTracker({ steps, selectedStep, onStepSelect
                   {index > 0 && (
                     <span
                       className="absolute left-0 top-7 block h-1 w-1/2 -translate-y-1/2 rounded-full"
-                      style={{ backgroundColor: leftConnectorActive ? '#1976D2' : '#E0E0E0' }}
+                      style={{ backgroundColor: leftConnectorActive ? '#2f4da0' : '#e2e8f0' }}
                       aria-hidden="true"
                     />
                   )}
                   {index < steps.length - 1 && (
                     <span
                       className="absolute right-0 top-7 block h-1 w-1/2 -translate-y-1/2 rounded-full"
-                      style={{ backgroundColor: rightConnectorActive ? '#1976D2' : '#E0E0E0' }}
+                      style={{ backgroundColor: rightConnectorActive ? '#2f4da0' : '#e2e8f0' }}
                       aria-hidden="true"
                     />
                   )}
@@ -88,7 +88,7 @@ export default function OfferProgressTracker({ steps, selectedStep, onStepSelect
                       className={cn(
                         'relative z-10 flex h-14 w-14 items-center justify-center rounded-full transition-all',
                         iconStyles.outer,
-                        isSelected && 'ring-2 ring-[#1976D2] ring-opacity-60 ring-offset-2',
+                        isSelected && 'ring-2 ring-[#2f4da0] ring-opacity-35 ring-offset-2',
                       )}
                     >
                       <div


### PR DESCRIPTION
### Motivation

- オファー管理画面（store / talent / company）の配色がバラバラで見た目が安っぽく見えるため、色数を減らして業務SaaSらしい落ち着いたトーンに統一する。 
- 既存の API / 認証 / ルーティング / データ取得の挙動は一切変えず、見た目（スタイル・表示ロジック）のみを調整する。 

### Description

- 対象ファイルをカラーガイド（グレー + メイン青 #2f4da0、補助色 `#334155`, `#64748b`, `#e2e8f0`, `#f8fafc`）に合わせて更新し、色数を削減した（変更ファイル: `app/store/offers/page.tsx`, `app/talent/offers/page.tsx`, `app/company/offers/page.tsx`, `components/offer/OfferProgressStatusIcons.tsx`, `components/offer/OfferProgressTracker.tsx`）。
- ステータスバッジを意味ベースで整理し、完了は緑、キャンセル系は赤、それ以外はグレー/青で統一するように `statusToneClasses` 等を調整した。 
- 進捗 UI（ステップアイコン／トラッカー）を単色寄りに再設計し、未完了はグレー、進行中/完了は青系に統一してコネクターやリングの色も合わせた。 
- テーブル・タブ・フォーム要素・ボタンの文字色・境界線・hover 挙動を白ベース＋薄い境界線＋薄グレー hover に統一し、視認性を高めた（クラス名／インラインスタイル置換のみ）。

### Testing

- `npm run lint` を実行して ESLint を確認し、実行は成功で既存の `<img>` に関する警告が出力されました（エラーはなし）。
- `npm run build` はローカル環境で `DATABASE_URL` が未設定のためビルドが中断されましたが、停止理由は環境変数未設定でありコード由来のビルドエラーは確認できていません。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d890f6d6d48332af0249bdb101d531)