### PR TITLE
Scope offer table styles to offer-management pages (fix layout regression)

### DIFF
--- a/talentify-next-frontend/app/offer-management-table.module.css
+++ b/talentify-next-frontend/app/offer-management-table.module.css
@@ -1,0 +1,48 @@
+.offerPage {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.tableCard {
+  overflow-x: auto;
+  border-radius: 0.75rem;
+  border: 1px solid #e2e8f0;
+  background: #ffffff;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+}
+
+.offerTable {
+  width: 100%;
+  min-width: 980px;
+  border-collapse: separate;
+  border-spacing: 0;
+  table-layout: fixed;
+  background: #ffffff;
+}
+
+.offerThead {
+  background: #f8fafc;
+}
+
+.offerHeadCell {
+  padding-top: 0.85rem;
+  padding-bottom: 0.85rem;
+  border-bottom: 1px solid #e2e8f0;
+  vertical-align: middle;
+}
+
+.offerBodyRow {
+  background: #ffffff;
+}
+
+.offerBodyRow:last-child td {
+  border-bottom: 0;
+}
+
+.offerBodyCell {
+  padding-top: 0.95rem;
+  padding-bottom: 0.95rem;
+  border-bottom: 1px solid #e2e8f0;
+  vertical-align: middle;
+}

--- a/talentify-next-frontend/app/store/offers/page.tsx
+++ b/talentify-next-frontend/app/store/offers/page.tsx
@@ -15,6 +15,7 @@ import { OfferProgressStatusIcons } from '@/components/offer/OfferProgressStatus
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import styles from '@/app/offer-management-table.module.css'
 
 const statusLabels: Record<string, string> = {
   pending: '保留中',
@@ -124,7 +125,7 @@ export default function StoreOffersPage() {
   }
 
   return (
-    <main className="space-y-4 bg-[#f8fafc] p-4 md:p-6">
+    <main className={`space-y-4 bg-[#f8fafc] p-4 md:p-6 ${styles.offerPage}`}>
       <div>
         <h1 className="text-2xl font-bold text-[#334155]">オファー管理</h1>
         <p className="mt-1 text-sm text-[#64748b]">来店予定・進捗状況を一覧で確認できます。</p>
@@ -157,11 +158,11 @@ export default function StoreOffersPage() {
         <EmptyState title="対象のオファーがありません" />
       ) : (
         <>
-          <section className="hidden overflow-x-auto rounded-xl border border-[#e2e8f0] bg-white shadow-sm md:block">
-            <Table>
-              <TableHeader className="sticky top-0 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/90">
+          <section className={`hidden md:block ${styles.tableCard}`}>
+            <Table className={styles.offerTable}>
+              <TableHeader className={`sticky top-0 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/90 ${styles.offerThead}`}>
                 <TableRow className="h-11 border-b border-[#e2e8f0] text-sm">
-                  <TableHead className="w-[180px] px-6 text-xs font-semibold tracking-wide text-[#334155]" aria-sort={sortOrder === 'asc' ? 'ascending' : 'descending'}>
+                  <TableHead className={`w-[180px] px-6 text-xs font-semibold tracking-wide text-[#334155] ${styles.offerHeadCell}`} aria-sort={sortOrder === 'asc' ? 'ascending' : 'descending'}>
                     <button
                       type="button"
                       onClick={toggleSortOrder}
@@ -176,26 +177,26 @@ export default function StoreOffersPage() {
                       <span className="sr-only">来店日で並び替え</span>
                     </button>
                   </TableHead>
-                  <TableHead className="min-w-[220px] px-4 text-xs font-semibold tracking-wide text-[#334155]">演者名</TableHead>
-                  <TableHead className="w-[150px] px-4 text-xs font-semibold tracking-wide text-[#334155]">現在ステータス</TableHead>
-                  <TableHead className="min-w-[360px] px-4 text-xs font-semibold tracking-wide text-[#334155]">進捗</TableHead>
-                  <TableHead className="w-[120px] px-6 text-right text-xs font-semibold tracking-wide text-[#334155]">詳細</TableHead>
+                  <TableHead className={`min-w-[220px] px-4 text-xs font-semibold tracking-wide text-[#334155] ${styles.offerHeadCell}`}>演者名</TableHead>
+                  <TableHead className={`w-[150px] px-4 text-xs font-semibold tracking-wide text-[#334155] ${styles.offerHeadCell}`}>現在ステータス</TableHead>
+                  <TableHead className={`min-w-[360px] px-4 text-xs font-semibold tracking-wide text-[#334155] ${styles.offerHeadCell}`}>進捗</TableHead>
+                  <TableHead className={`w-[120px] px-6 text-right text-xs font-semibold tracking-wide text-[#334155] ${styles.offerHeadCell}`}>詳細</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {filtered.map(o => (
                   <TableRow
                     key={o.id}
-                    className="h-[68px] cursor-pointer border-b border-[#e2e8f0] transition-colors hover:bg-[#f8fafc]"
+                    className={`h-[68px] cursor-pointer border-b border-[#e2e8f0] transition-colors hover:bg-[#f8fafc] ${styles.offerBodyRow}`}
                     onClick={() => handleRowClick(o.id)}
                   >
-                    <TableCell className="px-6 align-middle">
+                    <TableCell className={`px-6 align-middle ${styles.offerBodyCell}`}>
                       <div className="font-medium text-[#334155]">{formatVisitDate(o.date)}</div>
                     </TableCell>
-                    <TableCell className="px-4 align-middle">
+                    <TableCell className={`px-4 align-middle ${styles.offerBodyCell}`}>
                       <div className="truncate text-[#334155]" title={o.talent_name ?? ''}>{o.talent_name ?? '-'}</div>
                     </TableCell>
-                    <TableCell className="px-4 align-middle">
+                    <TableCell className={`px-4 align-middle ${styles.offerBodyCell}`}>
                       <Badge
                         variant={statusVariants[o.status ?? 'pending']}
                         className={`rounded-md px-2.5 py-1 text-[11px] font-semibold ${statusToneClasses[o.status ?? 'pending'] ?? statusToneClasses.pending}`}
@@ -203,7 +204,7 @@ export default function StoreOffersPage() {
                         {statusLabels[o.status ?? 'pending']}
                       </Badge>
                     </TableCell>
-                    <TableCell className="px-4 align-middle">
+                    <TableCell className={`px-4 align-middle ${styles.offerBodyCell}`}>
                       {CANCEL_STATUSES.has(o.status ?? '') ? (
                         <Badge variant="outline" className="border-[#7f1d1d]/35 bg-[#fef2f2] px-2.5 py-1 font-semibold text-[#7f1d1d]">
                           キャンセル済み
@@ -212,7 +213,7 @@ export default function StoreOffersPage() {
                         <OfferProgressStatusIcons steps={o.steps} badge={o.badge} />
                       )}
                     </TableCell>
-                    <TableCell className="px-6 align-middle text-right">
+                    <TableCell className={`px-6 align-middle text-right ${styles.offerBodyCell}`}>
                       <Button variant="ghost" size="sm" asChild className="text-[#2f4da0] hover:bg-[#eef2ff] hover:text-[#233a7a]">
                         <Link href={`/store/offers/${o.id}`} className="inline-flex items-center gap-1" onClick={event => event.stopPropagation()}>
                           詳細

--- a/talentify-next-frontend/app/talent/offers/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/page.tsx
@@ -16,6 +16,7 @@ import { OfferProgressStatusIcons } from '@/components/offer/OfferProgressStatus
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import styles from '@/app/offer-management-table.module.css'
 
 const statusLabels: Record<string, string> = {
   pending: '保留中',
@@ -130,7 +131,7 @@ export default function TalentOffersPage() {
   }
 
   return (
-    <main className="space-y-4 bg-[#f8fafc] p-4 md:p-6">
+    <main className={`space-y-4 bg-[#f8fafc] p-4 md:p-6 ${styles.offerPage}`}>
       <div>
         <h1 className="text-2xl font-bold text-[#334155]">オファー管理</h1>
         <p className="mt-1 text-sm text-[#64748b]">受信したオファーと進捗を一覧で確認できます。</p>
@@ -163,11 +164,11 @@ export default function TalentOffersPage() {
         <EmptyState title="対象のオファーがありません" />
       ) : (
         <>
-          <section className="hidden overflow-x-auto rounded-xl border border-[#e2e8f0] bg-white shadow-sm md:block">
-            <Table>
-              <TableHeader className="sticky top-0 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/90">
+          <section className={`hidden md:block ${styles.tableCard}`}>
+            <Table className={styles.offerTable}>
+              <TableHeader className={`sticky top-0 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/90 ${styles.offerThead}`}>
                 <TableRow className="h-11 border-b border-[#e2e8f0] text-sm">
-                  <TableHead className="w-[180px] px-6 text-xs font-semibold tracking-wide text-[#334155]" aria-sort={sortOrder === 'asc' ? 'ascending' : 'descending'}>
+                  <TableHead className={`w-[180px] px-6 text-xs font-semibold tracking-wide text-[#334155] ${styles.offerHeadCell}`} aria-sort={sortOrder === 'asc' ? 'ascending' : 'descending'}>
                     <button
                       type="button"
                       onClick={toggleSortOrder}
@@ -182,28 +183,28 @@ export default function TalentOffersPage() {
                       <span className="sr-only">来店日で並び替え</span>
                     </button>
                   </TableHead>
-                  <TableHead className="min-w-[220px] px-4 text-xs font-semibold tracking-wide text-[#334155]">店舗名</TableHead>
-                  <TableHead className="w-[150px] px-4 text-xs font-semibold tracking-wide text-[#334155]">現在ステータス</TableHead>
-                  <TableHead className="min-w-[360px] px-4 text-xs font-semibold tracking-wide text-[#334155]">進捗</TableHead>
-                  <TableHead className="w-[120px] px-6 text-right text-xs font-semibold tracking-wide text-[#334155]">詳細</TableHead>
+                  <TableHead className={`min-w-[220px] px-4 text-xs font-semibold tracking-wide text-[#334155] ${styles.offerHeadCell}`}>店舗名</TableHead>
+                  <TableHead className={`w-[150px] px-4 text-xs font-semibold tracking-wide text-[#334155] ${styles.offerHeadCell}`}>現在ステータス</TableHead>
+                  <TableHead className={`min-w-[360px] px-4 text-xs font-semibold tracking-wide text-[#334155] ${styles.offerHeadCell}`}>進捗</TableHead>
+                  <TableHead className={`w-[120px] px-6 text-right text-xs font-semibold tracking-wide text-[#334155] ${styles.offerHeadCell}`}>詳細</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {filtered.map(o => (
                   <TableRow
                     key={o.id}
-                    className="h-[68px] cursor-pointer border-b border-[#e2e8f0] transition-colors hover:bg-[#f8fafc]"
+                    className={`h-[68px] cursor-pointer border-b border-[#e2e8f0] transition-colors hover:bg-[#f8fafc] ${styles.offerBodyRow}`}
                     onClick={() => handleRowClick(o.id)}
                   >
-                    <TableCell className="px-6 align-middle">
+                    <TableCell className={`px-6 align-middle ${styles.offerBodyCell}`}>
                       <div className="font-medium text-[#334155]">{formatVisitDate(o.date)}</div>
                     </TableCell>
-                    <TableCell className="px-4 align-middle">
+                    <TableCell className={`px-4 align-middle ${styles.offerBodyCell}`}>
                       <div className="truncate text-[#334155]" title={o.store_name ?? ''}>
                         {o.store_name ?? '-'}
                       </div>
                     </TableCell>
-                    <TableCell className="px-4 align-middle">
+                    <TableCell className={`px-4 align-middle ${styles.offerBodyCell}`}>
                       <Badge
                         variant={statusVariants[o.status ?? 'pending']}
                         className={`rounded-md px-2.5 py-1 text-[11px] font-semibold ${statusToneClasses[o.status ?? 'pending'] ?? statusToneClasses.pending}`}
@@ -211,7 +212,7 @@ export default function TalentOffersPage() {
                         {statusLabels[o.status ?? 'pending']}
                       </Badge>
                     </TableCell>
-                    <TableCell className="px-4 align-middle">
+                    <TableCell className={`px-4 align-middle ${styles.offerBodyCell}`}>
                       {CANCEL_STATUSES.has(o.status ?? '') ? (
                         <Badge variant="outline" className="border-[#7f1d1d]/35 bg-[#fef2f2] px-2.5 py-1 font-semibold text-[#7f1d1d]">
                           キャンセル済み
@@ -220,7 +221,7 @@ export default function TalentOffersPage() {
                         <OfferProgressStatusIcons steps={o.steps} badge={o.badge} />
                       )}
                     </TableCell>
-                    <TableCell className="px-6 align-middle text-right">
+                    <TableCell className={`px-6 align-middle text-right ${styles.offerBodyCell}`}>
                       <Button variant="ghost" size="sm" asChild className="text-[#2f4da0] hover:bg-[#eef2ff] hover:text-[#233a7a]">
                         <Link href={`/talent/offers/${o.id}`} className="inline-flex items-center gap-1" onClick={event => event.stopPropagation()}>
                           詳細


### PR DESCRIPTION
### Motivation

- Recent global UI changes (background/card/common CSS) leaked into the offer management pages and broke the table layout. 
- We must not modify global selectors like `table`/`body`, so table styles need to be localized to the offer pages. 
- Preserve the new gray background + card visuals site-wide while restoring readable table spacing and borders only on the offer pages.

### Description

- Added a page-scoped CSS module `app/offer-management-table.module.css` that defines wrapper, card, table, header and cell styles to restore the intended table layout. 
- Updated store and talent offer pages to import the module and apply `styles.offerPage`, `styles.tableCard`, `styles.offerTable`, `styles.offerThead`, `styles.offerHeadCell`, `styles.offerBodyRow`, and `styles.offerBodyCell` to localize styling. 
- Kept the mobile card/list layout unchanged and only scoped desktop table adjustments to the offer-management pages. 
- No changes were made to the global CSS files; the fix isolates rules to the offer pages only.

### Testing

- Ran `cd /workspace/talentify/talentify-next-frontend && npm run lint` and the lint step completed without errors (only unrelated `@next/next/no-img-element` warnings remain). 
- The modified files were committed and the changes are ready for review (`app/offer-management-table.module.css`, `app/store/offers/page.tsx`, `app/talent/offers/page.tsx`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d89a3a1300833294b349efbfe5384e)