### PR TITLE
Redirect store payment completion to offer detail page

### DIFF
--- a/talentify-next-frontend/app/store/invoices/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/invoices/[id]/page.tsx
@@ -100,7 +100,7 @@ export default function StoreInvoiceDetail() {
       toast.success('支払いを記録しました')
       router.refresh()
       if (invoice?.offer_id) {
-        router.push(`/store/reviews/new?offerId=${invoice.offer_id}`)
+        router.push(`/store/offers/${invoice.offer_id}`)
       }
     } else {
       toast.error('支払いの記録に失敗しました')

--- a/talentify-next-frontend/components/offer/OfferPaymentStatusCard.tsx
+++ b/talentify-next-frontend/components/offer/OfferPaymentStatusCard.tsx
@@ -56,7 +56,7 @@ export default function OfferPaymentStatusCard({
       toast.success('支払いを記録しました')
       router.refresh()
       if (offerId) {
-        router.push(`/store/reviews/new?offerId=${offerId}`)
+        router.push(`/store/offers/${offerId}`)
       }
     } else {
       toast.error('支払いの記録に失敗しました')


### PR DESCRIPTION
### Motivation
- 支払い完了操作後に `/store/reviews/new?offerId=...` へ遷移して 404 になる不具合を解消するための変更です。 
- 原因は遷移先だけ旧仕様のレビュー専用ページを想定したまま残っていたことです。 
- 現在のレビューUXはオファー詳細ページ内のモーダルなので、遷移先をオファー詳細へ揃えてUXと整合させます。

### Description
- `talentify-next-frontend/app/store/invoices/[id]/page.tsx` の支払い完了後の遷移を `router.push('/store/reviews/new?offerId=...')` から `router.push('/store/offers/{offerId}')` に変更しました. 
- `talentify-next-frontend/components/offer/OfferPaymentStatusCard.tsx` の同様の遷移も `router.push('/store/offers/{offerId}')` に変更して共通挙動を統一しました. 
- `reviews/new` ページは新規実装せず、既存の「オファー詳細内モーダル」UXを正とする方針を維持しています. 
- 将来的に `?openReview=1` のようなクエリでモーダルを開く拡張を入れやすい箇所のみを修正しています（今回は未実装）。

### Testing
- 自動静的解析として `npx eslint components/offer/OfferPaymentStatusCard.tsx app/store/invoices/[id]/page.tsx` を実行して問題がないことを確認しました（成功）。
- フロントエンド全体で旧導線が残っていないか `rg -n "/store/reviews/new"` で検索し、該当参照が解消されたことを確認しました（該当なし）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc7fb950f08332b001392c0a42b7fe)