### PR TITLE
Unify invoice status & fix broken payment links in offer details

### DIFF
--- a/talentify-next-frontend/__tests__/invoices-status.test.ts
+++ b/talentify-next-frontend/__tests__/invoices-status.test.ts
@@ -1,0 +1,24 @@
+import { deriveOfferInvoiceProgressStatus, getInvoiceStatusLabel, getPaymentStatusLabel } from '@/lib/invoices/status'
+
+describe('invoices status helpers', () => {
+  it('maps invoice status labels', () => {
+    expect(getInvoiceStatusLabel('draft')).toBe('未提出')
+    expect(getInvoiceStatusLabel('submitted')).toBe('提出済み')
+    expect(getInvoiceStatusLabel('approved')).toBe('承認済み')
+  })
+
+  it('derives offer invoice status from invoice.status as source of truth', () => {
+    expect(deriveOfferInvoiceProgressStatus({ invoiceStatus: 'draft' })).toBe('not_submitted')
+    expect(deriveOfferInvoiceProgressStatus({ invoiceStatus: 'submitted' })).toBe('submitted')
+  })
+
+  it('treats payment completion as paid progress', () => {
+    expect(
+      deriveOfferInvoiceProgressStatus({
+        invoiceStatus: 'submitted',
+        invoicePaymentStatus: 'paid',
+      })
+    ).toBe('paid')
+    expect(getPaymentStatusLabel('unpaid', true)).toBe('支払済み')
+  })
+})

--- a/talentify-next-frontend/app/store/offers/[id]/StepDetailCard.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/StepDetailCard.tsx
@@ -26,6 +26,8 @@ type StepDetailCardProps = {
     paid: boolean
     paidAt: string | null
     invoiceStatus: 'not_submitted' | 'submitted' | 'paid'
+    invoiceStatusLabel: string
+    paymentStatusLabel: string
     reward: number | null
     talentId: string | null
     reviewCompleted: boolean
@@ -35,6 +37,7 @@ type StepDetailCardProps = {
     invoiceUrl: string | null
     amount: number | null
     status: string
+    paymentStatus: string | null
   } | null
   paymentLink?: string
   cancelation?: {
@@ -51,12 +54,6 @@ type StepDetail = {
   actions?: ReactNode[]
   note?: ReactNode
   footer?: ReactNode
-}
-
-const invoiceStatusText: Record<'not_submitted' | 'submitted' | 'paid', string> = {
-  not_submitted: '未提出',
-  submitted: '提出済み',
-  paid: '支払済み',
 }
 
 const statusBadge = (status: string) => {
@@ -235,7 +232,7 @@ export default function StepDetailCard({
           description,
           badge: activeStatus === 'complete' ? <Badge variant="success">完了</Badge> : undefined,
           meta: [
-            { label: '請求ステータス', value: invoiceStatusText[offer.invoiceStatus] },
+            { label: '請求ステータス', value: offer.invoiceStatusLabel },
             ...(invoice?.amount != null
               ? [{ label: '請求額', value: `¥${invoice.amount.toLocaleString('ja-JP')}` }]
               : []),
@@ -256,7 +253,7 @@ export default function StepDetailCard({
         if (paymentLink) {
           actions.push(
             <Button key="payment" size="sm" asChild>
-              <Link href={paymentLink}>支払い状況</Link>
+              <Link href={paymentLink}>支払いを確認する</Link>
             </Button>,
           )
         }
@@ -265,7 +262,7 @@ export default function StepDetailCard({
           description,
           badge: offer.paid ? <Badge variant="success">完了</Badge> : undefined,
           meta: [
-            { label: '支払い状況', value: offer.paid ? '完了' : '未完了' },
+            { label: '支払い状況', value: offer.paymentStatusLabel },
             ...(paymentCompletedLabel ? [{ label: '支払い日', value: paymentCompletedLabel }] : []),
           ],
           actions,
@@ -327,7 +324,9 @@ export default function StepDetailCard({
     invoice,
     offer.id,
     offer.invoiceStatus,
+    offer.invoiceStatusLabel,
     offer.paid,
+    offer.paymentStatusLabel,
     offer.reviewCompleted,
     offer.talentId,
     offer.reward,

--- a/talentify-next-frontend/app/store/offers/[id]/StoreOfferProgressPanel.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/StoreOfferProgressPanel.tsx
@@ -33,6 +33,7 @@ interface StoreOfferProgressPanelProps {
     invoiceUrl: string | null
     amount: number | null
     status: string
+    paymentStatus: string | null
   } | null
   paymentLink?: string
   cancelation: {

--- a/talentify-next-frontend/app/store/offers/[id]/StoreOfferProgressPanel.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/StoreOfferProgressPanel.tsx
@@ -21,6 +21,8 @@ interface StoreOfferProgressPanelProps {
     paid: boolean
     paidAt: string | null
     invoiceStatus: 'not_submitted' | 'submitted' | 'paid'
+    invoiceStatusLabel: string
+    paymentStatusLabel: string
     storeName: string
     reward: number | null
     talentId: string | null
@@ -43,12 +45,6 @@ interface StoreOfferProgressPanelProps {
     storeName: string
     talentName: string
   }
-}
-
-const invoiceStatusText: Record<'not_submitted' | 'submitted' | 'paid', string> = {
-  not_submitted: '未提出',
-  submitted: '提出済み',
-  paid: '支払済み',
 }
 
 export default function StoreOfferProgressPanel({
@@ -99,7 +95,7 @@ export default function StoreOfferProgressPanel({
         case 'visit':
           return { ...step, subLabel: `来店予定: ${formattedVisitDate}` }
         case 'invoice':
-          return { ...step, subLabel: `請求状況: ${invoiceStatusText[offer.invoiceStatus]}` }
+          return { ...step, subLabel: `請求状況: ${offer.invoiceStatusLabel}` }
         case 'payment':
           return {
             ...step,
@@ -122,7 +118,7 @@ export default function StoreOfferProgressPanel({
     formattedSubmittedAt,
     formattedRespondDeadline,
     formattedVisitDate,
-    offer.invoiceStatus,
+    offer.invoiceStatusLabel,
     offer.paid,
     paymentCompletedLabel,
     offer.reviewCompleted,

--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -7,6 +7,11 @@ import { cn } from '@/lib/utils'
 import { getOfferProgress } from '@/utils/offerProgress'
 import StoreOfferProgressPanel from './StoreOfferProgressPanel'
 import { deriveActiveStep } from '@/lib/offers/deriveActiveStep'
+import {
+  deriveOfferInvoiceProgressStatus,
+  getInvoiceStatusLabel,
+  getPaymentStatusLabel,
+} from '@/lib/invoices/status'
 
 type PageProps = {
   params: { id: string }
@@ -39,15 +44,17 @@ export default async function StoreOfferPage({ params }: PageProps) {
 
   const { data: invoice } = await supabase
     .from('invoices')
-    .select('id,amount,invoice_url,status')
+    .select('id,amount,invoice_url,status,payment_status')
     .eq('offer_id', params.id)
     .maybeSingle()
 
-  const invoiceStatus: 'not_submitted' | 'submitted' | 'paid' = invoice
-    ? data.paid
-      ? 'paid'
-      : 'submitted'
-    : 'not_submitted'
+  const invoiceStatus = deriveOfferInvoiceProgressStatus({
+    invoiceStatus: invoice?.status,
+    invoicePaymentStatus: invoice?.payment_status,
+    offerPaid: data.paid,
+  })
+  const invoiceStatusLabel = getInvoiceStatusLabel(invoice?.status)
+  const paymentStatusLabel = getPaymentStatusLabel(invoice?.payment_status, data.paid)
 
   const offer = {
     id: data.id as string,
@@ -64,6 +71,8 @@ export default async function StoreOfferPage({ params }: PageProps) {
     paid: data.paid as boolean,
     paidAt: data.paid_at as string | null,
     invoiceStatus,
+    invoiceStatusLabel,
+    paymentStatusLabel,
     reward: data.reward as number | null,
     talentId: data.talent_id as string | null,
     reviewCompleted,
@@ -75,11 +84,12 @@ export default async function StoreOfferPage({ params }: PageProps) {
         invoiceUrl: invoice.invoice_url as string | null,
         amount: invoice.amount as number | null,
         status: invoice.status as string,
+        paymentStatus: (invoice.payment_status as string | null) ?? null,
       }
     : null
 
   const showActions = ['accepted', 'confirmed', 'completed'].includes(data.status as string)
-  const paymentLink = showActions ? `/store/offers/${params.id}/payment` : undefined
+  const paymentLink = showActions && invoice ? `/store/invoices/${invoice.id}` : undefined
 
   const { steps } = getOfferProgress({
     status: offer.status,
@@ -145,6 +155,8 @@ export default async function StoreOfferPage({ params }: PageProps) {
             paid: offer.paid,
             paidAt: offer.paidAt,
             invoiceStatus: offer.invoiceStatus,
+            invoiceStatusLabel: offer.invoiceStatusLabel,
+            paymentStatusLabel: offer.paymentStatusLabel,
             storeName: offer.storeName,
             reward: offer.reward,
             talentId: offer.talentId,

--- a/talentify-next-frontend/app/talent/offers/[id]/StepDetailCard.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/StepDetailCard.tsx
@@ -21,6 +21,8 @@ type StepDetailCardProps = {
     paid: boolean
     paidAt: string | null
     invoiceStatus: 'not_submitted' | 'submitted' | 'paid'
+    invoiceStatusLabel: string
+    paymentStatusLabel: string
   }
   invoiceId: string | null
   paymentLink?: string
@@ -36,12 +38,6 @@ type StepDetail = {
   meta?: { label: string; value: string }[]
   actions?: ReactNode[]
   note?: ReactNode
-}
-
-const invoiceStatusText: Record<'not_submitted' | 'submitted' | 'paid', string> = {
-  not_submitted: '未提出',
-  submitted: '提出済み',
-  paid: '支払済み',
 }
 
 const statusDisplay = (status: string) => {
@@ -227,7 +223,7 @@ export default function StepDetailCard({
         } else {
           actions.push(
             <Button key="view" size="sm" variant="outline" asChild>
-              <Link href="/talent/invoices">請求書を確認</Link>
+              <Link href={`/talent/invoices/${invoiceId}`}>請求書を確認</Link>
             </Button>,
           )
         }
@@ -254,7 +250,7 @@ export default function StepDetailCard({
           badge,
           meta: [
             { label: '請求書', value: invoiceId ? '作成済み' : '未作成' },
-            { label: 'ステータス', value: invoiceStatusText[offer.invoiceStatus] },
+            { label: 'ステータス', value: offer.invoiceStatusLabel },
           ],
           actions,
           note:
@@ -268,7 +264,7 @@ export default function StepDetailCard({
         if (paymentLink) {
           actions.push(
             <Button key="payment" size="sm" asChild>
-              <Link href={paymentLink}>支払い状況を確認</Link>
+              <Link href={paymentLink}>支払いを確認する</Link>
             </Button>,
           )
         }
@@ -294,7 +290,7 @@ export default function StepDetailCard({
             : '請求書の支払いを待っています。状況を確認し、必要であれば店舗に連絡しましょう。',
           badge,
           meta: [
-            { label: '支払い状況', value: offer.paid ? '完了' : '未完了' },
+            { label: '支払い状況', value: offer.paymentStatusLabel },
             ...(paymentCompletedLabel ? [{ label: '支払い日', value: paymentCompletedLabel }] : []),
           ],
           actions,
@@ -322,7 +318,9 @@ export default function StepDetailCard({
     invoiceId,
     offer.id,
     offer.invoiceStatus,
+    offer.invoiceStatusLabel,
     offer.paid,
+    offer.paymentStatusLabel,
     offer.status,
     paymentCompletedLabel,
     paymentLink,
@@ -363,4 +361,3 @@ export default function StepDetailCard({
     </Card>
   )
 }
-

--- a/talentify-next-frontend/app/talent/offers/[id]/TalentOfferProgressPanel.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/TalentOfferProgressPanel.tsx
@@ -20,6 +20,8 @@ type TalentOfferProgressPanelProps = {
     paid: boolean
     paidAt: string | null
     invoiceStatus: 'not_submitted' | 'submitted' | 'paid'
+    invoiceStatusLabel: string
+    paymentStatusLabel: string
   }
   invoiceId: string | null
   paymentLink?: string
@@ -75,7 +77,7 @@ export default function TalentOfferProgressPanel({
         case 'visit':
           return { ...step, subLabel: `来店予定: ${formattedVisitDate}` }
         case 'invoice':
-          return { ...step, subLabel: `請求状況: ${invoiceStatusText[offer.invoiceStatus]}` }
+          return { ...step, subLabel: `請求状況: ${offer.invoiceStatusLabel}` }
         case 'payment':
           return {
             ...step,
@@ -90,7 +92,7 @@ export default function TalentOfferProgressPanel({
           return step
       }
     })
-  }, [formattedSubmittedAt, formattedVisitDate, offer.invoiceStatus, offer.paid, paymentCompletedLabel, steps])
+  }, [formattedSubmittedAt, formattedVisitDate, offer.invoiceStatusLabel, offer.paid, paymentCompletedLabel, steps])
 
   const activeStatus: OfferProgressStatus = useMemo(() => {
     return progressSteps.find(step => step.key === activeStep)?.status ?? 'upcoming'
@@ -123,11 +125,5 @@ export default function TalentOfferProgressPanel({
       </div>
     </div>
   )
-}
-
-const invoiceStatusText: Record<'not_submitted' | 'submitted' | 'paid', string> = {
-  not_submitted: '未提出',
-  submitted: '提出済み',
-  paid: '支払済み',
 }
 

--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -7,6 +7,11 @@ import { getOfferProgress } from '@/utils/offerProgress'
 import { toast } from 'sonner'
 import { toDbOfferStatus } from '@/app/lib/offerStatus'
 import TalentOfferProgressPanel from './TalentOfferProgressPanel'
+import {
+  deriveOfferInvoiceProgressStatus,
+  getInvoiceStatusLabel,
+  getPaymentStatusLabel,
+} from '@/lib/invoices/status'
 
 export default function TalentOfferPage() {
   const params = useParams<{ id: string }>()
@@ -33,14 +38,14 @@ export default function TalentOfferPage() {
     if (data) {
       const { data: invoice } = await supabase
         .from('invoices')
-        .select('id,status')
+        .select('id,status,payment_status')
         .eq('offer_id', params.id)
         .maybeSingle()
-      const invoiceStatus: 'not_submitted' | 'submitted' | 'paid' = invoice
-        ? data.paid
-          ? 'paid'
-          : 'submitted'
-        : 'not_submitted'
+      const invoiceStatus = deriveOfferInvoiceProgressStatus({
+        invoiceStatus: invoice?.status,
+        invoicePaymentStatus: invoice?.payment_status,
+        offerPaid: data.paid,
+      })
       setOffer({
         id: data.id,
         status: data.status,
@@ -54,6 +59,8 @@ export default function TalentOfferPage() {
         paid: data.paid,
         paidAt: data.paid_at,
         invoiceStatus,
+        invoiceStatusLabel: getInvoiceStatusLabel(invoice?.status),
+        paymentStatusLabel: getPaymentStatusLabel(invoice?.payment_status, data.paid),
       })
       setInvoiceId(invoice?.id ?? null)
     } else {
@@ -115,7 +122,7 @@ export default function TalentOfferPage() {
   }
 
   const showActions = ['accepted', 'confirmed', 'completed'].includes(offer.status)
-  const paymentLink = showActions ? `/talent/offers/${offer.id}/payment` : undefined
+  const paymentLink = showActions && invoiceId ? `/talent/invoices/${invoiceId}` : undefined
 
   const { steps, current: currentStep } = getOfferProgress({
     status: offer.status,
@@ -138,6 +145,8 @@ export default function TalentOfferPage() {
             paid: offer.paid,
             paidAt: offer.paidAt,
             invoiceStatus: offer.invoiceStatus,
+            invoiceStatusLabel: offer.invoiceStatusLabel,
+            paymentStatusLabel: offer.paymentStatusLabel,
           }}
           invoiceId={invoiceId}
           paymentLink={paymentLink}

--- a/talentify-next-frontend/lib/invoices/status.ts
+++ b/talentify-next-frontend/lib/invoices/status.ts
@@ -1,5 +1,6 @@
 export type InvoiceStatus = 'draft' | 'submitted' | 'approved' | 'rejected' | string | null | undefined
 export type PaymentStatus = 'paid' | 'unpaid' | string | null | undefined
+export type OfferInvoiceProgressStatus = 'not_submitted' | 'submitted' | 'paid'
 
 export function getInvoiceStatusLabel(status: InvoiceStatus): string {
   switch (status) {
@@ -22,4 +23,20 @@ export function isPaymentCompleted(paymentStatus: PaymentStatus, offerPaid?: boo
 
 export function getPaymentStatusLabel(paymentStatus: PaymentStatus, offerPaid?: boolean | null): string {
   return isPaymentCompleted(paymentStatus, offerPaid) ? '支払済み' : '未払い'
+}
+
+export function deriveOfferInvoiceProgressStatus(params: {
+  invoiceStatus?: InvoiceStatus
+  invoicePaymentStatus?: PaymentStatus
+  offerPaid?: boolean | null
+  paymentStatus?: string | null
+}): OfferInvoiceProgressStatus {
+  const { invoiceStatus, invoicePaymentStatus, offerPaid, paymentStatus } = params
+  const paymentCompleted = paymentStatus === 'completed' || isPaymentCompleted(invoicePaymentStatus, offerPaid)
+
+  if (paymentCompleted) return 'paid'
+  if (invoiceStatus === 'submitted' || invoiceStatus === 'approved' || invoiceStatus === 'rejected') {
+    return 'submitted'
+  }
+  return 'not_submitted'
 }

--- a/talentify-next-frontend/utils/getOffersForStore.ts
+++ b/talentify-next-frontend/utils/getOffersForStore.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { getCurrentUserWithClient } from '@/lib/auth/getCurrentUserWithClient'
+import { deriveOfferInvoiceProgressStatus } from '@/lib/invoices/status'
 import { createClient } from '@/utils/supabase/client'
 
 const supabase = createClient()
@@ -81,11 +82,11 @@ export async function getOffersForStore() {
     const payment = Array.isArray(o.payments) ? o.payments[0] : o.payments
     const paymentStatus = payment?.status ?? null
     const invoice = invoiceMap.get(o.id)
-    const invoiceStatus: 'not_submitted' | 'submitted' | 'paid' = invoice
-      ? paymentStatus === 'completed' || invoice.payment_status === 'paid'
-        ? 'paid'
-        : 'submitted'
-      : 'not_submitted'
+    const invoiceStatus = deriveOfferInvoiceProgressStatus({
+      invoiceStatus: invoice?.status,
+      invoicePaymentStatus: invoice?.payment_status,
+      paymentStatus,
+    })
 
     const reviews = Array.isArray(o.reviews) ? o.reviews : []
 

--- a/talentify-next-frontend/utils/getOffersForTalent.ts
+++ b/talentify-next-frontend/utils/getOffersForTalent.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { z } from 'zod'
+import { deriveOfferInvoiceProgressStatus } from '@/lib/invoices/status'
 import { createClient } from '@/utils/supabase/client'
 import { getTalentId } from './getTalentId'
 
@@ -85,11 +86,11 @@ export async function getOffersForTalent() {
   return parsed.data.map(o => {
     const paymentStatus = o.payments?.[0]?.status ?? null
     const invoice = invoiceMap.get(o.id)
-    const invoiceStatus: 'not_submitted' | 'submitted' | 'paid' = invoice
-      ? paymentStatus === 'completed' || invoice.payment_status === 'paid'
-        ? 'paid'
-        : 'submitted'
-      : 'not_submitted'
+    const invoiceStatus = deriveOfferInvoiceProgressStatus({
+      invoiceStatus: invoice?.status,
+      invoicePaymentStatus: invoice?.payment_status,
+      paymentStatus,
+    })
 
     const storeName = o.store?.store_name ?? null
 


### PR DESCRIPTION
### Motivation
- Offer detail pages used ad-hoc invoice/payment heuristics that diverged from invoice detail pages which use `invoice.status`, causing mismatched labels between offer and invoice views.
- Payment action links pointed to non-existent routes (`/store/offers/[id]/payment` and `/talent/offers/[id]/payment`), producing 404s and breaking the payment flow.
- The intent is to make `invoice.status` the single source of truth for invoice labels and route payment actions to existing invoice detail pages to avoid 404s.

### Description
- Added `deriveOfferInvoiceProgressStatus` and `OfferInvoiceProgressStatus` to `lib/invoices/status.ts` and continued using `getInvoiceStatusLabel`/`getPaymentStatusLabel` as the canonical label helpers. 
- Updated store and talent offer pages (`app/store/offers/[id]/page.tsx`, `app/talent/offers/[id]/page.tsx`) to derive `invoiceStatus`, `invoiceStatusLabel`, and `paymentStatusLabel` from the invoice record and to point `paymentLink` to the existing invoice detail (`/store/invoices/{id}` or `/talent/invoices/{id}`) when appropriate.
- Replaced ad-hoc text and ad-hoc status logic in progress panels and step detail cards (`StoreOfferProgressPanel.tsx`, `StepDetailCard.tsx`, `TalentOfferProgressPanel.tsx`) to show labels from the shared helpers and to use invoice-id-based navigation for "請求書を見る" / 支払い導線.
- Unified offer-list utilities (`utils/getOffersForStore.ts`, `utils/getOffersForTalent.ts`) to use the new progress derivation and added tests in `__tests__/invoices-status.test.ts` to prevent regressions; modified files include the ones above and `lib/invoices/status.ts`.

### Testing
- Ran the new unit test suite `npm test -- --runInBand __tests__/invoices-status.test.ts` and it passed. 
- Ran the existing `npm test -- --runInBand __tests__/invoiceStatus.test.ts` and it passed. 
- Ran `npm run -s lint` and it completed with unrelated `<img>` warnings but no new errors from these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc469f29f0833298d9a252faafc541)