### PR TITLE
Improve /guide page contrast with gray background and stronger gold accents

### DIFF
--- a/talentify-next-frontend/app/guide/components/RoleCard.tsx
+++ b/talentify-next-frontend/app/guide/components/RoleCard.tsx
@@ -8,11 +8,13 @@ export function RoleCard({ href, title, description }: RoleCardProps) {
   return (
     <a
       href={href}
-      className="group block rounded-2xl border border-amber-200 bg-amber-50/60 p-6 transition-all duration-200 hover:-translate-y-1 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2"
+      className="group block rounded-2xl border border-[#d7dce3] bg-white p-6 shadow-sm transition-all duration-200 hover:-translate-y-1 hover:border-[#c89211] hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#c89211] focus-visible:ring-offset-2"
     >
-      <h3 className="text-xl font-semibold text-slate-800">{title}</h3>
-      <p className="mt-3 text-sm leading-6 text-slate-600">{description}</p>
-      <p className="mt-4 text-sm font-medium text-amber-700">流れを見る</p>
+      <h3 className="text-xl font-semibold text-[#0f172a]">{title}</h3>
+      <p className="mt-3 text-sm leading-6 text-[#334155]">{description}</p>
+      <p className="mt-5 inline-flex items-center text-sm font-semibold text-[#c89211] transition-colors group-hover:text-[#b8820f]">
+        流れを見る
+      </p>
     </a>
   )
 }

--- a/talentify-next-frontend/app/guide/components/StepFlow.tsx
+++ b/talentify-next-frontend/app/guide/components/StepFlow.tsx
@@ -6,16 +6,16 @@ interface StepFlowProps {
 
 export function StepFlow({ title, steps, id }: StepFlowProps) {
   return (
-    <section id={id} className="scroll-mt-24 rounded-2xl border border-slate-200 bg-white p-6 md:p-8">
-      <h2 className="text-xl font-semibold text-slate-800">{title}</h2>
+    <section id={id} className="scroll-mt-24 rounded-2xl border border-[#d7dce3] bg-white p-6 shadow-sm md:p-8">
+      <h2 className="text-xl font-semibold text-[#0f172a]">{title}</h2>
       <ol className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
         {steps.map((step, index) => (
           <li
             key={step}
-            className="rounded-xl border border-slate-200 bg-white px-4 py-5 transition-all duration-200 hover:-translate-y-1 hover:shadow-md"
+            className="rounded-xl border border-[#d7dce3] bg-white px-4 py-5 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-sm"
           >
-            <p className="text-xs font-semibold tracking-wide text-amber-600">STEP {index + 1}</p>
-            <p className="mt-2 text-sm font-medium text-slate-700">{step}</p>
+            <p className="text-xs font-semibold tracking-wide text-[#c89211]">STEP {index + 1}</p>
+            <p className="mt-2 text-sm font-medium text-[#334155]">{step}</p>
           </li>
         ))}
       </ol>

--- a/talentify-next-frontend/app/guide/page.tsx
+++ b/talentify-next-frontend/app/guide/page.tsx
@@ -7,61 +7,66 @@ const storeSteps = ['演者を探す', 'プロフィールを確認', 'オファ
 
 const talentSteps = ['登録', 'プロフィール設定', 'オファー確認', '条件・日程調整', '実施・請求対応']
 
+const relatedLinks = [
+  { href: '/faq', label: 'FAQ' },
+  { href: '/news', label: 'お知らせ' },
+  { href: '/pricing', label: '料金' },
+  { href: '/company', label: '会社概要' },
+  { href: '/contact', label: 'お問い合わせ' },
+]
+
 export default function GuidePage() {
   return (
-    <main className="mx-auto w-full max-w-6xl px-4 py-16 text-slate-800 md:px-6 md:py-24">
-      <section className="rounded-2xl border border-slate-200 bg-white p-6 md:p-8">
-        <h1 className="text-3xl font-bold tracking-tight text-slate-800 md:text-4xl">ご利用ガイド</h1>
-        <p className="mt-3 text-sm text-slate-600 md:text-base">はじめてでも迷わない、役割別の使い方ガイドです。</p>
+    <main className="min-h-screen bg-[#f3f4f6] py-14 md:py-20">
+      <div className="mx-auto w-full max-w-6xl px-4 md:px-6">
+        <section className="rounded-2xl border border-[#d7dce3] bg-white p-6 shadow-sm md:p-8">
+          <h1 className="text-3xl font-bold tracking-tight text-[#0f172a] md:text-4xl">ご利用ガイド</h1>
+          <p className="mt-3 text-sm text-[#334155] md:text-base">はじめてでも迷わない、役割別の使い方ガイドです。</p>
 
-        <div className="mt-8">
-          <h2 className="text-lg font-semibold text-slate-800">あなたはどちらですか？</h2>
-          <div className="mt-4 grid gap-4 md:grid-cols-2">
-            <RoleCard
-              href="#store-flow"
-              title="店舗の方はこちら"
-              description="演者検索、オファー送信、進行管理まで一括で行えます"
-            />
-            <RoleCard
-              href="#talent-flow"
-              title="演者の方はこちら"
-              description="オファー確認、日程調整、メッセージ、請求対応まで行えます"
-            />
+          <div className="mt-10">
+            <h2 className="text-xl font-semibold text-[#0f172a]">あなたはどちらですか？</h2>
+            <div className="mt-4 grid gap-4 md:grid-cols-2">
+              <RoleCard
+                href="#store-flow"
+                title="店舗の方はこちら"
+                description="演者検索、オファー送信、進行管理まで一括で行えます"
+              />
+              <RoleCard
+                href="#talent-flow"
+                title="演者の方はこちら"
+                description="オファー確認、日程調整、メッセージ、請求対応まで行えます"
+              />
+            </div>
           </div>
+        </section>
+
+        <section className="mt-8 rounded-2xl border border-[#d7dce3] bg-white p-6 shadow-sm md:p-8">
+          <h2 className="text-xl font-semibold text-[#0f172a]">Talentifyとは</h2>
+          <p className="mt-3 text-sm leading-7 text-[#334155] md:text-base">
+            店舗と演者をつなぎ、案件作成から実施後のやりとりまで管理できるプラットフォームです。
+          </p>
+        </section>
+
+        <div className="mt-8 space-y-6">
+          <StepFlow id="store-flow" title="店舗の流れ" steps={storeSteps} />
+          <StepFlow id="talent-flow" title="演者の流れ" steps={talentSteps} />
         </div>
-      </section>
 
-      <section className="mt-6 rounded-2xl border border-slate-200 bg-white p-6 md:p-8">
-        <h2 className="text-lg font-semibold text-slate-800">Talentifyとは</h2>
-        <p className="mt-2 text-sm leading-7 text-slate-600 md:text-base">
-          店舗と演者をつなぎ、案件作成から実施後のやりとりまで管理できるプラットフォームです。
-        </p>
-      </section>
-
-      <div className="mt-6 space-y-6">
-        <StepFlow id="store-flow" title="店舗の流れ" steps={storeSteps} />
-        <StepFlow id="talent-flow" title="演者の流れ" steps={talentSteps} />
+        <section className="mt-8 rounded-2xl border border-[#d7dce3] bg-white p-6 shadow-sm md:p-8">
+          <h2 className="text-xl font-semibold text-[#0f172a]">関連ページ</h2>
+          <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+            {relatedLinks.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                className="rounded-xl border border-[#d7dce3] bg-white px-4 py-3 text-sm font-semibold text-[#334155] transition-all duration-200 hover:-translate-y-0.5 hover:border-[#c89211] hover:text-[#b8820f] hover:shadow-sm"
+              >
+                {item.label}
+              </Link>
+            ))}
+          </div>
+        </section>
       </div>
-
-      <section className="mt-6 rounded-2xl border border-slate-200 bg-white p-6 md:p-8">
-        <h2 className="text-lg font-semibold text-slate-800">関連リンク</h2>
-        <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-          {[
-            { href: '/faq', label: 'FAQ' },
-            { href: '/news', label: 'お知らせ' },
-            { href: '/pricing', label: '料金' },
-            { href: '/company', label: '会社概要' },
-          ].map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              className="rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm font-medium text-slate-700 transition-all duration-200 hover:-translate-y-1 hover:shadow-md"
-            >
-              {item.label}
-            </Link>
-          ))}
-        </div>
-      </section>
     </main>
   )
 }


### PR DESCRIPTION
### Motivation
- Make the `/guide` page a role-first, action-oriented guide that removes the “placeholder” feel by strengthening contrast and boundaries. 
- Align the page with Talentify’s product tone through deeper text contrast and a richer gold accent color. 
- Improve discoverability and CTAs so first-time users can immediately choose their role and follow the flow.

### Description
- Updated `app/guide/page.tsx` to use a gray page background (`#f3f4f6`), tighter max-width/spacing, clearer section cards with border `#d7dce3` and `shadow-sm`, and added `relatedLinks` including `お問い合わせ`.
- Reworked `app/guide/components/RoleCard.tsx` to render white cards with border `#d7dce3`, stronger gold accent (`#c89211` / hover `#b8820f`), improved typography (`#0f172a` for headings, `#334155` for body), hover elevation, and accessible focus ring.
- Reworked `app/guide/components/StepFlow.tsx` to use the same border `#d7dce3`, shadow, gold `STEP` label, and tightened hover behavior and text colors for better step recognition.
- Kept original information architecture (hero, role selection, service overview, store/talent flows, related links) while applying the visual and spacing rules requested.

### Testing
- Ran `npm run lint` and the command completed successfully, with existing unrelated `no-img-element` warnings in other files remaining outside this change scope.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8a9ea1020833293901fcef30fcdeb)