### PR TITLE
Unify invoice status display and complete store/talent invoice UI flows

### DIFF
--- a/talentify-next-frontend/app/store/invoices/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/invoices/[id]/page.tsx
@@ -10,6 +10,7 @@ import { Badge } from '@/components/ui/badge'
 import { toast } from 'sonner'
 import { formatJaDateTimeWithWeekday } from '@/utils/formatJaDateTimeWithWeekday'
 import { Loader2 } from 'lucide-react'
+import { getInvoiceStatusLabel, getPaymentStatusLabel } from '@/lib/invoices/status'
 
 const supabase = createClient()
 
@@ -25,6 +26,7 @@ interface Invoice {
   notes: string | null
   invoice_number: string | null
   due_date: string | null
+  payment_status: string | null
   offers: { paid: boolean | null } | null
   talents: {
     bank_name: string | null
@@ -47,16 +49,11 @@ interface RawInvoice extends Omit<Invoice, 'offers' | 'talents'> {
 }
 
 function statusLabel(inv: Invoice): string {
-  if (inv.offers?.paid) return '支払い完了'
-  switch (inv.status) {
-    case 'approved':
-    case 'submitted':
-      return '提出済み'
-    case 'rejected':
-      return '差し戻し済み'
-    default:
-      return '下書き'
-  }
+  return getInvoiceStatusLabel(inv.status)
+}
+
+function paymentStatusLabel(inv: Invoice): string {
+  return getPaymentStatusLabel(inv.payment_status, inv.offers?.paid)
 }
 
 export default function StoreInvoiceDetail() {
@@ -67,13 +64,14 @@ export default function StoreInvoiceDetail() {
   const [invoice, setInvoice] = useState<Invoice | null>(null)
   const [loading, setLoading] = useState(true)
   const [paying, setPaying] = useState(false)
+  const [updatingStatus, setUpdatingStatus] = useState(false)
   const [downloading, setDownloading] = useState(false)
 
   const load = async () => {
     const { data } = await supabase
       .from('invoices')
       .select(
-        'id,amount,transport_fee,extra_fee,notes,invoice_number,due_date,invoice_url,status,created_at,offer_id,offers(paid),talents:talent_id(bank_name,branch_name,account_type,account_number,account_holder)'
+        'id,amount,transport_fee,extra_fee,notes,invoice_number,due_date,invoice_url,status,payment_status,created_at,offer_id,offers(paid),talents:talent_id(bank_name,branch_name,account_type,account_number,account_holder)'
       )
       .eq('id', id)
       .maybeSingle()
@@ -106,6 +104,33 @@ export default function StoreInvoiceDetail() {
       }
     } else {
       toast.error('支払いの記録に失敗しました')
+    }
+  }
+
+  const handleApprove = async () => {
+    setUpdatingStatus(true)
+    const res = await fetch(`/api/invoices/${id}/approve`, { method: 'POST' })
+    setUpdatingStatus(false)
+    if (res.ok) {
+      toast.success('請求書を承認しました')
+      await load()
+    } else {
+      toast.error('承認に失敗しました')
+    }
+  }
+
+  const handleReject = async () => {
+    const ok = window.confirm('この請求書を差し戻しますか？')
+    if (!ok) return
+
+    setUpdatingStatus(true)
+    const res = await fetch(`/api/invoices/${id}/reject`, { method: 'POST' })
+    setUpdatingStatus(false)
+    if (res.ok) {
+      toast.success('請求書を差し戻しました')
+      await load()
+    } else {
+      toast.error('差し戻しに失敗しました')
     }
   }
 
@@ -162,8 +187,14 @@ export default function StoreInvoiceDetail() {
               : '-'}
           </div>
           <div>
-            ステータス:{' '}
+            請求書ステータス:{' '}
             <Badge variant='outline'>{statusLabel(invoice)}</Badge>
+          </div>
+          <div>
+            支払い状態:{' '}
+            <Badge variant={invoice.offers?.paid ? 'success' : 'secondary'}>
+              {paymentStatusLabel(invoice)}
+            </Badge>
           </div>
           {invoice.invoice_url && (
             <div>
@@ -219,7 +250,20 @@ export default function StoreInvoiceDetail() {
         請求書をダウンロード
       </Button>
 
-      {!invoice.offers?.paid && invoice.status !== 'draft' && (
+      {invoice.status === 'submitted' && (
+        <div className='flex gap-2'>
+          <Button onClick={handleApprove} disabled={updatingStatus}>
+            {updatingStatus && <Loader2 className='mr-2 h-4 w-4 animate-spin' />}
+            承認する
+          </Button>
+          <Button onClick={handleReject} disabled={updatingStatus} variant='outline'>
+            {updatingStatus && <Loader2 className='mr-2 h-4 w-4 animate-spin' />}
+            差し戻す
+          </Button>
+        </div>
+      )}
+
+      {!invoice.offers?.paid && invoice.status === 'approved' && (
         <Button onClick={handlePay} disabled={paying}>
           {paying && <Loader2 className='mr-2 h-4 w-4 animate-spin' />}
           支払い完了にする

--- a/talentify-next-frontend/app/store/invoices/page.tsx
+++ b/talentify-next-frontend/app/store/invoices/page.tsx
@@ -9,21 +9,18 @@ import { EmptyState } from '@/components/ui/empty-state'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { formatJaDateTimeWithWeekday } from '@/utils/formatJaDateTimeWithWeekday'
+import { getInvoiceStatusLabel, getPaymentStatusLabel } from '@/lib/invoices/status'
 
 function renderStatus(inv: Invoice) {
-  if (inv.offers?.paid) {
-    return <Badge variant='success'>支払い完了</Badge>
-  }
-  switch (inv.status) {
-    case 'approved':
-      return <Badge variant='secondary'>提出済み</Badge>
-    case 'submitted':
-      return <Badge variant='secondary'>提出済み</Badge>
-    case 'rejected':
-      return <Badge variant='destructive'>差し戻し済み</Badge>
-    default:
-      return <Badge variant='outline'>下書き</Badge>
-  }
+  return <Badge variant='outline'>{getInvoiceStatusLabel(inv.status)}</Badge>
+}
+
+function renderPaymentStatus(inv: Invoice) {
+  return (
+    <Badge variant={inv.offers?.paid ? 'success' : 'secondary'}>
+      {getPaymentStatusLabel(inv.payment_status, inv.offers?.paid)}
+    </Badge>
+  )
 }
 
 export default function StoreInvoicesPage() {
@@ -50,7 +47,8 @@ export default function StoreInvoicesPage() {
             <TableRow>
               <TableHead>作成日</TableHead>
               <TableHead>金額</TableHead>
-              <TableHead>ステータス</TableHead>
+              <TableHead>請求書ステータス</TableHead>
+              <TableHead>支払い状態</TableHead>
               <TableHead>操作</TableHead>
             </TableRow>
           </TableHeader>
@@ -60,6 +58,7 @@ export default function StoreInvoicesPage() {
                 <TableCell>{formatJaDateTimeWithWeekday(inv.created_at ?? '')}</TableCell>
                 <TableCell>¥{inv.amount.toLocaleString('ja-JP')}</TableCell>
                 <TableCell>{renderStatus(inv)}</TableCell>
+                <TableCell>{renderPaymentStatus(inv)}</TableCell>
                 <TableCell>
                   <div className='flex gap-2'>
                     {inv.invoice_url && (

--- a/talentify-next-frontend/app/talent/invoices/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/invoices/[id]/page.tsx
@@ -11,6 +11,7 @@ import { Badge } from '@/components/ui/badge'
 import { formatJaDateTimeWithWeekday } from '@/utils/formatJaDateTimeWithWeekday'
 import { Loader2 } from 'lucide-react'
 import { toast } from 'sonner'
+import { getInvoiceStatusLabel, getPaymentStatusLabel } from '@/lib/invoices/status'
 
 const supabase = createClient()
 
@@ -28,14 +29,6 @@ interface Invoice {
   created_at: string | null
 }
 
-const statusLabels: Record<string, string> = {
-  draft: '下書き',
-  approved: '提出済み',
-  submitted: '提出済み',
-  paid: '支払い済み',
-  rejected: '差し戻し',
-}
-
 export default function TalentInvoiceDetailPage() {
   const params = useParams()
   const id = params?.id as string
@@ -50,6 +43,7 @@ export default function TalentInvoiceDetailPage() {
 
   const [saving, setSaving] = useState(false)
   const [submitting, setSubmitting] = useState(false)
+  const [downloading, setDownloading] = useState(false)
 
   useEffect(() => {
     const load = async () => {
@@ -117,6 +111,25 @@ export default function TalentInvoiceDetailPage() {
     }
   }
 
+  const handleDownload = async () => {
+    setDownloading(true)
+    const res = await fetch(`/api/invoices/${id}/pdf`)
+    setDownloading(false)
+    if (res.ok) {
+      const blob = await res.blob()
+      const url = window.URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `invoice-${id}.pdf`
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+      window.URL.revokeObjectURL(url)
+    } else {
+      toast.error('PDFのダウンロードに失敗しました')
+    }
+  }
+
   return (
     <main className="p-6 space-y-4">
       <h1 className="text-xl font-bold">請求詳細</h1>
@@ -148,11 +161,13 @@ export default function TalentInvoiceDetailPage() {
           </div>
 
           <div>
-            ステータス:{' '}
-            <Badge variant="outline">
-              {invoice.payment_status === 'paid'
-                ? '支払い済み'
-                : statusLabels[invoice.status] ?? invoice.status}
+            請求書ステータス:{' '}
+            <Badge variant="outline">{getInvoiceStatusLabel(invoice.status)}</Badge>
+          </div>
+          <div>
+            支払い状態:{' '}
+            <Badge variant={invoice.payment_status === 'paid' ? 'success' : 'secondary'}>
+              {getPaymentStatusLabel(invoice.payment_status)}
             </Badge>
           </div>
         </CardContent>
@@ -190,7 +205,11 @@ export default function TalentInvoiceDetailPage() {
           </Button>
         </div>
       )}
+
+      <Button onClick={handleDownload} disabled={downloading} variant='outline'>
+        {downloading && <Loader2 className='mr-2 h-4 w-4 animate-spin' />}
+        請求書をダウンロード
+      </Button>
     </main>
   )
 }
-

--- a/talentify-next-frontend/app/talent/invoices/[id]/submitted/page.tsx
+++ b/talentify-next-frontend/app/talent/invoices/[id]/submitted/page.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { formatJaDateTimeWithWeekday } from '@/utils/formatJaDateTimeWithWeekday'
+import { getInvoiceStatusLabel, getPaymentStatusLabel } from '@/lib/invoices/status'
 
 const supabase = createClient()
 
@@ -23,14 +24,6 @@ interface Invoice {
   status: string
   payment_status: string | null
   created_at: string | null
-}
-
-const statusLabels: Record<string, string> = {
-  draft: '下書き',
-  approved: '提出済み',
-  submitted: '提出済み',
-  paid: '支払い済み',
-  rejected: '差し戻し',
 }
 
 export default function TalentInvoiceSubmittedPage() {
@@ -112,11 +105,12 @@ export default function TalentInvoiceSubmittedPage() {
               : '-'}
           </div>
           <div>
-            ステータス:{' '}
-            <Badge variant='outline'>
-              {invoice.payment_status === 'paid'
-                ? '支払い済み'
-                : statusLabels[invoice.status] ?? invoice.status}
+            請求書ステータス: <Badge variant='outline'>{getInvoiceStatusLabel(invoice.status)}</Badge>
+          </div>
+          <div>
+            支払い状態:{' '}
+            <Badge variant={invoice.payment_status === 'paid' ? 'success' : 'secondary'}>
+              {getPaymentStatusLabel(invoice.payment_status)}
             </Badge>
           </div>
         </CardContent>

--- a/talentify-next-frontend/app/talent/invoices/new/page.tsx
+++ b/talentify-next-frontend/app/talent/invoices/new/page.tsx
@@ -10,6 +10,7 @@ import { Badge } from '@/components/ui/badge'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import { addMonths, endOfMonth, format, parseISO, setDate } from 'date-fns'
+import { getInvoiceStatusLabel, isPaymentCompleted } from '@/lib/invoices/status'
 
 const dueDateOptions = [
   { value: 'none', label: '設定しない' },
@@ -128,16 +129,15 @@ export default function TalentInvoiceNewPage() {
     Number(extraFee || 0)
 
   const statusLabel = () => {
-    if (invoice?.payment_status === 'paid') return '支払済み'
-    if (invoice?.status === 'approved') return '提出済み'
-    return '下書き'
+    if (isPaymentCompleted(invoice?.payment_status)) return '支払済み'
+    return getInvoiceStatusLabel(invoice?.status)
   }
 
   const storeDisplayName = offer?.store?.store_name ?? ''
 
   const currentStep = () => {
-    if (invoice?.payment_status === 'paid') return 2
-    return invoice?.status === 'approved' ? 1 : 0
+    if (isPaymentCompleted(invoice?.payment_status)) return 2
+    return invoice?.status === 'submitted' || invoice?.status === 'approved' ? 1 : 0
   }
 
   const saveDraft = async () => {

--- a/talentify-next-frontend/app/talent/invoices/page.tsx
+++ b/talentify-next-frontend/app/talent/invoices/page.tsx
@@ -15,14 +15,8 @@ import { TableSkeleton } from '@/components/ui/skeleton'
 import { EmptyState } from '@/components/ui/empty-state'
 import { formatJaDateTimeWithWeekday } from '@/utils/formatJaDateTimeWithWeekday'
 import { Button } from '@/components/ui/button'
-
-const statusLabels: Record<string, string> = {
-  draft: '下書き',
-  approved: '提出済み',
-  submitted: '提出済み',
-  paid: '支払完了',
-  rejected: '差し戻し',
-}
+import { Badge } from '@/components/ui/badge'
+import { getInvoiceStatusLabel, getPaymentStatusLabel } from '@/lib/invoices/status'
 
 export default function TalentInvoicesPage() {
   const [invoices, setInvoices] = useState<Invoice[]>([])
@@ -48,7 +42,8 @@ export default function TalentInvoicesPage() {
             <TableRow>
               <TableHead>作成日</TableHead>
               <TableHead>金額</TableHead>
-              <TableHead>ステータス</TableHead>
+              <TableHead>請求書ステータス</TableHead>
+              <TableHead>支払い状態</TableHead>
               <TableHead>操作</TableHead>
             </TableRow>
           </TableHeader>
@@ -57,7 +52,14 @@ export default function TalentInvoicesPage() {
               <TableRow key={inv.id}>
                 <TableCell>{formatJaDateTimeWithWeekday(inv.created_at ?? '')}</TableCell>
                 <TableCell>¥{inv.amount.toLocaleString()}</TableCell>
-                <TableCell>{statusLabels[inv.status]}</TableCell>
+                <TableCell>
+                  <Badge variant='outline'>{getInvoiceStatusLabel(inv.status)}</Badge>
+                </TableCell>
+                <TableCell>
+                  <Badge variant={inv.payment_status === 'paid' ? 'success' : 'secondary'}>
+                    {getPaymentStatusLabel(inv.payment_status)}
+                  </Badge>
+                </TableCell>
                 <TableCell>
                   <Button size='sm' asChild>
                     <Link href={`/talent/invoices/${inv.id}`}>詳細</Link>

--- a/talentify-next-frontend/lib/invoices/status.ts
+++ b/talentify-next-frontend/lib/invoices/status.ts
@@ -1,0 +1,25 @@
+export type InvoiceStatus = 'draft' | 'submitted' | 'approved' | 'rejected' | string | null | undefined
+export type PaymentStatus = 'paid' | 'unpaid' | string | null | undefined
+
+export function getInvoiceStatusLabel(status: InvoiceStatus): string {
+  switch (status) {
+    case 'draft':
+      return '未提出'
+    case 'submitted':
+      return '提出済み'
+    case 'approved':
+      return '承認済み'
+    case 'rejected':
+      return '差し戻し'
+    default:
+      return status ?? '-'
+  }
+}
+
+export function isPaymentCompleted(paymentStatus: PaymentStatus, offerPaid?: boolean | null): boolean {
+  return paymentStatus === 'paid' || offerPaid === true
+}
+
+export function getPaymentStatusLabel(paymentStatus: PaymentStatus, offerPaid?: boolean | null): string {
+  return isPaymentCompleted(paymentStatus, offerPaid) ? '支払済み' : '未払い'
+}


### PR DESCRIPTION
### Motivation
- 現状の画面ごとのステータス表記差分を解消し、`submitted` を全画面で「提出済み」として扱う共通表示にして運用できる状態にするための最小改修を行いました。 
- store 側で `submitted` の請求書に対する承認/差し戻し導線が無く、talent 側で PDF ダウンロード導線が無い点を既存 API を再利用して補完します。 
- `invoice.status` と `payment_status` が混在して見える UI を分離して誤解を減らすことを優先し、DB/型の大改修は行いません。

### Description
- 追加: 共通ステータス表示ロジックを `lib/invoices/status.ts` に実装し、表示を以下に統一しました: `draft -> 未提出`, `submitted -> 提出済み`, `approved -> 承認済み`, `rejected -> 差し戻し`。また支払い判定を行う `isPaymentCompleted` / `getPaymentStatusLabel` を追加しました。 
- store 側一覧/詳細を更新して「請求書ステータス」と「支払い状態」を分離表示に変更し、文言は共通ロジック経由で表示するようにしました（`app/store/invoices/page.tsx`, `app/store/invoices/[id]/page.tsx`）。 
- store 請求詳細に承認/差し戻しボタンを追加し、`status === 'submitted'` のときのみ表示して既存 API (`/api/invoices/:id/approve` と `/api/invoices/:id/reject`) を呼び、成功時に画面を再読込するようにしました（差し戻しは確認ダイアログあり）。 
- talent 側一覧/詳細/提出完了/新規画面を共通ロジックへ合わせて調整し、talent 詳細に既存 `/api/invoices/:id/pdf` を使った PDF ダウンロードボタンを追加しました（`app/talent/invoices/*`）。 
- 変更ファイル（主なもの）: `lib/invoices/status.ts`, `app/store/invoices/page.tsx`, `app/store/invoices/[id]/page.tsx`, `app/talent/invoices/page.tsx`, `app/talent/invoices/[id]/page.tsx`, `app/talent/invoices/[id]/submitted/page.tsx`, `app/talent/invoices/new/page.tsx`.
- 既存 API (`approve`, `reject`, `pdf`, `pay`, `submit`) をそのまま再利用し、バックエンド契約は変更していません。型/DB の大きな変更は行っておらず、`offers.paid` と `invoices.payment_status` の二重管理は共通ヘルパーで扱いを統一することで暫定対応しています。

### Testing
- 実行: `npm run lint` を実行し、コマンドは正常終了しました（既存コード由来の `<img>` に関する ESLint 警告は残っていますが、今回の変更で得られたエラーはありません）。
- 備考: この PR は主にフロントエンド UI の変更であり、統合テスト・E2E は実行していません。ローカルでのビルド/ブラウズ確認は想定していますが、実行環境上のブラウザ確認は行っていません。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8be4f95ac8332a513156a2ea58355)