### PR TITLE
請求導線を来店完了に依存しないメインアクション判定へ調整

### DIFF
--- a/talentify-next-frontend/__tests__/mainActionPhase.test.ts
+++ b/talentify-next-frontend/__tests__/mainActionPhase.test.ts
@@ -1,0 +1,39 @@
+import { resolveMainActionPhase } from '@/lib/offers/mainActionPhase'
+
+describe('resolveMainActionPhase', () => {
+  it('returns invoice_waiting before visit completion once offer is accepted and invoice is not submitted', () => {
+    const phase = resolveMainActionPhase({
+      role: 'talent',
+      status: 'accepted',
+      invoiceStatus: 'not_submitted',
+      paid: false,
+      reviewCompleted: false,
+    })
+
+    expect(phase).toBe('invoice_waiting')
+  })
+
+  it('prioritizes submitted invoice phase over visit completion', () => {
+    const phase = resolveMainActionPhase({
+      role: 'store',
+      status: 'accepted',
+      invoiceStatus: 'submitted',
+      paid: false,
+      reviewCompleted: false,
+    })
+
+    expect(phase).toBe('invoice_submitted')
+  })
+
+  it('treats pending offers without invoice as before_invoice', () => {
+    const phase = resolveMainActionPhase({
+      role: 'store',
+      status: 'pending',
+      invoiceStatus: 'not_submitted',
+      paid: false,
+      reviewCompleted: false,
+    })
+
+    expect(phase).toBe('before_invoice')
+  })
+})

--- a/talentify-next-frontend/app/store/offers/[id]/StepDetailCard.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/StepDetailCard.tsx
@@ -99,7 +99,7 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
       case 'invoice_waiting':
         return {
           title: '請求をお待ちしています',
-          description: '出演は完了しています。次はタレントの請求書提出を待ち、必要ならメッセージでフォローしてください。',
+          description: '請求書がまだ作成されていません。必要に応じてメッセージで作成・提出を案内してください。',
           badge: <Badge variant="outline">請求待ち</Badge>,
           meta: [{ label: '請求書ステータス', value: offer.invoiceStatusLabel }],
           primaryAction: undefined,
@@ -160,8 +160,8 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
         }
       default:
         return {
-          title: '来店完了後に請求フローへ進みます',
-          description: '現在は請求・支払い・レビュー前のステップです。進行ステップバーで状況を確認してください。',
+          title: '請求書の準備がこれからです',
+          description: 'まだ請求書が作成されていない状態です。進行ステップバーで状況を確認してください。',
           badge: <Badge variant="outline">準備中</Badge>,
           meta: [{ label: '現在ステップ', value: activeStep }],
           secondaryAction: <Button variant="outline" asChild><a href="#offer-messages">メッセージを送る</a></Button>,

--- a/talentify-next-frontend/app/talent/offers/[id]/StepDetailCard.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/StepDetailCard.tsx
@@ -88,7 +88,7 @@ export default function StepDetailCard({
       case 'invoice_waiting':
         return {
           title: '請求をお待ちしています',
-          description: '出演が完了しました。次は請求書の提出を進めてください。',
+          description: '請求書がまだ作成されていません。請求書の作成・提出を進めてください。',
           badge: <Badge variant="outline">請求待ち</Badge>,
           meta: [{ label: '請求書ステータス', value: offer.invoiceStatusLabel }],
           primaryAction: <Button asChild><Link href={`/talent/invoices/new?offerId=${offer.id}`}>請求書を作成する</Link></Button>,
@@ -131,8 +131,8 @@ export default function StepDetailCard({
         }
       default:
         return {
-          title: '来店完了後に請求フローへ進みます',
-          description: '現在は請求・支払い・レビュー前のステップです。進行ステップバーで状況を確認してください。',
+          title: '請求書の準備がこれからです',
+          description: 'まだ請求書が作成されていない状態です。進行ステップバーで状況を確認してください。',
           badge: <Badge variant="outline">準備中</Badge>,
           secondaryAction: <Button variant="outline" asChild><a href="#offer-messages">メッセージを送る</a></Button>,
         }

--- a/talentify-next-frontend/lib/offers/mainActionPhase.ts
+++ b/talentify-next-frontend/lib/offers/mainActionPhase.ts
@@ -25,7 +25,8 @@ export function resolveMainActionPhase({
   reviewCompleted,
 }: MainActionPhaseParams): MainActionPhase {
   const paymentDone = paid || invoiceStatus === 'paid'
-  const visitCompleted = status === 'completed'
+  const invoiceCreated = invoiceStatus !== 'not_submitted'
+  const canStartInvoiceFlow = ['accepted', 'confirmed', 'completed'].includes(status)
 
   if (paymentDone && reviewCompleted) {
     return 'completed'
@@ -42,7 +43,7 @@ export function resolveMainActionPhase({
     return role === 'store' ? 'invoice_submitted' : 'payment_waiting'
   }
 
-  if (visitCompleted && invoiceStatus === 'not_submitted') {
+  if (!invoiceCreated && canStartInvoiceFlow) {
     return 'invoice_waiting'
   }
 


### PR DESCRIPTION
### Motivation
- 来店完了（`status === 'completed'`）がないと請求フェーズに進めない挙動を緩和し、来店前に請求書を作成・提出したいケースに対応するため。
- 請求書の存在・`invoiceStatus` を優先してメインアクションフェーズを決め、来店完了は参考進捗扱いにするため。
- `before_invoice` を「来店未完了で進めない」から「請求書未作成かつ請求導線未開始」の状態として再定義するため。

### Description
- `talentify-next-frontend/lib/offers/mainActionPhase.ts` の判定順を見直し、`invoiceCreated` と `canStartInvoiceFlow` を導入して `invoiceStatus === 'submitted'` を来店完了判定より前に評価するようにしました。 
- 上記により `accepted` / `confirmed` / `completed` の状態で `invoiceStatus === 'not_submitted'` の場合は `invoice_waiting` を返すようにし、来店完了を必須条件から外しました。 
- 表示文言を調整して誤解を避けるために `app/store/offers/[id]/StepDetailCard.tsx` と `app/talent/offers/[id]/StepDetailCard.tsx` の `invoice_waiting` / `before_invoice` 周りのテキストを「請求書未作成」に寄せる形で更新し、来店前でも請求作成 CTA が自然に表示されるようにしました。 
- 判定ロジックの回帰を防ぐために `talentify-next-frontend/__tests__/mainActionPhase.test.ts` を追加し、主要ケースを検証するユニットテストを用意しました。 

### Testing
- 追加した単体テストを `npm test -- --runTestsByPath __tests__/mainActionPhase.test.ts` で実行し、3件のテストが全て `PASS` しました。 
- 変更は主にフロントエンドの表示ロジックと文言の更新であり、既存の API / ルーティング / グローバル CSS には影響を与えていません（自動テストは上記の単体テストのみ実行）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc8fa2c8a08332b3b2844dfdc1b0c6)