### PR TITLE
Refine offer management UI: remove top cards, darker page bg, emphasize filter bar

### DIFF
--- a/talentify-next-frontend/app/store/offers/page.module.css
+++ b/talentify-next-frontend/app/store/offers/page.module.css
@@ -1,0 +1,26 @@
+.page {
+  background: #f1f5f9;
+}
+
+.pageInner {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.filterBar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.5rem;
+  border: 1px solid #cbd5e1;
+  background: #e2e8f0;
+  border-radius: 8px;
+  padding: 0.875rem;
+}
+
+.filterBar input,
+.filterBar select,
+.filterBar button {
+  background: #ffffff;
+}

--- a/talentify-next-frontend/app/store/offers/page.tsx
+++ b/talentify-next-frontend/app/store/offers/page.tsx
@@ -12,6 +12,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { TableSkeleton } from '@/components/ui/skeleton'
 import { EmptyState } from '@/components/ui/empty-state'
 import { Badge } from '@/components/ui/badge'
+import styles from './page.module.css'
 
 const statusLabels: Record<string, string> = {
   pending: '保留中',
@@ -94,22 +95,6 @@ export default function StoreOffersPage() {
     }
   }, [offersWithProgress])
 
-  const summaryItems = useMemo(() => {
-    const activeItems = offersWithProgress.filter(o => !o.isCanceled && !o.isHistory)
-    const awaitingApproval = activeItems.filter(o => (o.status ?? 'pending') === 'pending').length
-    const upcomingVisit = activeItems.filter(o => (o.status ?? 'pending') === 'confirmed').length
-    const waitingReview = activeItems.filter(o => o.steps.some(step => step.key === 'review' && step.status === 'current')).length
-
-    return [
-      { key: 'active', label: '進行中', count: tabCounts.active },
-      { key: 'approval', label: '承認待ち', count: awaitingApproval },
-      { key: 'visit', label: '来店予定', count: upcomingVisit },
-      { key: 'review', label: 'レビュー待ち', count: waitingReview },
-      { key: 'history', label: '履歴', count: tabCounts.history },
-      { key: 'cancel', label: 'キャンセル', count: tabCounts.cancel },
-    ]
-  }, [offersWithProgress, tabCounts])
-
   const processed = useMemo(() => {
     let rows = offersWithProgress.filter(offer => {
       if (tab === 'history') return offer.isHistory
@@ -156,21 +141,12 @@ export default function StoreOffersPage() {
   }
 
   return (
-    <main className="bg-[#f8fafc] p-4 text-[#334155] md:p-6">
-      <div className="mx-auto w-full max-w-7xl space-y-4">
+    <main className={`${styles.page} p-4 text-[#334155] md:p-6`}>
+      <div className={`${styles.pageInner} mx-auto w-full max-w-7xl`}>
         <header>
           <h1 className="text-2xl font-bold">オファー管理</h1>
           <p className="mt-1 text-sm text-[#64748b]">来店予定・進捗状況を一覧で確認できます。</p>
         </header>
-
-        <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-6">
-          {summaryItems.map(item => (
-            <div key={item.key} className="rounded-xl border border-[#e2e8f0] bg-white px-4 py-3 shadow-sm">
-              <p className="text-xs font-medium text-[#64748b]">{item.label}</p>
-              <p className="mt-1 text-2xl font-semibold text-[#334155]">{item.count}</p>
-            </div>
-          ))}
-        </section>
 
         <section className="space-y-3 rounded-xl border border-[#e2e8f0] bg-white p-3 shadow-sm md:p-4">
           <div className="flex flex-wrap gap-2 border-b border-[#e2e8f0] pb-2">
@@ -195,7 +171,7 @@ export default function StoreOffersPage() {
             ))}
           </div>
 
-          <div className="flex flex-wrap items-end gap-2 rounded-lg border border-[#e2e8f0] bg-[#f8fafc] p-3">
+          <div className={styles.filterBar}>
             <label className="flex min-w-[180px] flex-1 flex-col gap-1 text-xs text-[#64748b]">
               演者名検索
               <input

--- a/talentify-next-frontend/app/talent/offers/page.module.css
+++ b/talentify-next-frontend/app/talent/offers/page.module.css
@@ -1,0 +1,26 @@
+.page {
+  background: #f1f5f9;
+}
+
+.pageInner {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.filterBar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.5rem;
+  border: 1px solid #cbd5e1;
+  background: #e2e8f0;
+  border-radius: 8px;
+  padding: 0.875rem;
+}
+
+.filterBar input,
+.filterBar select,
+.filterBar button {
+  background: #ffffff;
+}

--- a/talentify-next-frontend/app/talent/offers/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/page.tsx
@@ -13,6 +13,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { TableSkeleton } from '@/components/ui/skeleton'
 import { EmptyState } from '@/components/ui/empty-state'
 import { Badge } from '@/components/ui/badge'
+import styles from './page.module.css'
 
 const statusLabels: Record<string, string> = {
   pending: '保留中',
@@ -100,22 +101,6 @@ export default function TalentOffersPage() {
     }
   }, [offersWithProgress])
 
-  const summaryItems = useMemo(() => {
-    const activeItems = offersWithProgress.filter(o => !o.isCanceled && !o.isHistory)
-    const receivedOffers = activeItems.filter(o => (o.status ?? 'pending') === 'pending').length
-    const upcomingVisit = activeItems.filter(o => (o.status ?? 'pending') === 'confirmed').length
-    const untouchedItems = activeItems.filter(o => o.steps.some(step => step.key === 'approval' && step.status === 'current')).length
-
-    return [
-      { key: 'active', label: '進行中', count: tabCounts.active },
-      { key: 'received', label: '受信オファー', count: receivedOffers },
-      { key: 'visit', label: '来店予定', count: upcomingVisit },
-      { key: 'untouched', label: '未対応案件', count: untouchedItems },
-      { key: 'history', label: '履歴', count: tabCounts.history },
-      { key: 'cancel', label: 'キャンセル', count: tabCounts.cancel },
-    ]
-  }, [offersWithProgress, tabCounts])
-
   const processed = useMemo(() => {
     let rows = offersWithProgress.filter(offer => {
       if (tab === 'history') return offer.isHistory
@@ -162,21 +147,12 @@ export default function TalentOffersPage() {
   }
 
   return (
-    <main className="bg-[#f8fafc] p-4 text-[#334155] md:p-6">
-      <div className="mx-auto w-full max-w-7xl space-y-4">
+    <main className={`${styles.page} p-4 text-[#334155] md:p-6`}>
+      <div className={`${styles.pageInner} mx-auto w-full max-w-7xl`}>
         <header>
           <h1 className="text-2xl font-bold">オファー管理</h1>
           <p className="mt-1 text-sm text-[#64748b]">受信したオファーと進捗を一覧で確認できます。</p>
         </header>
-
-        <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-6">
-          {summaryItems.map(item => (
-            <div key={item.key} className="rounded-xl border border-[#e2e8f0] bg-white px-4 py-3 shadow-sm">
-              <p className="text-xs font-medium text-[#64748b]">{item.label}</p>
-              <p className="mt-1 text-2xl font-semibold text-[#334155]">{item.count}</p>
-            </div>
-          ))}
-        </section>
 
         <section className="space-y-3 rounded-xl border border-[#e2e8f0] bg-white p-3 shadow-sm md:p-4">
           <div className="flex flex-wrap gap-2 border-b border-[#e2e8f0] pb-2">
@@ -201,7 +177,7 @@ export default function TalentOffersPage() {
             ))}
           </div>
 
-          <div className="flex flex-wrap items-end gap-2 rounded-lg border border-[#e2e8f0] bg-[#f8fafc] p-3">
+          <div className={styles.filterBar}>
             <label className="flex min-w-[180px] flex-1 flex-col gap-1 text-xs text-[#64748b]">
               店舗名検索
               <input


### PR DESCRIPTION
### Motivation
- Improve visual hierarchy on the offer management pages so content (white cards/tables) stands out on a slightly darker gray background and the filter area is easier to discover.
- Remove the redundant status summary cards at the top so the flow becomes header → tabs → filters → list.
- Implement changes locally to the offer pages only to avoid global side effects.

### Description
- Removed the top summary/status-card section from both store and talent offer pages so the page flow is header → tabs → filter → list; the tab counts and list logic remain unchanged.
- Added page-scoped CSS modules `page.module.css` for each page and applied them to `main` and the page container to set the page background to `#f1f5f9` (local change only).
- Introduced a `.filterBar` class in each module to restyle the filter area with `background: #e2e8f0`, `border: 1px solid #cbd5e1`, `border-radius: 8px`, and padding `0.875rem`, while keeping `input/select/button` white for contrast.
- Changes are limited to the two page components and their module files and do not alter routes, APIs, auth, or business logic.

### Testing
- Ran `npm run lint` in the frontend project and the command completed successfully (existing unrelated `<img>` warnings remain but the lint task succeeded).
- No other automated tests were added or modified; no unit/integration test failures reported.

Changed files:
- `app/store/offers/page.tsx` (removed top summary section, applied CSS module)
- `app/talent/offers/page.tsx` (removed top summary section, applied CSS module)
- `app/store/offers/page.module.css` (new)
- `app/talent/offers/page.module.css` (new)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8a4c0b888833280c4ad804054c8dc)