### PR TITLE
オファー一覧: 詳細列を操作列に置換し即時アクションを追加

### DIFF
--- a/talentify-next-frontend/app/store/offers/page.module.css
+++ b/talentify-next-frontend/app/store/offers/page.module.css
@@ -24,3 +24,12 @@
 .filterBar button {
   background: #ffffff;
 }
+
+.actionGroup {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  flex-wrap: nowrap;
+  white-space: nowrap;
+}

--- a/talentify-next-frontend/app/store/offers/page.tsx
+++ b/talentify-next-frontend/app/store/offers/page.tsx
@@ -1,17 +1,20 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
-import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { format } from 'date-fns'
 import { ja } from 'date-fns/locale'
-import { ArrowUpDown, ChevronRight } from 'lucide-react'
+import { ArrowUpDown } from 'lucide-react'
+import { toast } from 'sonner'
 import { getOffersForStore, Offer } from '@/utils/getOffersForStore'
 import { getOfferProgress } from '@/utils/offerProgress'
+import { createClient } from '@/utils/supabase/client'
+import { toDbOfferStatus } from '@/app/lib/offerStatus'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { TableSkeleton } from '@/components/ui/skeleton'
 import { EmptyState } from '@/components/ui/empty-state'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import styles from './page.module.css'
 
 const statusLabels: Record<string, string> = {
@@ -27,6 +30,7 @@ type OfferTab = 'active' | 'history' | 'cancel'
 type SortKey = 'visit' | 'updated' | 'created'
 
 const CANCEL_STATUSES = new Set(['canceled', 'rejected', 'expired'])
+const CANCELLABLE_STATUSES = new Set(['pending', 'accepted', 'confirmed'])
 
 const badgeToneByCategory = {
   neutral: 'border-[#e2e8f0] bg-white text-[#64748b]',
@@ -45,6 +49,7 @@ function formatDate(value: string | null, template = 'yyyy/MM/dd (EEE)') {
 }
 
 export default function StoreOffersPage() {
+  const supabase = createClient()
   const router = useRouter()
   const [offers, setOffers] = useState<Offer[]>([])
   const [loading, setLoading] = useState(true)
@@ -140,6 +145,32 @@ export default function StoreOffersPage() {
     router.push(`/store/offers/${offerId}`)
   }
 
+  const handleCancel = async (offer: Offer) => {
+    const currentStatus = offer.status ?? 'pending'
+    if (!CANCELLABLE_STATUSES.has(currentStatus)) return
+    if (!confirm('このオファーを取り下げますか？')) return
+
+    const prevStatus = currentStatus
+    setOffers(prev => prev.map(row => (row.id === offer.id ? { ...row, status: 'canceled' } : row)))
+
+    const { error } = await supabase
+      .from('offers')
+      .update({
+        status: toDbOfferStatus('canceled'),
+        canceled_at: new Date().toISOString(),
+        canceled_by_role: 'store',
+      })
+      .eq('id', offer.id)
+
+    if (error) {
+      setOffers(prev => prev.map(row => (row.id === offer.id ? { ...row, status: prevStatus } : row)))
+      toast.error('キャンセルに失敗しました')
+      return
+    }
+
+    toast('オファーをキャンセルしました')
+  }
+
   return (
     <main className={`${styles.page} p-4 text-[#334155] md:p-6`}>
       <div className={`${styles.pageInner} mx-auto w-full max-w-7xl`}>
@@ -227,7 +258,7 @@ export default function StoreOffersPage() {
                       <TableHead className="w-[130px] px-4 text-xs font-semibold text-[#334155]">現在ステータス</TableHead>
                       <TableHead className="min-w-[260px] px-4 text-xs font-semibold text-[#334155]">進捗</TableHead>
                       <TableHead className="w-[140px] px-4 text-xs font-semibold text-[#334155]">最終更新</TableHead>
-                      <TableHead className="w-[90px] px-4 text-right text-xs font-semibold text-[#334155]">詳細</TableHead>
+                      <TableHead className="w-[180px] px-4 text-right text-xs font-semibold text-[#334155]">操作</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
@@ -266,10 +297,21 @@ export default function StoreOffersPage() {
                         </TableCell>
                         <TableCell className="px-4 text-xs text-[#64748b]">{formatDate(o.created_at, 'yyyy/MM/dd HH:mm')}</TableCell>
                         <TableCell className="px-4 text-right">
-                          <Link href={`/store/offers/${o.id}`} className="inline-flex items-center gap-1 text-sm font-medium text-[#2f4da0] hover:text-[#233a7a]" onClick={event => event.stopPropagation()}>
-                            詳細
-                            <ChevronRight className="h-4 w-4" />
-                          </Link>
+                          {CANCELLABLE_STATUSES.has(o.status ?? 'pending') ? (
+                            <div className={styles.actionGroup} onClick={event => event.stopPropagation()} onKeyDown={event => event.stopPropagation()}>
+                              <Button
+                                type="button"
+                                size="sm"
+                                variant="outline"
+                                className="border-red-200 text-red-700 hover:bg-red-50 hover:text-red-800"
+                                onClick={() => handleCancel(o)}
+                              >
+                                キャンセル
+                              </Button>
+                            </div>
+                          ) : (
+                            '-'
+                          )}
                         </TableCell>
                       </TableRow>
                     ))}
@@ -301,10 +343,23 @@ export default function StoreOffersPage() {
                     )}
                     <div className="mt-3 flex items-center justify-between text-xs text-[#64748b]">
                       <span>最終更新: {formatDate(o.created_at, 'yyyy/MM/dd HH:mm')}</span>
-                      <Link href={`/store/offers/${o.id}`} className="inline-flex items-center gap-1 font-medium text-[#2f4da0]" onClick={event => event.stopPropagation()}>
-                        詳細
-                        <ChevronRight className="h-4 w-4" />
-                      </Link>
+                    </div>
+                    <div className="mt-3">
+                      {CANCELLABLE_STATUSES.has(o.status ?? 'pending') ? (
+                        <div className={styles.actionGroup} onClick={event => event.stopPropagation()} onKeyDown={event => event.stopPropagation()}>
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="outline"
+                            className="border-red-200 text-red-700 hover:bg-red-50 hover:text-red-800"
+                            onClick={() => handleCancel(o)}
+                          >
+                            キャンセル
+                          </Button>
+                        </div>
+                      ) : (
+                        <p className="text-xs text-[#64748b]">操作: -</p>
+                      )}
                     </div>
                   </article>
                 ))}

--- a/talentify-next-frontend/app/talent/offers/page.module.css
+++ b/talentify-next-frontend/app/talent/offers/page.module.css
@@ -24,3 +24,12 @@
 .filterBar button {
   background: #ffffff;
 }
+
+.actionGroup {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  flex-wrap: nowrap;
+  white-space: nowrap;
+}

--- a/talentify-next-frontend/app/talent/offers/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/page.tsx
@@ -1,18 +1,20 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
-import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { format } from 'date-fns'
 import { ja } from 'date-fns/locale'
-import { ArrowUpDown, ChevronRight } from 'lucide-react'
+import { ArrowUpDown } from 'lucide-react'
 import { toast } from 'sonner'
 import { getOffersForTalent, TalentOffer } from '@/utils/getOffersForTalent'
 import { getOfferProgress } from '@/utils/offerProgress'
+import { createClient } from '@/utils/supabase/client'
+import { toDbOfferStatus } from '@/app/lib/offerStatus'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { TableSkeleton } from '@/components/ui/skeleton'
 import { EmptyState } from '@/components/ui/empty-state'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import styles from './page.module.css'
 
 const statusLabels: Record<string, string> = {
@@ -46,6 +48,7 @@ function formatDate(value: string | null, template = 'yyyy/MM/dd (EEE)') {
 }
 
 export default function TalentOffersPage() {
+  const supabase = createClient()
   const router = useRouter()
   const [offers, setOffers] = useState<TalentOffer[]>([])
   const [loading, setLoading] = useState(true)
@@ -146,6 +149,42 @@ export default function TalentOffersPage() {
     router.push(`/talent/offers/${offerId}`)
   }
 
+  const handleAccept = async (offer: TalentOffer) => {
+    if ((offer.status ?? 'pending') !== 'pending') return
+    setOffers(prev => prev.map(row => (row.id === offer.id ? { ...row, status: 'confirmed' } : row)))
+
+    const { error } = await supabase
+      .from('offers')
+      .update({ status: toDbOfferStatus('confirmed') })
+      .eq('id', offer.id)
+
+    if (error) {
+      setOffers(prev => prev.map(row => (row.id === offer.id ? { ...row, status: 'pending' } : row)))
+      toast.error('承諾に失敗しました')
+      return
+    }
+
+    toast.success('オファーを承諾しました')
+  }
+
+  const handleDecline = async (offer: TalentOffer) => {
+    if ((offer.status ?? 'pending') !== 'pending') return
+    setOffers(prev => prev.map(row => (row.id === offer.id ? { ...row, status: 'rejected' } : row)))
+
+    const { error } = await supabase
+      .from('offers')
+      .update({ status: toDbOfferStatus('rejected') })
+      .eq('id', offer.id)
+
+    if (error) {
+      setOffers(prev => prev.map(row => (row.id === offer.id ? { ...row, status: 'pending' } : row)))
+      toast.error('辞退に失敗しました')
+      return
+    }
+
+    toast.success('オファーを辞退しました')
+  }
+
   return (
     <main className={`${styles.page} p-4 text-[#334155] md:p-6`}>
       <div className={`${styles.pageInner} mx-auto w-full max-w-7xl`}>
@@ -233,7 +272,7 @@ export default function TalentOffersPage() {
                       <TableHead className="w-[130px] px-4 text-xs font-semibold text-[#334155]">現在ステータス</TableHead>
                       <TableHead className="min-w-[260px] px-4 text-xs font-semibold text-[#334155]">進捗</TableHead>
                       <TableHead className="w-[140px] px-4 text-xs font-semibold text-[#334155]">最終更新</TableHead>
-                      <TableHead className="w-[90px] px-4 text-right text-xs font-semibold text-[#334155]">詳細</TableHead>
+                      <TableHead className="w-[200px] px-4 text-right text-xs font-semibold text-[#334155]">操作</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
@@ -272,10 +311,24 @@ export default function TalentOffersPage() {
                         </TableCell>
                         <TableCell className="px-4 text-xs text-[#64748b]">{formatDate(o.created_at, 'yyyy/MM/dd HH:mm')}</TableCell>
                         <TableCell className="px-4 text-right">
-                          <Link href={`/talent/offers/${o.id}`} className="inline-flex items-center gap-1 text-sm font-medium text-[#2f4da0] hover:text-[#233a7a]" onClick={event => event.stopPropagation()}>
-                            詳細
-                            <ChevronRight className="h-4 w-4" />
-                          </Link>
+                          {(o.status ?? 'pending') === 'pending' ? (
+                            <div className={styles.actionGroup} onClick={event => event.stopPropagation()} onKeyDown={event => event.stopPropagation()}>
+                              <Button type="button" size="sm" onClick={() => handleAccept(o)}>
+                                承諾する
+                              </Button>
+                              <Button
+                                type="button"
+                                size="sm"
+                                variant="ghost"
+                                className="text-red-700 hover:bg-red-50 hover:text-red-800"
+                                onClick={() => handleDecline(o)}
+                              >
+                                辞退する
+                              </Button>
+                            </div>
+                          ) : (
+                            '-'
+                          )}
                         </TableCell>
                       </TableRow>
                     ))}
@@ -307,10 +360,26 @@ export default function TalentOffersPage() {
                     )}
                     <div className="mt-3 flex items-center justify-between text-xs text-[#64748b]">
                       <span>最終更新: {formatDate(o.created_at, 'yyyy/MM/dd HH:mm')}</span>
-                      <Link href={`/talent/offers/${o.id}`} className="inline-flex items-center gap-1 font-medium text-[#2f4da0]" onClick={event => event.stopPropagation()}>
-                        詳細
-                        <ChevronRight className="h-4 w-4" />
-                      </Link>
+                    </div>
+                    <div className="mt-3">
+                      {(o.status ?? 'pending') === 'pending' ? (
+                        <div className={styles.actionGroup} onClick={event => event.stopPropagation()} onKeyDown={event => event.stopPropagation()}>
+                          <Button type="button" size="sm" onClick={() => handleAccept(o)}>
+                            承諾する
+                          </Button>
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="ghost"
+                            className="text-red-700 hover:bg-red-50 hover:text-red-800"
+                            onClick={() => handleDecline(o)}
+                          >
+                            辞退する
+                          </Button>
+                        </div>
+                      ) : (
+                        <p className="text-xs text-[#64748b]">操作: -</p>
+                      )}
                     </div>
                   </article>
                 ))}


### PR DESCRIPTION
### Motivation
- 一覧の右端「詳細」導線を廃止して行クリックで詳細へ遷移するUIに統一するため。 
- 現状コードベースで安全に実行可能な即時アクションだけを一覧に露出し、ユーザ操作を簡潔にするため。 

### Description
- テーブル右端の「詳細」列を `操作` に置き換え、`talent` 側では `status === 'pending'` のときに「承諾する」「辞退する」を、`store` 側では `status in ('pending','accepted','confirmed')` のときに「キャンセル」を表示するようにしました。 
- 一覧ページのファイルを変更しており、対象ファイルは `talentify-next-frontend/app/talent/offers/page.tsx`、`talentify-next-frontend/app/store/offers/page.tsx`、およびそれぞれの `page.module.css` です。 
- 即時アクションは既存の API / アクションを再利用して実装しており、`createClient` と `toDbOfferStatus` を使って Supabase の `offers` を更新し、成功時はローカルの行状態を楽観的に更新します。 
- ボタン押下時に行クリックが発火しないよう、操作ボタンを包む `actionGroup` コンテナに `onClick` / `onKeyDown` で `stopPropagation()` を設定し、ページスコープの CSS module (`actionGroup`) を追加して横並び・折り返しなしのレイアウトを担保しています（グローバルCSSは変更していません）。 

### Testing
- `npm run lint` を実行し、今回の変更による ESLint エラーは発生しなかったことを確認しました（既存の `no-img-element` 警告のみ表示）。 
- リント実行は成功しています（警告のみ）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8b10fa5948332bd4b1fa7ff9f1005)