### PR TITLE
talent側：店舗レビュー存在時にレビュー完了扱い＆確認ボタン表示を追加

### DIFF
--- a/talentify-next-frontend/app/talent/offers/[id]/StepDetailCard.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/StepDetailCard.tsx
@@ -23,6 +23,7 @@ type StepDetailCardProps = {
     invoiceStatus: 'not_submitted' | 'submitted' | 'paid'
     invoiceStatusLabel: string
     paymentStatusLabel: string
+    reviewCompleted: boolean
   }
   invoiceId: string | null
   paymentLink?: string
@@ -298,15 +299,29 @@ export default function StepDetailCard({
       }
       case 'review':
       default:
+        const reviewActions: ReactNode[] = []
+        if (offer.reviewCompleted) {
+          reviewActions.push(
+            <Button key="review" size="sm" asChild>
+              <Link href="/talent/reviews">レビューを確認する</Link>
+            </Button>,
+          )
+        }
+        reviewActions.push(
+          <Button key="message" variant="outline" size="sm" asChild>
+            <a href="#offer-messages">メッセージを送る</a>
+          </Button>,
+        )
         return {
           title: 'レビュー',
-          description: '支払いが完了すると店舗からのレビューを確認できます。フィードバックを次回に活かしましょう。',
-          badge: activeStatus === 'complete' ? <Badge variant="success">完了</Badge> : undefined,
-          actions: [
-            <Button key="message" variant="outline" size="sm" asChild>
-              <a href="#offer-messages">メッセージを送る</a>
-            </Button>,
-          ],
+          description: offer.reviewCompleted
+            ? '店舗レビューが投稿されています。内容を確認して次回の案件に活かしましょう。'
+            : 'まだ店舗レビューは投稿されていません。レビュー投稿後に確認できます。',
+          badge: offer.reviewCompleted
+            ? <Badge variant="success">レビュー済み</Badge>
+            : <Badge variant="outline">レビュー未実施</Badge>,
+          meta: [{ label: 'レビュー状態', value: offer.reviewCompleted ? 'レビュー済み' : 'レビュー未実施' }],
+          actions: reviewActions,
         }
     }
   }, [
@@ -321,6 +336,7 @@ export default function StepDetailCard({
     offer.invoiceStatusLabel,
     offer.paid,
     offer.paymentStatusLabel,
+    offer.reviewCompleted,
     offer.status,
     paymentCompletedLabel,
     paymentLink,

--- a/talentify-next-frontend/app/talent/offers/[id]/TalentOfferProgressPanel.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/TalentOfferProgressPanel.tsx
@@ -22,6 +22,7 @@ type TalentOfferProgressPanelProps = {
     invoiceStatus: 'not_submitted' | 'submitted' | 'paid'
     invoiceStatusLabel: string
     paymentStatusLabel: string
+    reviewCompleted: boolean
   }
   invoiceId: string | null
   paymentLink?: string
@@ -87,12 +88,20 @@ export default function TalentOfferProgressPanel({
                 : `支払い状況: ${offer.paid ? '完了' : '未完了'}`,
           }
         case 'review':
-          return { ...step, subLabel: `レビュー: ${step.status === 'complete' ? '完了' : '未実施'}` }
+          return { ...step, subLabel: `レビュー: ${offer.reviewCompleted ? 'レビュー済み' : 'レビュー未実施'}` }
         default:
           return step
       }
     })
-  }, [formattedSubmittedAt, formattedVisitDate, offer.invoiceStatusLabel, offer.paid, paymentCompletedLabel, steps])
+  }, [
+    formattedSubmittedAt,
+    formattedVisitDate,
+    offer.invoiceStatusLabel,
+    offer.paid,
+    offer.reviewCompleted,
+    paymentCompletedLabel,
+    steps,
+  ])
 
   const activeStatus: OfferProgressStatus = useMemo(() => {
     return progressSteps.find(step => step.key === activeStep)?.status ?? 'upcoming'
@@ -126,4 +135,3 @@ export default function TalentOfferProgressPanel({
     </div>
   )
 }
-

--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -28,6 +28,7 @@ export default function TalentOfferPage() {
       .select(
         `
         id,status,date,updated_at,created_at,message,talent_id,user_id,paid,paid_at,
+        reviews(id),
         talents(stage_name,avatar_url),
         store:stores!offers_store_id_fkey(id, store_name)
       `
@@ -58,6 +59,7 @@ export default function TalentOfferPage() {
         submittedAt: data.created_at,
         paid: data.paid,
         paidAt: data.paid_at,
+        reviewCompleted: Array.isArray(data.reviews) && data.reviews.length > 0,
         invoiceStatus,
         invoiceStatusLabel: getInvoiceStatusLabel(invoice?.status),
         paymentStatusLabel: getPaymentStatusLabel(invoice?.payment_status, data.paid),
@@ -128,6 +130,7 @@ export default function TalentOfferPage() {
     status: offer.status,
     invoiceStatus: offer.invoiceStatus,
     paid: offer.paid,
+    reviewCompleted: offer.reviewCompleted,
   })
 
   return (
@@ -147,6 +150,7 @@ export default function TalentOfferPage() {
             invoiceStatus: offer.invoiceStatus,
             invoiceStatusLabel: offer.invoiceStatusLabel,
             paymentStatusLabel: offer.paymentStatusLabel,
+            reviewCompleted: offer.reviewCompleted,
           }}
           invoiceId={invoiceId}
           paymentLink={paymentLink}

--- a/talentify-next-frontend/app/talent/offers/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/page.tsx
@@ -77,6 +77,7 @@ export default function TalentOffersPage() {
         status: offer.status ?? 'pending',
         invoiceStatus: offer.invoice_status,
         paid: Boolean(offer.paid),
+        reviewCompleted: offer.review_completed,
       })
 
       const isCanceled = CANCEL_STATUSES.has(offer.status ?? '')

--- a/talentify-next-frontend/utils/getOffersForTalent.ts
+++ b/talentify-next-frontend/utils/getOffersForTalent.ts
@@ -16,6 +16,7 @@ export type TalentOffer = {
   status: string | null
   paid?: boolean | null
   invoice_status: 'not_submitted' | 'submitted' | 'paid'
+  review_completed: boolean
 }
 
 const offerRowSchema = z.object({
@@ -29,6 +30,7 @@ const offerRowSchema = z.object({
       z.object({ status: z.string().nullable(), paid_at: z.string().nullable() })
     )
     .nullable(),
+  reviews: z.array(z.object({ id: z.string() })).nullable(),
   store: z
     .object({
       id: z.string(),
@@ -46,7 +48,7 @@ export async function getOffersForTalent() {
     .from('offers')
     .select(
       `
-      id, store_id, created_at, date, status, payments(status,paid_at),
+      id, store_id, created_at, date, status, payments(status,paid_at), reviews(id),
       store:stores!offers_store_id_fkey(id, store_name, is_setup_complete)
     `
     )
@@ -85,6 +87,7 @@ export async function getOffersForTalent() {
 
   return parsed.data.map(o => {
     const paymentStatus = o.payments?.[0]?.status ?? null
+    const reviews = Array.isArray(o.reviews) ? o.reviews : []
     const invoice = invoiceMap.get(o.id)
     const invoiceStatus = deriveOfferInvoiceProgressStatus({
       invoiceStatus: invoice?.status,
@@ -103,6 +106,7 @@ export async function getOffersForTalent() {
       status: o.status,
       paid: paymentStatus === 'completed',
       invoice_status: invoiceStatus,
+      review_completed: reviews.length > 0,
     }
   }) as TalentOffer[]
 }

--- a/talentify-next-frontend/utils/offerProgress.ts
+++ b/talentify-next-frontend/utils/offerProgress.ts
@@ -51,7 +51,14 @@ function resolveProgressBadge({
     }
   }
 
-  if (paid || invoiceStatus === 'paid' || reviewCompleted) {
+  if (reviewCompleted) {
+    return {
+      label: 'レビュー済み',
+      variant: 'success',
+    }
+  }
+
+  if (paid || invoiceStatus === 'paid') {
     return {
       label: '支払い済み',
       variant: 'success',


### PR DESCRIPTION
### Motivation
- talent側で店舗が投稿したレビューが存在しているにも関わらず進捗が「レビュー: 未実施」と表示され、案件が`進行中`のまま`履歴`へ移らない不整合を解消するため。 
- フロー完了条件を「店舗側レビューが存在すること」に統一し、talentがレビューを閲覧したかどうかを完了判定に含めない要件に合わせるため。 
- talentの詳細画面でレビューを確認するための導線（`レビューを確認する`ボタン）を追加して、UXを改善するため。 

### Description
- `utils/getOffersForTalent.ts`: `select`で`reviews(id)`を取得し、`review_completed`を計算して戻り値の型に追加することでレビュー存在をデータ源にした。 (`review_completed` を返すように変更)。
- `app/talent/offers/page.tsx`: オファー一覧側の進捗計算で `reviewCompleted: offer.review_completed` を `getOfferProgress` に渡すよう修正し、レビュー済みの案件が `履歴` に入るようにした。 
- `app/talent/offers/[id]/page.tsx` と `app/talent/offers/[id]/TalentOfferProgressPanel.tsx`: オファー詳細の進捗表示で `reviewCompleted` を受け渡し、進捗サブラベルを `レビュー: レビュー済み / レビュー未実施` に統一した。 
- `app/talent/offers/[id]/StepDetailCard.tsx`: レビューステップの文言・バッジを存在ベースで切替え、レビューがある場合は `レビュー済み` 表示と `レビューを確認する` ボタン（遷移先は `/talent/reviews`）を追加した。 
- `utils/offerProgress.ts`: プログレスバッジ判定を調整し、`reviewCompleted` が優先で `レビュー済み` 表示になるよう修正した（`レビュー未実施` はレビューがない場合のみ）。 
- 実装は既存のDBカラム・既存導線を再利用しており、ルート/API契約の大幅変更は行っていない。 

### Testing
- 実行コマンド `npm run lint` を実行し成功を確認（既存の `no-img-element` 警告のみ）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc834c1514833292c9edb6d3fa33b6)