### PR TITLE
Refine talent detail UI and remove talents sidebar

### DIFF
--- a/talentify-next-frontend/app/talents/[id]/TalentDetailPageClient.tsx
+++ b/talentify-next-frontend/app/talents/[id]/TalentDetailPageClient.tsx
@@ -127,157 +127,176 @@ export default function TalentDetailPageClient({ id, initialTalent }: Props) {
 
   return (
     <>
-    <main className="w-full max-w-[1333px] mx-auto p-4 mt-16 grid gap-8 md:grid-cols-[60%_40%]">
-      {/* 左カラム: 画像ギャラリー */}
-      <div className="w-full md:max-w-[800px]">
-        <div className="relative w-full aspect-[4/5] rounded-xl overflow-hidden bg-gray-100">
-          {photos.length > 0 ? (
-            <Image
-              key={photos[selectedPhoto]}
-              src={photos[selectedPhoto]}
-              alt={`${talent.stage_name} ${selectedPhoto + 1}`}
-              fill
-              className={clsx('object-cover w-full h-full transition-opacity duration-300', imageLoaded ? 'opacity-100' : 'opacity-0')}
-              onLoad={() => setImageLoaded(true)}
-            />
-          ) : (
-            <div className="w-full h-full flex items-center justify-center text-gray-500">No Image</div>
-          )}
-        </div>
-        {photos.length > 1 && (
-          <div className="grid grid-cols-4 gap-2 mt-2">
-            {photos.map((src, i) => (
-              <button
-                key={i}
-                aria-label={`サムネイル${i + 1}`}
-                onClick={() => {
-                  setSelectedPhoto(i)
-                  setImageLoaded(false)
-                }}
-                className={clsx(
-                  'relative w-full h-[100px] rounded-lg overflow-hidden border',
-                  i === selectedPhoto ? 'border-blue-500' : 'border-transparent hover:border-gray-300'
+      <main className="role-page-container pt-6 pb-10">
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)]">
+          <Card className="overflow-hidden border-slate-200 shadow-sm">
+            <CardContent className="p-4 md:p-5">
+              <div className="relative mx-auto w-full max-w-2xl aspect-[4/5] max-h-[620px] overflow-hidden rounded-2xl bg-slate-100">
+                {photos.length > 0 ? (
+                  <Image
+                    key={photos[selectedPhoto]}
+                    src={photos[selectedPhoto]}
+                    alt={`${talent.stage_name} ${selectedPhoto + 1}`}
+                    fill
+                    className={clsx('h-full w-full object-cover transition-opacity duration-300', imageLoaded ? 'opacity-100' : 'opacity-0')}
+                    onLoad={() => setImageLoaded(true)}
+                  />
+                ) : (
+                  <div className="flex h-full w-full items-center justify-center text-sm text-slate-500">No Image</div>
                 )}
-              >
-                <Image src={src} alt={talent.stage_name} fill className="object-cover" />
-              </button>
-            ))}
-          </div>
-        )}
-      </div>
-
-      {/* 右カラム: 詳細情報 */}
-      <div className="space-y-6 md:sticky md:top-16 h-fit">
-        <div>
-          <h1 className="text-3xl font-bold">{talent.stage_name}</h1>
-          {talent.profile && <p className="mt-1 text-sm whitespace-pre-line">{talent.profile}</p>}
-        </div>
-
-        {/* CTA ボタン群 */}
-        <div className="space-y-2">
-          <Button className="w-full" aria-label="このキャストにオファーする" onClick={() => (window.location.href = `/talents/${id}/offer`)}>
-            このキャストにオファーする
-          </Button>
-          <div className="flex gap-2">
-            {(role === 'store' || role === null) && (
-              <Button variant="outline" className="flex-1" aria-label="メッセージを送る" onClick={handleMessage}>
-                <MessageSquare className="w-4 h-4 mr-1" />メッセージを送る
-              </Button>
-            )}
-            <Button variant="outline" className="flex-1" aria-label="シェア" onClick={handleShare}>
-              <Share2 className="w-4 h-4 mr-1" />シェア
-            </Button>
-            <Button variant="outline" className="flex-1" aria-label="お気に入り" onClick={handleFavorite}>
-              <Heart className={clsx('w-4 h-4 mr-1', isFavorite ? 'fill-current text-red-500' : '')} />お気に入り
-            </Button>
-          </div>
-        </div>
-
-        {/* クイック情報 */}
-        <Card>
-          <CardContent className="space-y-2 text-sm">
-            {[
-              { icon: MapPin, label: '拠点地域', value: talent.residence || '要相談' },
-              { icon: Clock3, label: '出演可能時間', value: talent.availability || '要相談' },
-              { icon: Timer, label: '最低拘束時間', value: talent.min_hours || '要相談' },
-              { icon: Bus, label: '交通費', value: talent.transportation || '要相談' },
-              { icon: Wallet, label: '出演料金目安', value: talent.rate != null ? `${talent.rate.toLocaleString()}円〜` : '要相談' },
-            ].map(({ icon: Icon, label, value }) => (
-              <div key={label} className="flex items-center gap-2">
-                <Icon className="w-4 h-4" />
-                <span className="text-gray-600">{label}:</span>
-                <span>{value}</span>
               </div>
-            ))}
-          </CardContent>
-        </Card>
-
-        {/* タグ */}
-        {(talent.area.length > 0 || talent.genre) && (
-          <div className="space-y-2">
-            {talent.area.length > 0 && (
-              <div>
-                <p className="text-sm font-semibold mb-1">対応エリア</p>
-                <div className="flex flex-wrap gap-2">
-                  {talent.area.map(p => (
-                    <Badge key={p} variant="secondary" className="rounded-full">
-                      {p}
-                    </Badge>
+              {photos.length > 1 && (
+                <div className="mt-4 grid grid-cols-4 gap-2 sm:grid-cols-5">
+                  {photos.map((src, i) => (
+                    <button
+                      key={i}
+                      aria-label={`サムネイル${i + 1}`}
+                      onClick={() => {
+                        setSelectedPhoto(i)
+                        setImageLoaded(false)
+                      }}
+                      className={clsx(
+                        'relative aspect-square overflow-hidden rounded-lg border transition-all',
+                        i === selectedPhoto
+                          ? 'border-slate-800 shadow-[0_0_0_1px_rgba(15,23,42,0.2)]'
+                          : 'border-slate-200 hover:border-slate-400'
+                      )}
+                    >
+                      <Image src={src} alt={talent.stage_name} fill className="object-cover" />
+                    </button>
                   ))}
                 </div>
-              </div>
-            )}
-            {talent.genre && (
-              <div>
-                <p className="text-sm font-semibold mb-1">ジャンル</p>
-                <Badge variant="secondary" className="rounded-full">
-                  {talent.genre}
-                </Badge>
-              </div>
-            )}
-          </div>
-        )}
+              )}
+            </CardContent>
+          </Card>
 
-        {/* テキストセクション */}
-        <div className="space-y-4 text-sm">
-          <div>
-            <p className="font-semibold">NG事項 / 特記事項</p>
-            <p className="mt-1 whitespace-pre-line">{talent.notes ? talent.notes : '特にありません'}</p>
-          </div>
-          <div>
-            <p className="font-semibold">来店実績 / PR文</p>
-            <p className="mt-1 whitespace-pre-line">{talent.media_appearance ? talent.media_appearance : '準備中'}</p>
+          <div className="space-y-4 lg:sticky lg:top-20 h-fit">
+            <Card className="border-slate-200 shadow-sm">
+              <CardContent className="space-y-5 p-5">
+                <div>
+                  <h1 className="text-2xl md:text-3xl font-bold tracking-tight">{talent.stage_name}</h1>
+                  {talent.profile && <p className="mt-2 text-sm text-slate-700 whitespace-pre-line">{talent.profile}</p>}
+                </div>
+
+                <div className="space-y-2.5">
+                  <Button
+                    className="h-11 w-full bg-slate-900 text-white hover:bg-slate-800"
+                    aria-label="このキャストにオファーする"
+                    onClick={() => (window.location.href = `/talents/${id}/offer`)}
+                  >
+                    このキャストにオファーする
+                  </Button>
+                  <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+                    {(role === 'store' || role === null) && (
+                      <Button variant="outline" className="w-full border-slate-300" aria-label="メッセージを送る" onClick={handleMessage}>
+                        <MessageSquare className="mr-1 h-4 w-4" />
+                        メッセージ
+                      </Button>
+                    )}
+                    <Button variant="outline" className="w-full border-slate-300" aria-label="シェア" onClick={handleShare}>
+                      <Share2 className="mr-1 h-4 w-4" />
+                      シェア
+                    </Button>
+                    <Button variant="outline" className="w-full border-slate-300" aria-label="お気に入り" onClick={handleFavorite}>
+                      <Heart className={clsx('mr-1 h-4 w-4', isFavorite ? 'fill-current text-red-500' : '')} />
+                      お気に入り
+                    </Button>
+                  </div>
+                </div>
+
+                <div className="space-y-3 text-sm">
+                  {[
+                    { icon: MapPin, label: '拠点地域', value: talent.residence || '要相談' },
+                    { icon: Clock3, label: '出演可能時間', value: talent.availability || '要相談' },
+                    { icon: Timer, label: '最低拘束時間', value: talent.min_hours || '要相談' },
+                    { icon: Bus, label: '交通費', value: talent.transportation || '要相談' },
+                    { icon: Wallet, label: '出演料金目安', value: talent.rate != null ? `${talent.rate.toLocaleString()}円〜` : '要相談' },
+                  ].map(({ icon: Icon, label, value }) => (
+                    <div key={label} className="flex items-center gap-2 border-b border-slate-100 pb-2 last:border-0 last:pb-0">
+                      <Icon className="h-4 w-4 text-slate-500" />
+                      <span className="min-w-24 text-slate-500">{label}</span>
+                      <span className="font-medium text-slate-900">{value}</span>
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+
+            {role === 'talent' && userId === talent.user_id && (
+              <Button className="w-full" aria-label="プロフィールを編集する" onClick={() => (window.location.href = '/talent/edit')}>
+                プロフィールを編集する
+              </Button>
+            )}
           </div>
         </div>
 
-        {/* SNSリンク */}
-        {(talent.twitter || talent.instagram || talent.youtube) && (
-          <div className="flex gap-3 text-lg">
-            {talent.twitter && (
-              <a href={talent.twitter} target="_blank" rel="noopener noreferrer" aria-label="Twitter">
-                <FaTwitter />
-              </a>
-            )}
-            {talent.instagram && (
-              <a href={talent.instagram} target="_blank" rel="noopener noreferrer" aria-label="Instagram">
-                <FaInstagram />
-              </a>
-            )}
-            {talent.youtube && (
-              <a href={talent.youtube} target="_blank" rel="noopener noreferrer" aria-label="YouTube">
-                <FaYoutube />
-              </a>
-            )}
-          </div>
-        )}
+        <div className="mt-6 grid gap-4 md:grid-cols-2">
+          {(talent.area.length > 0 || talent.genre) && (
+            <Card className="border-slate-200 shadow-sm">
+              <CardContent className="space-y-4 p-5">
+                {talent.area.length > 0 && (
+                  <div>
+                    <p className="mb-2 text-sm font-semibold text-slate-800">対応エリア</p>
+                    <div className="flex flex-wrap gap-2">
+                      {talent.area.map(p => (
+                        <Badge key={p} variant="secondary" className="rounded-full border border-slate-200 bg-slate-50 text-slate-700">
+                          {p}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {talent.genre && (
+                  <div>
+                    <p className="mb-2 text-sm font-semibold text-slate-800">ジャンル</p>
+                    <Badge variant="secondary" className="rounded-full border border-slate-200 bg-slate-50 text-slate-700">
+                      {talent.genre}
+                    </Badge>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          )}
 
-        {role === 'talent' && userId === talent.user_id && (
-          <Button className="w-full" aria-label="プロフィールを編集する" onClick={() => (window.location.href = '/talent/edit')}>
-            プロフィールを編集する
-          </Button>
-        )}
-      </div>
-    </main>
+          {(talent.twitter || talent.instagram || talent.youtube) && (
+            <Card className="border-slate-200 shadow-sm">
+              <CardContent className="p-5">
+                <p className="mb-2 text-sm font-semibold text-slate-800">SNS</p>
+                <div className="flex gap-4 text-xl text-slate-700">
+                  {talent.twitter && (
+                    <a href={talent.twitter} target="_blank" rel="noopener noreferrer" aria-label="Twitter" className="hover:text-slate-900">
+                      <FaTwitter />
+                    </a>
+                  )}
+                  {talent.instagram && (
+                    <a href={talent.instagram} target="_blank" rel="noopener noreferrer" aria-label="Instagram" className="hover:text-slate-900">
+                      <FaInstagram />
+                    </a>
+                  )}
+                  {talent.youtube && (
+                    <a href={talent.youtube} target="_blank" rel="noopener noreferrer" aria-label="YouTube" className="hover:text-slate-900">
+                      <FaYoutube />
+                    </a>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          <Card className="border-slate-200 shadow-sm md:col-span-2">
+            <CardContent className="grid gap-6 p-5 md:grid-cols-2 text-sm">
+              <div>
+                <p className="font-semibold text-slate-800">NG事項 / 特記事項</p>
+                <p className="mt-2 whitespace-pre-line text-slate-700">{talent.notes ? talent.notes : '特にありません'}</p>
+              </div>
+              <div>
+                <p className="font-semibold text-slate-800">来店実績 / PR文</p>
+                <p className="mt-2 whitespace-pre-line text-slate-700">{talent.media_appearance ? talent.media_appearance : '準備中'}</p>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </main>
     <NewMessageModal
       open={messageOpen}
       onOpenChange={setMessageOpen}
@@ -287,4 +306,3 @@ export default function TalentDetailPageClient({ id, initialTalent }: Props) {
     </>
   )
 }
-

--- a/talentify-next-frontend/app/talents/layout.tsx
+++ b/talentify-next-frontend/app/talents/layout.tsx
@@ -1,8 +1,6 @@
 import React from 'react'
 import Header from '@/components/Header'
-import Sidebar from '@/components/Sidebar'
-import { SidebarProvider } from '@/components/SidebarProvider'
-import SidebarToggle from '@/components/SidebarToggle'
+import SiteFooter from '@/components/SiteFooter'
 import { createClient } from '@/lib/supabase/server'
 import { SupabaseProvider } from '@/lib/supabase/provider'
 
@@ -22,20 +20,11 @@ export default async function TalentsLayout({
 
   return (
     <html lang="ja" className="h-full">
-      <body className="font-sans antialiased bg-white text-black min-h-screen flex flex-col">
+      <body className="font-sans antialiased bg-[#f8fafc] text-black min-h-screen flex flex-col">
         <SupabaseProvider session={session}>
           <Header sidebarRole="store" />
-          <div className="flex flex-1 pt-16">
-            <SidebarProvider>
-              <div className="hidden md:block">
-                <Sidebar role="store" collapsible />
-              </div>
-              <div className="hidden md:block">
-                <SidebarToggle />
-              </div>
-              <main className="flex-1 overflow-y-auto p-6 transition-[margin,width]">{children}</main>
-            </SidebarProvider>
-          </div>
+          <main className="flex-1 pt-16">{children}</main>
+          <SiteFooter />
         </SupabaseProvider>
       </body>
     </html>


### PR DESCRIPTION
### Motivation

- Remove the legacy left-side menu in the talent section and align `/talents/*` pages with the header-centered, gray-background role pages.
- Reduce the visual dominance of the talent photo and improve balance between image and information area.
- Improve multi-photo UX and surface the `このキャストにオファーする` action as the primary CTA so user flows are clearer.

### Description

- Updated `app/talents/layout.tsx` to remove `Sidebar`/`SidebarProvider`/`SidebarToggle` and switch to the header-centered gray background layout used by role pages.
- Reworked `app/talents/[id]/TalentDetailPageClient.tsx` into a balanced two-column layout using white card sections, constrained main image (`max-w-2xl`, `aspect-[4/5]`, `max-h-[620px]`) and a clickable thumbnail strip with selected-state styling.
- Promoted the offer flow button to a prominent dark primary button and reorganized message/share/favorite into outline secondary actions while retaining existing handlers and navigation behavior.

### Testing

- Ran `npm run lint` and the lint task completed successfully while reporting unrelated `<img>` warnings in other files.
- Attempted `npm run build` but the build could not complete in this environment because `prisma generate` failed due to a missing `DATABASE_URL` environment variable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d898c809d88332a2ac6fc488a6e08c)