### PR TITLE
store/talent レイアウトのUI統一とフッター消失バグ修正

### DIFF
--- a/talentify-next-frontend/app/globals.css
+++ b/talentify-next-frontend/app/globals.css
@@ -4,7 +4,7 @@
 
 /* カスタムCSS変数の定義 */
 :root {
-  --background: #ffffff;
+  --background: #f8fafc;
   --foreground: #171717;
   --font-inter: 'Inter', sans-serif;
   --z-header: 50;
@@ -30,6 +30,47 @@ body {
   color: var(--foreground);
   font-family: var(--font-inter), Arial, Helvetica, sans-serif;
   line-height: 1.75;
+}
+
+.role-page-container {
+  margin: 0 auto;
+  width: 100%;
+  max-width: 1200px;
+  padding: 1.5rem 1rem 2rem;
+}
+
+.role-page-card {
+  border-radius: 0.875rem;
+  border: 1px solid #e2e8f0;
+  background: #ffffff;
+  padding: 1.25rem;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+}
+
+.role-page-card table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #ffffff;
+}
+
+.role-page-card thead {
+  background: #f8fafc;
+}
+
+.role-page-card tr {
+  background: #ffffff;
+}
+
+.role-page-card th,
+.role-page-card td {
+  border-color: #e2e8f0;
+}
+
+.role-page-card form {
+  border-radius: 0.75rem;
+  border: 1px solid #e2e8f0;
+  background: #ffffff;
+  padding: 1rem;
 }
 
 .toast-portal {

--- a/talentify-next-frontend/app/store/layout.tsx
+++ b/talentify-next-frontend/app/store/layout.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Header from "@/components/Header";
+import SiteFooter from "@/components/SiteFooter";
 import { createClient } from "@/lib/supabase/server";
 import { SupabaseProvider } from "@/lib/supabase/provider";
 
@@ -19,12 +20,15 @@ export default async function StoreLayout({
 
   return (
     <html lang="ja" className="h-full">
-      <body className="font-sans antialiased bg-[#f1f5f9] text-black min-h-screen flex flex-col">
+      <body className="font-sans antialiased bg-[#f8fafc] text-black min-h-screen flex flex-col">
         <SupabaseProvider session={session}>
           <Header sidebarRole="store" />
-          <div className="flex flex-1 pt-16">
-            <main className="flex-1 overflow-y-auto bg-[#f1f5f9] p-6">{children}</main>
-          </div>
+          <main className="flex-1 pt-16">
+            <div className="role-page-container">
+              <div className="role-page-card">{children}</div>
+            </div>
+          </main>
+          <SiteFooter />
         </SupabaseProvider>
       </body>
     </html>

--- a/talentify-next-frontend/app/talent/layout.tsx
+++ b/talentify-next-frontend/app/talent/layout.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Header from "@/components/Header";
+import SiteFooter from "@/components/SiteFooter";
 import { createClient } from "@/lib/supabase/server";
 import { SupabaseProvider } from "@/lib/supabase/provider";
 
@@ -19,12 +20,15 @@ export default async function TalentLayout({
 
   return (
     <html lang="ja" className="h-full">
-      <body className="font-sans antialiased bg-[#f1f5f9] text-black min-h-screen flex flex-col">
+      <body className="font-sans antialiased bg-[#f8fafc] text-black min-h-screen flex flex-col">
         <SupabaseProvider session={session}>
           <Header sidebarRole="talent" />
-          <div className="flex flex-1 pt-16">
-            <main className="flex-1 overflow-y-auto bg-[#f1f5f9] p-6">{children}</main>
-          </div>
+          <main className="flex-1 pt-16">
+            <div className="role-page-container">
+              <div className="role-page-card">{children}</div>
+            </div>
+          </main>
+          <SiteFooter />
         </SupabaseProvider>
       </body>
     </html>


### PR DESCRIPTION
### Motivation

- store / talent 配下の全ページでUIを統一しつつ、クライアント遷移時にフッターが消える不具合を修正するための変更です。

### Description

- `app/store/layout.tsx` と `app/talent/layout.tsx` を更新し、`Header -> main (flex-1) -> Footer` の縦構造を明示して `SiteFooter` を常時配置することでフッターの消失を防止しました。
- 両レイアウトで背景色を `#f8fafc` に統一し、`main` を `flex-1 pt-16` にしてヘッダー下の余白を維持するようにしました。
- グローバルCSS (`app/globals.css`) に `role-page-container`（中央寄せ・max-width・padding）と `role-page-card`（白カード・border・radius・padding・shadow）を追加し、テーブル・フォームの見た目をカード内で統一しました。
- 変更ファイル: `app/store/layout.tsx`, `app/talent/layout.tsx`, `app/globals.css`.

### Testing

- 実行した自動化コマンドは `npm run build` で、ビルドは起動しましたが `DATABASE_URL` 環境変数未設定による Prisma 初期化エラーで停止したため最終ビルドは完了していません（今回の変更によるものではありません）。
- 他の自動テストは実行しておらず、スタイルとレイアウト変更はアプリの既存認証/API/ルーティング処理を変更していません。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d896d87ed0833283c348b75f3c6901)