### PR TITLE
演者詳細ページのオファー導線をDrawer/Modal化

### DIFF
--- a/talentify-next-frontend/app/talents/[id]/OfferComposerOverlay.tsx
+++ b/talentify-next-frontend/app/talents/[id]/OfferComposerOverlay.tsx
@@ -1,0 +1,247 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import * as Dialog from '@radix-ui/react-dialog'
+import { X } from 'lucide-react'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/button'
+import { createClient } from '@/utils/supabase/client'
+import { toast } from 'sonner'
+
+type OfferTargetSummary = {
+  stageName: string
+  residence?: string | null
+  availability?: string | null
+  minHours?: string | null
+  transportation?: string | null
+  rate?: number | null
+}
+
+type OfferComposerOverlayProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  talentId: string
+  summary: OfferTargetSummary
+  onSuccess: () => void
+}
+
+const supabase = createClient()
+
+export default function OfferComposerOverlay({
+  open,
+  onOpenChange,
+  talentId,
+  summary,
+  onSuccess,
+}: OfferComposerOverlayProps) {
+  const [isMobile, setIsMobile] = useState(false)
+  const [message, setMessage] = useState('')
+  const [visitDate, setVisitDate] = useState('')
+  const [timeRange, setTimeRange] = useState('')
+  const [agreed, setAgreed] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [discardConfirmOpen, setDiscardConfirmOpen] = useState(false)
+
+  const dirty = useMemo(
+    () => message.trim().length > 0 || visitDate.length > 0 || timeRange.trim().length > 0 || agreed,
+    [agreed, message, timeRange, visitDate]
+  )
+
+  useEffect(() => {
+    const updateViewport = () => {
+      setIsMobile(window.innerWidth < 768)
+    }
+    updateViewport()
+    window.addEventListener('resize', updateViewport)
+    return () => window.removeEventListener('resize', updateViewport)
+  }, [])
+
+  const resetForm = () => {
+    setMessage('')
+    setVisitDate('')
+    setTimeRange('')
+    setAgreed(false)
+    setDiscardConfirmOpen(false)
+    setSubmitting(false)
+  }
+
+  const requestClose = () => {
+    if (!dirty || submitting) {
+      onOpenChange(false)
+      if (!submitting) resetForm()
+      return
+    }
+    setDiscardConfirmOpen(true)
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (submitting) return
+
+    setSubmitting(true)
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
+    if (!user) {
+      toast.error('ログインしてください')
+      setSubmitting(false)
+      return
+    }
+
+    const { data: store } = await supabase.from('stores').select('id').eq('user_id', user.id).single()
+
+    if (!store) {
+      toast.error('店舗情報が見つかりません')
+      setSubmitting(false)
+      return
+    }
+
+    const res = await fetch('/api/offers', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        store_id: store.id,
+        talent_id: talentId,
+        date: visitDate,
+        time_range: timeRange,
+        agreed,
+        message,
+      }),
+    })
+
+    const result = await res.json()
+    if (!res.ok || !result.ok) {
+      toast.error(result.reason ? String(result.reason) : '送信に失敗しました')
+      setSubmitting(false)
+      return
+    }
+
+    toast.success('オファーを送信しました')
+    onSuccess()
+    onOpenChange(false)
+    resetForm()
+  }
+
+  return (
+    <>
+      <Dialog.Root open={open} onOpenChange={nextOpen => (nextOpen ? onOpenChange(true) : requestClose())}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 z-50 bg-black/40" />
+          <Dialog.Content
+            className={
+              isMobile
+                ? 'fixed inset-0 z-50 flex flex-col bg-white pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]'
+                : 'fixed right-0 top-0 z-50 flex h-screen w-[min(92vw,560px)] min-w-[480px] flex-col bg-white shadow-xl'
+            }
+          >
+            <header className="flex items-center justify-between border-b border-slate-200 px-4 py-3 md:px-5">
+              <Dialog.Title className="text-base font-semibold text-slate-900">オファーを送る</Dialog.Title>
+              <button
+                type="button"
+                onClick={requestClose}
+                aria-label="閉じる"
+                className="rounded-md p-1 text-slate-500 transition hover:bg-slate-100 hover:text-slate-900"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </header>
+
+            <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
+              <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-4 py-4 md:px-5">
+                <section className="space-y-2 rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm">
+                  <p className="text-xs font-semibold text-slate-600">オファー対象</p>
+                  <SummaryRow label="キャスト名" value={summary.stageName} />
+                  <SummaryRow label="拠点地域" value={summary.residence || '要相談'} />
+                  <SummaryRow label="出演可能時間" value={summary.availability || '要相談'} />
+                  <SummaryRow label="最低拘束時間" value={summary.minHours || '要相談'} />
+                  <SummaryRow label="交通費" value={summary.transportation || '要相談'} />
+                  <SummaryRow
+                    label="出演料金目安"
+                    value={summary.rate != null ? `${summary.rate.toLocaleString('ja-JP')}円〜` : '要相談'}
+                  />
+                </section>
+
+                <section className="space-y-4">
+                  <div>
+                    <label className="mb-1 block text-sm font-medium text-slate-700">希望日</label>
+                    <Input type="date" value={visitDate} onChange={e => setVisitDate(e.target.value)} />
+                  </div>
+                  <div>
+                    <label className="mb-1 block text-sm font-medium text-slate-700">希望時間帯</label>
+                    <Input value={timeRange} onChange={e => setTimeRange(e.target.value)} placeholder="例: 10:00~" />
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <input
+                      id="offer-agree"
+                      type="checkbox"
+                      checked={agreed}
+                      onChange={e => setAgreed(e.target.checked)}
+                      required
+                    />
+                    <label htmlFor="offer-agree" className="text-sm text-slate-700">
+                      出演条件に同意します
+                    </label>
+                  </div>
+                  <div>
+                    <label className="mb-1 block text-sm font-medium text-slate-700">メッセージ</label>
+                    <Textarea
+                      value={message}
+                      onChange={e => setMessage(e.target.value)}
+                      placeholder="出演依頼内容などを入力"
+                      className="min-h-[120px]"
+                    />
+                  </div>
+                </section>
+              </div>
+
+              <footer className="sticky bottom-0 flex items-center justify-end gap-2 border-t border-slate-200 bg-white px-4 py-3 md:px-5">
+                <Button type="button" variant="outline" onClick={requestClose} disabled={submitting}>
+                  キャンセル
+                </Button>
+                <Button type="submit" disabled={submitting}>
+                  {submitting ? '送信中...' : 'オファー送信'}
+                </Button>
+              </footer>
+            </form>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+
+      <Dialog.Root open={discardConfirmOpen} onOpenChange={setDiscardConfirmOpen}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 z-[60] bg-black/50" />
+          <Dialog.Content className="fixed left-1/2 top-1/2 z-[61] w-[min(92vw,420px)] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-white p-5 shadow-lg">
+            <Dialog.Title className="text-base font-semibold text-slate-900">入力内容を破棄しますか？</Dialog.Title>
+            <p className="mt-2 text-sm text-slate-600">編集中の内容は保存されません。</p>
+            <div className="mt-4 flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setDiscardConfirmOpen(false)}>
+                編集を続ける
+              </Button>
+              <Button
+                onClick={() => {
+                  setDiscardConfirmOpen(false)
+                  onOpenChange(false)
+                  resetForm()
+                }}
+              >
+                破棄して閉じる
+              </Button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </>
+  )
+}
+
+function SummaryRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-start justify-between gap-3 border-b border-slate-200 pb-1 last:border-b-0 last:pb-0">
+      <span className="text-slate-500">{label}</span>
+      <span className="text-right font-medium text-slate-900">{value}</span>
+    </div>
+  )
+}

--- a/talentify-next-frontend/app/talents/[id]/TalentDetailPageClient.tsx
+++ b/talentify-next-frontend/app/talents/[id]/TalentDetailPageClient.tsx
@@ -14,6 +14,7 @@ import { toast } from 'sonner'
 import { useRouter } from 'next/navigation'
 import NewMessageModal from '@/components/messages/NewMessageModal'
 import { findOrCreateConversation } from '@/lib/messages'
+import OfferComposerOverlay from './OfferComposerOverlay'
 
 type Talent = {
   id: string
@@ -53,6 +54,8 @@ export default function TalentDetailPageClient({ id, initialTalent }: Props) {
   const [imageLoaded, setImageLoaded] = useState(false)
   const router = useRouter()
   const [messageOpen, setMessageOpen] = useState(false)
+  const [offerOpen, setOfferOpen] = useState(false)
+  const [offerSent, setOfferSent] = useState(false)
 
   useEffect(() => {
     const fetchData = async () => {
@@ -107,6 +110,12 @@ export default function TalentDetailPageClient({ id, initialTalent }: Props) {
   const handleFavorite = () => {
     setIsFavorite(v => !v)
     toast.success(isFavorite ? 'お気に入りを解除しました' : 'お気に入りに追加しました')
+  }
+
+
+  const handleOfferSuccess = () => {
+    setOfferSent(true)
+    router.refresh()
   }
 
   const handleMessage = async () => {
@@ -182,9 +191,10 @@ export default function TalentDetailPageClient({ id, initialTalent }: Props) {
                   <Button
                     className="h-11 w-full bg-slate-900 text-white hover:bg-slate-800"
                     aria-label="このキャストにオファーする"
-                    onClick={() => (window.location.href = `/talents/${id}/offer`)}
+                    onClick={() => setOfferOpen(true)}
+                    disabled={offerSent}
                   >
-                    このキャストにオファーする
+                    {offerSent ? '送信済み' : 'このキャストにオファーする'}
                   </Button>
                   <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
                     {(role === 'store' || role === null) && (
@@ -297,6 +307,21 @@ export default function TalentDetailPageClient({ id, initialTalent }: Props) {
           </Card>
         </div>
       </main>
+
+    <OfferComposerOverlay
+      open={offerOpen}
+      onOpenChange={setOfferOpen}
+      talentId={id}
+      summary={{
+        stageName: talent.stage_name,
+        residence: talent.residence,
+        availability: talent.availability,
+        minHours: talent.min_hours,
+        transportation: talent.transportation,
+        rate: talent.rate,
+      }}
+      onSuccess={handleOfferSuccess}
+    />
     <NewMessageModal
       open={messageOpen}
       onOpenChange={setMessageOpen}


### PR DESCRIPTION
### Motivation
- 演者詳細ページでオファー送信時に画面遷移による文脈切断を無くし、元の演者情報を見ながら判断できるようにするため。 
- PCでは右サイドDrawer、MobileではフルスクリーンModalとして一貫したオンページUIで送信フローを完結させるため。 
- 既存のAPI契約やグローバルCSSを変えずにUI改善のみ行うため。

### Description
- 演者詳細ページの遷移ボタンを遷移からオーバーレイ開閉へ置換し、`OfferComposerOverlay` コンポーネントで Drawer/Modal 表示を実装しました（ファイル: `app/talents/[id]/OfferComposerOverlay.tsx`）。
- 既存のオファーフォーム処理／API呼び出しは保持し、`/api/offers` に `store_id / talent_id / date / time_range / agreed / message` を送信する実装にしています。 
- Drawer（PC: 右側、幅 `min(92vw,560px)` / 最小幅 `480px`）と Mobile（フルスクリーン、`safe-area` 考慮）でヘッダー／フッターを固定し本文のみスクロール可能にしました。 
- dirty 判定による離脱確認ダイアログ、送信中のボタンローディング、送信成功時のトースト表示・オーバーレイ閉鎖・`router.refresh()` と CTA を「送信済み」に更新するフローを追加しました。

### Testing
- `npm run lint` を実行し正常終了しました（既存ファイル由来の `no-img-element` 警告のみでエラーは発生していません）。
- 追加の自動テストは実行しておらず、変更点は UI とクライアント側フローに限定されています。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8b77418b08332a03a29a5d918230d)