### PR TITLE
Remove per-row action column from store/talent offer lists and unify detail navigation to row click

### DIFF
--- a/talentify-next-frontend/app/store/offers/page.module.css
+++ b/talentify-next-frontend/app/store/offers/page.module.css
@@ -24,12 +24,3 @@
 .filterBar button {
   background: #ffffff;
 }
-
-.actionGroup {
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 0.5rem;
-  flex-wrap: nowrap;
-  white-space: nowrap;
-}

--- a/talentify-next-frontend/app/store/offers/page.tsx
+++ b/talentify-next-frontend/app/store/offers/page.tsx
@@ -5,16 +5,12 @@ import { useRouter } from 'next/navigation'
 import { format } from 'date-fns'
 import { ja } from 'date-fns/locale'
 import { ArrowUpDown } from 'lucide-react'
-import { toast } from 'sonner'
 import { getOffersForStore, Offer } from '@/utils/getOffersForStore'
 import { getOfferProgress } from '@/utils/offerProgress'
-import { createClient } from '@/utils/supabase/client'
-import { toDbOfferStatus } from '@/app/lib/offerStatus'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { TableSkeleton } from '@/components/ui/skeleton'
 import { EmptyState } from '@/components/ui/empty-state'
 import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
 import styles from './page.module.css'
 
 const statusLabels: Record<string, string> = {
@@ -30,7 +26,6 @@ type OfferTab = 'active' | 'history' | 'cancel'
 type SortKey = 'visit' | 'updated' | 'created'
 
 const CANCEL_STATUSES = new Set(['canceled', 'rejected', 'expired'])
-const CANCELLABLE_STATUSES = new Set(['pending', 'accepted', 'confirmed'])
 
 const badgeToneByCategory = {
   neutral: 'border-[#e2e8f0] bg-white text-[#64748b]',
@@ -49,7 +44,6 @@ function formatDate(value: string | null, template = 'yyyy/MM/dd (EEE)') {
 }
 
 export default function StoreOffersPage() {
-  const supabase = createClient()
   const router = useRouter()
   const [offers, setOffers] = useState<Offer[]>([])
   const [loading, setLoading] = useState(true)
@@ -145,32 +139,6 @@ export default function StoreOffersPage() {
     router.push(`/store/offers/${offerId}`)
   }
 
-  const handleCancel = async (offer: Offer) => {
-    const currentStatus = offer.status ?? 'pending'
-    if (!CANCELLABLE_STATUSES.has(currentStatus)) return
-    if (!confirm('このオファーを取り下げますか？')) return
-
-    const prevStatus = currentStatus
-    setOffers(prev => prev.map(row => (row.id === offer.id ? { ...row, status: 'canceled' } : row)))
-
-    const { error } = await supabase
-      .from('offers')
-      .update({
-        status: toDbOfferStatus('canceled'),
-        canceled_at: new Date().toISOString(),
-        canceled_by_role: 'store',
-      })
-      .eq('id', offer.id)
-
-    if (error) {
-      setOffers(prev => prev.map(row => (row.id === offer.id ? { ...row, status: prevStatus } : row)))
-      toast.error('キャンセルに失敗しました')
-      return
-    }
-
-    toast('オファーをキャンセルしました')
-  }
-
   return (
     <main className={`${styles.page} p-4 text-[#334155] md:p-6`}>
       <div className={`${styles.pageInner} mx-auto w-full max-w-7xl`}>
@@ -258,7 +226,6 @@ export default function StoreOffersPage() {
                       <TableHead className="w-[130px] px-4 text-xs font-semibold text-[#334155]">現在ステータス</TableHead>
                       <TableHead className="min-w-[260px] px-4 text-xs font-semibold text-[#334155]">進捗</TableHead>
                       <TableHead className="w-[140px] px-4 text-xs font-semibold text-[#334155]">最終更新</TableHead>
-                      <TableHead className="w-[180px] px-4 text-right text-xs font-semibold text-[#334155]">操作</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
@@ -296,23 +263,6 @@ export default function StoreOffersPage() {
                           )}
                         </TableCell>
                         <TableCell className="px-4 text-xs text-[#64748b]">{formatDate(o.created_at, 'yyyy/MM/dd HH:mm')}</TableCell>
-                        <TableCell className="px-4 text-right">
-                          {CANCELLABLE_STATUSES.has(o.status ?? 'pending') ? (
-                            <div className={styles.actionGroup} onClick={event => event.stopPropagation()} onKeyDown={event => event.stopPropagation()}>
-                              <Button
-                                type="button"
-                                size="sm"
-                                variant="outline"
-                                className="border-red-200 text-red-700 hover:bg-red-50 hover:text-red-800"
-                                onClick={() => handleCancel(o)}
-                              >
-                                キャンセル
-                              </Button>
-                            </div>
-                          ) : (
-                            '-'
-                          )}
-                        </TableCell>
                       </TableRow>
                     ))}
                   </TableBody>
@@ -343,23 +293,6 @@ export default function StoreOffersPage() {
                     )}
                     <div className="mt-3 flex items-center justify-between text-xs text-[#64748b]">
                       <span>最終更新: {formatDate(o.created_at, 'yyyy/MM/dd HH:mm')}</span>
-                    </div>
-                    <div className="mt-3">
-                      {CANCELLABLE_STATUSES.has(o.status ?? 'pending') ? (
-                        <div className={styles.actionGroup} onClick={event => event.stopPropagation()} onKeyDown={event => event.stopPropagation()}>
-                          <Button
-                            type="button"
-                            size="sm"
-                            variant="outline"
-                            className="border-red-200 text-red-700 hover:bg-red-50 hover:text-red-800"
-                            onClick={() => handleCancel(o)}
-                          >
-                            キャンセル
-                          </Button>
-                        </div>
-                      ) : (
-                        <p className="text-xs text-[#64748b]">操作: -</p>
-                      )}
                     </div>
                   </article>
                 ))}

--- a/talentify-next-frontend/app/talent/offers/page.module.css
+++ b/talentify-next-frontend/app/talent/offers/page.module.css
@@ -24,12 +24,3 @@
 .filterBar button {
   background: #ffffff;
 }
-
-.actionGroup {
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 0.5rem;
-  flex-wrap: nowrap;
-  white-space: nowrap;
-}

--- a/talentify-next-frontend/app/talent/offers/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/page.tsx
@@ -8,13 +8,10 @@ import { ArrowUpDown } from 'lucide-react'
 import { toast } from 'sonner'
 import { getOffersForTalent, TalentOffer } from '@/utils/getOffersForTalent'
 import { getOfferProgress } from '@/utils/offerProgress'
-import { createClient } from '@/utils/supabase/client'
-import { toDbOfferStatus } from '@/app/lib/offerStatus'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { TableSkeleton } from '@/components/ui/skeleton'
 import { EmptyState } from '@/components/ui/empty-state'
 import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
 import styles from './page.module.css'
 
 const statusLabels: Record<string, string> = {
@@ -48,7 +45,6 @@ function formatDate(value: string | null, template = 'yyyy/MM/dd (EEE)') {
 }
 
 export default function TalentOffersPage() {
-  const supabase = createClient()
   const router = useRouter()
   const [offers, setOffers] = useState<TalentOffer[]>([])
   const [loading, setLoading] = useState(true)
@@ -149,42 +145,6 @@ export default function TalentOffersPage() {
     router.push(`/talent/offers/${offerId}`)
   }
 
-  const handleAccept = async (offer: TalentOffer) => {
-    if ((offer.status ?? 'pending') !== 'pending') return
-    setOffers(prev => prev.map(row => (row.id === offer.id ? { ...row, status: 'confirmed' } : row)))
-
-    const { error } = await supabase
-      .from('offers')
-      .update({ status: toDbOfferStatus('confirmed') })
-      .eq('id', offer.id)
-
-    if (error) {
-      setOffers(prev => prev.map(row => (row.id === offer.id ? { ...row, status: 'pending' } : row)))
-      toast.error('承諾に失敗しました')
-      return
-    }
-
-    toast.success('オファーを承諾しました')
-  }
-
-  const handleDecline = async (offer: TalentOffer) => {
-    if ((offer.status ?? 'pending') !== 'pending') return
-    setOffers(prev => prev.map(row => (row.id === offer.id ? { ...row, status: 'rejected' } : row)))
-
-    const { error } = await supabase
-      .from('offers')
-      .update({ status: toDbOfferStatus('rejected') })
-      .eq('id', offer.id)
-
-    if (error) {
-      setOffers(prev => prev.map(row => (row.id === offer.id ? { ...row, status: 'pending' } : row)))
-      toast.error('辞退に失敗しました')
-      return
-    }
-
-    toast.success('オファーを辞退しました')
-  }
-
   return (
     <main className={`${styles.page} p-4 text-[#334155] md:p-6`}>
       <div className={`${styles.pageInner} mx-auto w-full max-w-7xl`}>
@@ -272,7 +232,6 @@ export default function TalentOffersPage() {
                       <TableHead className="w-[130px] px-4 text-xs font-semibold text-[#334155]">現在ステータス</TableHead>
                       <TableHead className="min-w-[260px] px-4 text-xs font-semibold text-[#334155]">進捗</TableHead>
                       <TableHead className="w-[140px] px-4 text-xs font-semibold text-[#334155]">最終更新</TableHead>
-                      <TableHead className="w-[200px] px-4 text-right text-xs font-semibold text-[#334155]">操作</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
@@ -310,26 +269,6 @@ export default function TalentOffersPage() {
                           )}
                         </TableCell>
                         <TableCell className="px-4 text-xs text-[#64748b]">{formatDate(o.created_at, 'yyyy/MM/dd HH:mm')}</TableCell>
-                        <TableCell className="px-4 text-right">
-                          {(o.status ?? 'pending') === 'pending' ? (
-                            <div className={styles.actionGroup} onClick={event => event.stopPropagation()} onKeyDown={event => event.stopPropagation()}>
-                              <Button type="button" size="sm" onClick={() => handleAccept(o)}>
-                                承諾する
-                              </Button>
-                              <Button
-                                type="button"
-                                size="sm"
-                                variant="ghost"
-                                className="text-red-700 hover:bg-red-50 hover:text-red-800"
-                                onClick={() => handleDecline(o)}
-                              >
-                                辞退する
-                              </Button>
-                            </div>
-                          ) : (
-                            '-'
-                          )}
-                        </TableCell>
                       </TableRow>
                     ))}
                   </TableBody>
@@ -360,26 +299,6 @@ export default function TalentOffersPage() {
                     )}
                     <div className="mt-3 flex items-center justify-between text-xs text-[#64748b]">
                       <span>最終更新: {formatDate(o.created_at, 'yyyy/MM/dd HH:mm')}</span>
-                    </div>
-                    <div className="mt-3">
-                      {(o.status ?? 'pending') === 'pending' ? (
-                        <div className={styles.actionGroup} onClick={event => event.stopPropagation()} onKeyDown={event => event.stopPropagation()}>
-                          <Button type="button" size="sm" onClick={() => handleAccept(o)}>
-                            承諾する
-                          </Button>
-                          <Button
-                            type="button"
-                            size="sm"
-                            variant="ghost"
-                            className="text-red-700 hover:bg-red-50 hover:text-red-800"
-                            onClick={() => handleDecline(o)}
-                          >
-                            辞退する
-                          </Button>
-                        </div>
-                      ) : (
-                        <p className="text-xs text-[#64748b]">操作: -</p>
-                      )}
                     </div>
                   </article>
                 ))}


### PR DESCRIPTION
### Motivation
- Remove the incomplete per-row action UI from the offer lists to simplify the interface and make detail navigation uniform via row clicks.
- Reduce duplicated action logic in list pages and keep page-level styles scoped without touching global CSS.

### Description
- Removed the right-most “操作” (`TableHead` and per-row `TableCell`) from `app/store/offers/page.tsx` and `app/talent/offers/page.tsx` so the table no longer shows action buttons. 
- Deleted per-row action UI and logic including cancel/accept/decline handlers and related imports (`createClient`, `toDbOfferStatus`, `Button`, and action-related `toast` usage) from both pages. 
- Removed the now-unused `actionGroup` rule from `app/store/offers/page.module.css` and `app/talent/offers/page.module.css` while preserving `hover:bg-[#f8fafc]` and `cursor-pointer` so row-click navigation (`handleRowClick`) to `/store/offers/[id]` and `/talent/offers/[id]` remains. 
- Did not change global CSS, API routes, authentication, or data structures. 

### Testing
- Ran `npm run lint`, which completed successfully with only existing `@next/next/no-img-element` warnings and no lint errors. 
- No additional automated tests were added or required for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8b3dfad7883328a05d610c44bedaf)