### PR TITLE
Improve /guide with role-first navigation and step flows

### DIFF
--- a/talentify-next-frontend/app/guide/components/RoleCard.tsx
+++ b/talentify-next-frontend/app/guide/components/RoleCard.tsx
@@ -1,0 +1,18 @@
+interface RoleCardProps {
+  href: string
+  title: string
+  description: string
+}
+
+export function RoleCard({ href, title, description }: RoleCardProps) {
+  return (
+    <a
+      href={href}
+      className="group block rounded-2xl border border-amber-200 bg-amber-50/60 p-6 transition-all duration-200 hover:-translate-y-1 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2"
+    >
+      <h3 className="text-xl font-semibold text-slate-800">{title}</h3>
+      <p className="mt-3 text-sm leading-6 text-slate-600">{description}</p>
+      <p className="mt-4 text-sm font-medium text-amber-700">流れを見る</p>
+    </a>
+  )
+}

--- a/talentify-next-frontend/app/guide/components/StepFlow.tsx
+++ b/talentify-next-frontend/app/guide/components/StepFlow.tsx
@@ -1,0 +1,24 @@
+interface StepFlowProps {
+  title: string
+  steps: string[]
+  id: string
+}
+
+export function StepFlow({ title, steps, id }: StepFlowProps) {
+  return (
+    <section id={id} className="scroll-mt-24 rounded-2xl border border-slate-200 bg-white p-6 md:p-8">
+      <h2 className="text-xl font-semibold text-slate-800">{title}</h2>
+      <ol className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+        {steps.map((step, index) => (
+          <li
+            key={step}
+            className="rounded-xl border border-slate-200 bg-white px-4 py-5 transition-all duration-200 hover:-translate-y-1 hover:shadow-md"
+          >
+            <p className="text-xs font-semibold tracking-wide text-amber-600">STEP {index + 1}</p>
+            <p className="mt-2 text-sm font-medium text-slate-700">{step}</p>
+          </li>
+        ))}
+      </ol>
+    </section>
+  )
+}

--- a/talentify-next-frontend/app/guide/page.tsx
+++ b/talentify-next-frontend/app/guide/page.tsx
@@ -1,42 +1,67 @@
 import Link from 'next/link'
 
+import { RoleCard } from './components/RoleCard'
+import { StepFlow } from './components/StepFlow'
+
+const storeSteps = ['演者を探す', 'プロフィールを確認', 'オファーを送る', '条件・日程を調整', '実施・管理']
+
+const talentSteps = ['登録', 'プロフィール設定', 'オファー確認', '条件・日程調整', '実施・請求対応']
+
 export default function GuidePage() {
   return (
-    <div className="mx-auto w-full max-w-5xl px-4 py-24 text-slate-900">
-      <header className="mb-8 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-        <h1 className="text-3xl font-bold">ご利用ガイド</h1>
-        <p className="mt-2 text-sm text-slate-600">Talentifyの使い方を役割ごとに整理したご案内ページです。</p>
-      </header>
+    <main className="mx-auto w-full max-w-6xl px-4 py-16 text-slate-800 md:px-6 md:py-24">
+      <section className="rounded-2xl border border-slate-200 bg-white p-6 md:p-8">
+        <h1 className="text-3xl font-bold tracking-tight text-slate-800 md:text-4xl">ご利用ガイド</h1>
+        <p className="mt-3 text-sm text-slate-600 md:text-base">はじめてでも迷わない、役割別の使い方ガイドです。</p>
 
-      <div className="grid gap-4 md:grid-cols-2">
-        {[
-          { title: 'Talentifyとは', body: 'パチンコ店と演者をつなぐマッチングプラットフォームです。案件作成から契約後のやり取りまでオンラインで管理できます。' },
-          { title: '店舗の方へ', body: '演者検索、オファー送信、進行管理、請求対応までを一つの画面で運用できます。' },
-          { title: '演者の方へ', body: 'オファー確認、スケジュール調整、メッセージ、請求提出などを効率よく進められます。' },
-          { title: '基本的な利用の流れ', body: '登録 → プロフィール設定 → 案件作成/応募 → 調整 → 契約・実施という流れで利用できます。' },
-        ].map((item) => (
-          <section key={item.title} className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-            <h2 className="text-lg font-semibold">{item.title}</h2>
-            <p className="mt-2 text-sm leading-6 text-slate-600">{item.body}</p>
-          </section>
-        ))}
+        <div className="mt-8">
+          <h2 className="text-lg font-semibold text-slate-800">あなたはどちらですか？</h2>
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            <RoleCard
+              href="#store-flow"
+              title="店舗の方はこちら"
+              description="演者検索、オファー送信、進行管理まで一括で行えます"
+            />
+            <RoleCard
+              href="#talent-flow"
+              title="演者の方はこちら"
+              description="オファー確認、日程調整、メッセージ、請求対応まで行えます"
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="mt-6 rounded-2xl border border-slate-200 bg-white p-6 md:p-8">
+        <h2 className="text-lg font-semibold text-slate-800">Talentifyとは</h2>
+        <p className="mt-2 text-sm leading-7 text-slate-600 md:text-base">
+          店舗と演者をつなぎ、案件作成から実施後のやりとりまで管理できるプラットフォームです。
+        </p>
+      </section>
+
+      <div className="mt-6 space-y-6">
+        <StepFlow id="store-flow" title="店舗の流れ" steps={storeSteps} />
+        <StepFlow id="talent-flow" title="演者の流れ" steps={talentSteps} />
       </div>
 
-      <section className="mt-8 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="text-lg font-semibold">関連ページ</h2>
-        <div className="mt-3 flex flex-wrap gap-2 text-sm">
+      <section className="mt-6 rounded-2xl border border-slate-200 bg-white p-6 md:p-8">
+        <h2 className="text-lg font-semibold text-slate-800">関連リンク</h2>
+        <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
           {[
             { href: '/faq', label: 'FAQ' },
             { href: '/news', label: 'お知らせ' },
             { href: '/pricing', label: '料金' },
             { href: '/company', label: '会社概要' },
           ].map((item) => (
-            <Link key={item.href} href={item.href} className="rounded-md border border-slate-200 px-3 py-1.5 text-slate-700 hover:bg-slate-50">
+            <Link
+              key={item.href}
+              href={item.href}
+              className="rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm font-medium text-slate-700 transition-all duration-200 hover:-translate-y-1 hover:shadow-md"
+            >
               {item.label}
             </Link>
           ))}
         </div>
       </section>
-    </div>
+    </main>
   )
 }


### PR DESCRIPTION
### Motivation
- Turn the `/guide` page from a long explanatory list into an action-oriented, role-first guide so users know what to do immediately.
- Make the UI simple, elegant, and product-like while ensuring first-time users can act without friction.
- Replace long paragraphs with concise steps and clear role selection to reduce choice paralysis.

### Description
- Replaced the previous layout with a role-first structure: Title → Subtitle → Role selection → One-line service overview → Store flow → Talent flow → Related links in `app/guide/page.tsx`.
- Added reusable components `RoleCard` (`app/guide/components/RoleCard.tsx`) and `StepFlow` (`app/guide/components/StepFlow.tsx`) and wired them into `page.tsx` for clearer separation of concerns.
- Implemented Tailwind-based styling matching the design rules: white base, dark-gray text (`slate-*`), gold/amber accents, larger padding (`p-6`/`p-8`), rounded corners, and hover lift (`-translate-y-1` + shadow), and ensured responsive grid behavior (mobile vertical, multi-column on larger screens).
- Simplified the "Talentifyとは" copy to a single sentence and added anchor links on role cards to scroll to each flow section (`#store-flow`, `#talent-flow`).

### Testing
- Ran `npm run lint` in `talentify-next-frontend` and the command completed successfully with existing unrelated `no-img-element` warnings in other files.
- No unit tests were added or modified for this UI change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8a1da6a9c83329e5005bb55a5decf)