### PR TITLE
Compact and reorganize offer detail UI for store/talent pages

### DIFF
--- a/talentify-next-frontend/app/store/offers/[id]/MessageCard.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/MessageCard.tsx
@@ -11,14 +11,14 @@ type MessageCardProps = {
 
 export default function MessageCard({ offerId, currentUserId, storeName, talentName }: MessageCardProps) {
   return (
-    <div id="offer-messages">
+    <div id="offer-messages" className="h-full">
       <OfferChatThread
         offerId={offerId}
         currentUserId={currentUserId}
         currentRole="store"
         storeName={storeName}
         talentName={talentName}
-        className="lg:max-h-[540px]"
+        className="lg:max-h-[calc(100vh-3rem)]"
       />
     </div>
   )

--- a/talentify-next-frontend/app/store/offers/[id]/ProgressCard.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/ProgressCard.tsx
@@ -12,12 +12,12 @@ type ProgressCardProps = {
 
 export default function ProgressCard({ steps, activeStep, onStepChange }: ProgressCardProps) {
   return (
-    <Card className="rounded-2xl border border-slate-200 shadow-sm">
-      <CardHeader className="space-y-1">
-        <CardTitle className="text-lg font-semibold text-slate-900">進捗状況</CardTitle>
-        <p className="text-sm text-muted-foreground">オファーの進行状況と各ステップの対応内容を確認できます。</p>
+    <Card className="rounded-xl border border-slate-200 bg-white shadow-sm">
+      <CardHeader className="space-y-1 px-4 pt-4 sm:px-5 sm:pt-5">
+        <CardTitle className="text-base font-semibold text-slate-900 sm:text-lg">進捗状況</CardTitle>
+        <p className="text-xs leading-relaxed text-muted-foreground sm:text-sm">オファーの進行状況と各ステップの対応内容を確認できます。</p>
       </CardHeader>
-      <CardContent className="pt-2">
+      <CardContent className="px-4 pb-4 pt-1 sm:px-5 sm:pb-5">
         <OfferProgressTracker steps={steps} selectedStep={activeStep} onStepSelect={onStepChange} />
       </CardContent>
     </Card>

--- a/talentify-next-frontend/app/store/offers/[id]/StepDetailCard.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/StepDetailCard.tsx
@@ -57,6 +57,9 @@ type StepDetail = {
   footer?: ReactNode
 }
 
+const primaryActionClass = 'h-9 bg-blue-700 px-4 text-white hover:bg-blue-800 focus-visible:ring-blue-300'
+const secondaryActionClass = 'h-9 border-slate-300 bg-white px-4 text-slate-700 hover:bg-slate-100'
+
 const statusBadge = (status: string) => {
   switch (status) {
     case 'confirmed':
@@ -103,7 +106,7 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
           badge: <Badge variant="outline">請求待ち</Badge>,
           meta: [{ label: '請求書ステータス', value: offer.invoiceStatusLabel }],
           primaryAction: undefined,
-          secondaryAction: <Button variant="outline" asChild><a href="#offer-messages">メッセージを送る</a></Button>,
+          secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
         }
       case 'invoice_submitted':
         return {
@@ -115,8 +118,8 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
             ...(invoice?.amount != null ? [{ label: '請求額', value: `¥${invoice.amount.toLocaleString('ja-JP')}` }] : []),
             { label: '支払い状況', value: offer.paymentStatusLabel },
           ],
-          primaryAction: invoice ? <Button asChild><Link href={`/store/invoices/${invoice.id}`}>請求書を見る</Link></Button> : undefined,
-          secondaryAction: <Button variant="outline" asChild><a href="#offer-messages">メッセージを送る</a></Button>,
+          primaryAction: invoice ? <Button className={primaryActionClass} asChild><Link href={`/store/invoices/${invoice.id}`}>請求書を見る</Link></Button> : undefined,
+          secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
         }
       case 'payment_waiting':
         return {
@@ -127,8 +130,8 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
             { label: '支払い状況', value: offer.paymentStatusLabel },
             ...(invoice?.amount != null ? [{ label: '支払い予定額', value: `¥${invoice.amount.toLocaleString('ja-JP')}` }] : []),
           ],
-          primaryAction: paymentLink ? <Button asChild><Link href={paymentLink}>支払いを確認する</Link></Button> : invoice ? <Button asChild><Link href={`/store/invoices/${invoice.id}`}>請求書を見る</Link></Button> : undefined,
-          secondaryAction: <Button variant="outline" asChild><a href="#offer-messages">メッセージを送る</a></Button>,
+          primaryAction: paymentLink ? <Button className={primaryActionClass} asChild><Link href={paymentLink}>支払いを確認する</Link></Button> : invoice ? <Button className={primaryActionClass} asChild><Link href={`/store/invoices/${invoice.id}`}>請求書を見る</Link></Button> : undefined,
+          secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
         }
       case 'payment_completed_review_waiting':
         return {
@@ -143,11 +146,11 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
             <ReviewModal
               offerId={offer.id}
               talentId={offer.talentId}
-              trigger={<Button>レビューする</Button>}
+              trigger={<Button className={primaryActionClass}>レビューする</Button>}
               onSubmitted={handleReviewSubmitted}
             />
           ) : undefined,
-          secondaryAction: <Button variant="outline" asChild><a href="#offer-messages">メッセージを送る</a></Button>,
+          secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
         }
       case 'completed':
         return {
@@ -155,8 +158,8 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
           description: 'この案件はすべてのステップが完了しています。',
           badge: <Badge variant="success">全完了</Badge>,
           meta: [{ label: 'レビュー状態', value: offer.reviewCompleted ? 'レビュー済み' : '未実施' }],
-          primaryAction: <Button asChild><Link href="/store/reviews">レビューを見る</Link></Button>,
-          secondaryAction: <Button variant="outline" asChild><a href="#offer-messages">メッセージを送る</a></Button>,
+          primaryAction: <Button className={primaryActionClass} asChild><Link href="/store/reviews">レビューを見る</Link></Button>,
+          secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
         }
       default:
         return {
@@ -164,7 +167,7 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
           description: 'まだ請求書が作成されていない状態です。進行ステップバーで状況を確認してください。',
           badge: <Badge variant="outline">準備中</Badge>,
           meta: [{ label: '現在ステップ', value: activeStep }],
-          secondaryAction: <Button variant="outline" asChild><a href="#offer-messages">メッセージを送る</a></Button>,
+          secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
         }
     }
   }, [activeStep, offer.status, offer.invoiceStatus, offer.paid, offer.reviewCompleted, offer.invoiceStatusLabel, offer.paymentStatusLabel, offer.id, offer.talentId, invoice, paymentLink, paymentCompletedLabel, handleReviewSubmitted])
@@ -189,7 +192,7 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
     let result: StepDetail = {
       title: '進行中',
       description: '進行ステップを確認してください。',
-      secondaryAction: <Button variant="outline" asChild><a href="#offer-messages">メッセージを送る</a></Button>,
+      secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
     }
 
     if (activeStep === 'offer_submitted') {
@@ -202,7 +205,7 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
           { label: 'オファー金額', value: offer.reward != null ? `¥${offer.reward.toLocaleString('ja-JP')}` : '未設定' },
           { label: '提出者', value: offer.storeName || '未設定' },
         ],
-        secondaryAction: <Button variant="outline" asChild><a href="#offer-messages">メッセージを送る</a></Button>,
+        secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
       }
     }
 
@@ -215,7 +218,7 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
           { label: '承認期限', value: formattedRespondDeadline },
           { label: '最終更新', value: formattedUpdatedAt },
         ],
-        secondaryAction: <Button variant="outline" asChild><a href="#offer-messages">メッセージを送る</a></Button>,
+        secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
       }
     }
 
@@ -228,7 +231,7 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
           { label: '来店日時', value: formattedVisitDate },
           { label: '最終更新', value: formattedUpdatedAt },
         ],
-        secondaryAction: <Button variant="outline" asChild><a href="#offer-messages">メッセージを送る</a></Button>,
+        secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
       }
     }
 
@@ -247,26 +250,26 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
   }, [activeStep, activeStatus, cancelation, formattedRespondDeadline, formattedSubmittedAt, formattedUpdatedAt, formattedVisitDate, mainActionDetail, offer.id, offer.reward, offer.status, offer.storeName])
 
   return (
-    <Card className="rounded-2xl border border-slate-200 bg-white shadow-sm">
-      <CardHeader className="flex flex-col gap-2 border-b border-slate-100 p-6">
+    <Card className="rounded-xl border border-slate-200 bg-white shadow-sm">
+      <CardHeader className="flex flex-col gap-1.5 border-b border-slate-100 p-4 sm:p-5">
         <div className="flex flex-wrap items-center gap-3">
-          <CardTitle className="text-lg font-semibold text-slate-900">{detail.title}</CardTitle>
+          <CardTitle className="text-base font-semibold text-slate-900 sm:text-lg">{detail.title}</CardTitle>
           {detail.badge}
         </div>
-        <p className="text-sm text-muted-foreground">{detail.description}</p>
+        <p className="text-sm leading-relaxed text-muted-foreground">{detail.description}</p>
       </CardHeader>
-      <CardContent className="space-y-6 p-6">
+      <CardContent className="space-y-4 p-4 sm:p-5">
         {detail.meta && detail.meta.length > 0 && (
-          <dl className="grid gap-4 rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm sm:grid-cols-2">
+          <dl className="grid gap-3 rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm sm:grid-cols-2">
             {detail.meta.map(item => (
-              <div key={item.label} className="space-y-1">
+              <div key={item.label} className="space-y-0.5">
                 <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{item.label}</dt>
-                <dd className="text-base font-semibold text-slate-900">{item.value}</dd>
+                <dd className="text-sm font-semibold text-slate-900 sm:text-base">{item.value}</dd>
               </div>
             ))}
           </dl>
         )}
-        <div className="flex flex-wrap justify-end gap-3">
+        <div className="flex flex-wrap justify-end gap-2.5">
           {detail.secondaryAction && <div className="inline-flex">{detail.secondaryAction}</div>}
           {detail.primaryAction && <div className="inline-flex">{detail.primaryAction}</div>}
         </div>

--- a/talentify-next-frontend/app/store/offers/[id]/StoreOfferProgressPanel.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/StoreOfferProgressPanel.tsx
@@ -6,7 +6,6 @@ import { format } from 'date-fns'
 import { ja } from 'date-fns/locale'
 import ProgressCard from './ProgressCard'
 import StepDetailCard from './StepDetailCard'
-import MessageCard from './MessageCard'
 
 interface StoreOfferProgressPanelProps {
   steps: OfferProgressStep[]
@@ -40,12 +39,6 @@ interface StoreOfferProgressPanelProps {
     initialStatus: string
     initialCanceledAt: string | null
   }
-  message: {
-    offerId: string
-    currentUserId: string
-    storeName: string
-    talentName: string
-  }
 }
 
 export default function StoreOfferProgressPanel({
@@ -55,7 +48,6 @@ export default function StoreOfferProgressPanel({
   invoice,
   paymentLink,
   cancelation,
-  message,
 }: StoreOfferProgressPanelProps) {
   const [activeStep, setActiveStep] = useState<OfferStepKey>(initialActiveStep)
 
@@ -130,28 +122,16 @@ export default function StoreOfferProgressPanel({
   }, [progressSteps, activeStep])
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <ProgressCard steps={progressSteps} activeStep={activeStep} onStepChange={setActiveStep} />
-      <div className="grid gap-6 lg:grid-cols-3">
-        <div className="lg:col-span-2">
-          <StepDetailCard
-            activeStep={activeStep}
-            activeStatus={activeStatus}
-            offer={offer}
-            invoice={invoice}
-            paymentLink={paymentLink}
-            cancelation={cancelation}
-          />
-        </div>
-        <div className="lg:col-span-1">
-          <MessageCard
-            offerId={message.offerId}
-            currentUserId={message.currentUserId}
-            storeName={message.storeName}
-            talentName={message.talentName}
-          />
-        </div>
-      </div>
+      <StepDetailCard
+        activeStep={activeStep}
+        activeStatus={activeStatus}
+        offer={offer}
+        invoice={invoice}
+        paymentLink={paymentLink}
+        cancelation={cancelation}
+      />
     </div>
   )
 }

--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -12,6 +12,7 @@ import {
   getInvoiceStatusLabel,
   getPaymentStatusLabel,
 } from '@/lib/invoices/status'
+import MessageCard from './MessageCard'
 
 type PageProps = {
   params: { id: string }
@@ -116,15 +117,16 @@ export default async function StoreOfferPage({ params }: PageProps) {
   const statusClassName = getStatusBadgeClassName(offer.status)
 
   return (
-    <div className="bg-slate-50 p-4 sm:p-6 lg:p-8">
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 lg:gap-8">
-        <section className="rounded-2xl bg-white p-6 shadow-sm">
+    <div className="bg-slate-50 p-3 sm:p-5 lg:p-6">
+      <div className="mx-auto grid w-full max-w-6xl gap-4 lg:grid-cols-3 lg:items-start">
+        <div className="space-y-4 lg:col-span-2">
+          <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm sm:p-5">
           <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-            <div className="space-y-3">
+            <div className="space-y-2">
               <div className="flex items-center gap-2">
-                <h1 className="text-2xl font-bold text-slate-900">オファー詳細</h1>
+                <h1 className="text-xl font-bold text-slate-900 sm:text-2xl">オファー詳細</h1>
               </div>
-              <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-sm text-slate-600">
+              <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 text-sm text-slate-600">
                 <div className="flex items-center gap-2">
                   <span className="font-medium text-slate-900">{offer.performerName || 'タレント未設定'}</span>
                   <span className="text-slate-300">/</span>
@@ -140,38 +142,41 @@ export default async function StoreOfferPage({ params }: PageProps) {
               <div>{formattedUpdatedAt}</div>
             </div>
           </div>
-        </section>
+          </section>
 
-        <StoreOfferProgressPanel
-          steps={steps}
-          initialActiveStep={activeStep}
-          offer={{
-            id: offer.id,
-            status: offer.status,
-            date: offer.date,
-            respondDeadline: offer.respondDeadline,
-            updatedAt: offer.updatedAt,
-            submittedAt: offer.submittedAt,
-            paid: offer.paid,
-            paidAt: offer.paidAt,
-            invoiceStatus: offer.invoiceStatus,
-            invoiceStatusLabel: offer.invoiceStatusLabel,
-            paymentStatusLabel: offer.paymentStatusLabel,
-            storeName: offer.storeName,
-            reward: offer.reward,
-            talentId: offer.talentId,
-            reviewCompleted: offer.reviewCompleted,
-          }}
-          invoice={invoiceData}
-          paymentLink={paymentLink}
-          cancelation={{ initialStatus: data.status as string, initialCanceledAt: data.canceled_at as string | null }}
-          message={{
-            offerId: offer.id,
-            currentUserId: user.id,
-            storeName: offer.storeName,
-            talentName: offer.performerName,
-          }}
-        />
+          <StoreOfferProgressPanel
+            steps={steps}
+            initialActiveStep={activeStep}
+            offer={{
+              id: offer.id,
+              status: offer.status,
+              date: offer.date,
+              respondDeadline: offer.respondDeadline,
+              updatedAt: offer.updatedAt,
+              submittedAt: offer.submittedAt,
+              paid: offer.paid,
+              paidAt: offer.paidAt,
+              invoiceStatus: offer.invoiceStatus,
+              invoiceStatusLabel: offer.invoiceStatusLabel,
+              paymentStatusLabel: offer.paymentStatusLabel,
+              storeName: offer.storeName,
+              reward: offer.reward,
+              talentId: offer.talentId,
+              reviewCompleted: offer.reviewCompleted,
+            }}
+            invoice={invoiceData}
+            paymentLink={paymentLink}
+            cancelation={{ initialStatus: data.status as string, initialCanceledAt: data.canceled_at as string | null }}
+          />
+        </div>
+        <div className="lg:sticky lg:top-6">
+          <MessageCard
+            offerId={offer.id}
+            currentUserId={user.id}
+            storeName={offer.storeName}
+            talentName={offer.performerName}
+          />
+        </div>
       </div>
     </div>
   )

--- a/talentify-next-frontend/app/talent/offers/[id]/MessageCard.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/MessageCard.tsx
@@ -11,16 +11,15 @@ type MessageCardProps = {
 
 export default function MessageCard({ offerId, currentUserId, storeName, talentName }: MessageCardProps) {
   return (
-    <div id="offer-messages">
+    <div id="offer-messages" className="h-full">
       <OfferChatThread
         offerId={offerId}
         currentUserId={currentUserId}
         currentRole="talent"
         storeName={storeName}
         talentName={talentName}
-        className="lg:max-h-[540px]"
+        className="lg:max-h-[calc(100vh-3rem)]"
       />
     </div>
   )
 }
-

--- a/talentify-next-frontend/app/talent/offers/[id]/ProgressCard.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/ProgressCard.tsx
@@ -12,15 +12,14 @@ type ProgressCardProps = {
 
 export default function ProgressCard({ steps, activeStep, onStepChange }: ProgressCardProps) {
   return (
-    <Card className="rounded-2xl border border-slate-200 shadow-sm">
-      <CardHeader className="space-y-1">
-        <CardTitle className="text-lg font-semibold text-slate-900">進捗状況</CardTitle>
-        <p className="text-sm text-muted-foreground">オファーの進行状況と各ステップの対応内容を確認できます。</p>
+    <Card className="rounded-xl border border-slate-200 bg-white shadow-sm">
+      <CardHeader className="space-y-1 px-4 pt-4 sm:px-5 sm:pt-5">
+        <CardTitle className="text-base font-semibold text-slate-900 sm:text-lg">進捗状況</CardTitle>
+        <p className="text-xs leading-relaxed text-muted-foreground sm:text-sm">オファーの進行状況と各ステップの対応内容を確認できます。</p>
       </CardHeader>
-      <CardContent className="pt-2">
+      <CardContent className="px-4 pb-4 pt-1 sm:px-5 sm:pb-5">
         <OfferProgressTracker steps={steps} selectedStep={activeStep} onStepSelect={onStepChange} />
       </CardContent>
     </Card>
   )
 }
-

--- a/talentify-next-frontend/app/talent/offers/[id]/StepDetailCard.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/StepDetailCard.tsx
@@ -42,6 +42,9 @@ type StepDetail = {
   secondaryAction?: ReactNode
 }
 
+const primaryActionClass = 'h-9 bg-blue-700 px-4 text-white hover:bg-blue-800 focus-visible:ring-blue-300'
+const secondaryActionClass = 'h-9 border-slate-300 bg-white px-4 text-slate-700 hover:bg-slate-100'
+
 const statusDisplay = (status: string) => {
   switch (status) {
     case 'pending':
@@ -91,8 +94,8 @@ export default function StepDetailCard({
           description: '請求書がまだ作成されていません。請求書の作成・提出を進めてください。',
           badge: <Badge variant="outline">請求待ち</Badge>,
           meta: [{ label: '請求書ステータス', value: offer.invoiceStatusLabel }],
-          primaryAction: <Button asChild><Link href={`/talent/invoices/new?offerId=${offer.id}`}>請求書を作成する</Link></Button>,
-          secondaryAction: <Button variant="outline" asChild><a href="#offer-messages">メッセージを送る</a></Button>,
+          primaryAction: <Button className={primaryActionClass} asChild><Link href={`/talent/invoices/new?offerId=${offer.id}`}>請求書を作成する</Link></Button>,
+          secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
         }
       case 'payment_waiting':
         return {
@@ -100,8 +103,8 @@ export default function StepDetailCard({
           description: '店舗側での支払い処理待ちです。必要に応じて状況を確認してください。',
           badge: <Badge variant="outline">支払い待ち</Badge>,
           meta: [{ label: '支払い状態', value: offer.paymentStatusLabel }],
-          primaryAction: invoiceId ? <Button asChild><Link href={`/talent/invoices/${invoiceId}`}>請求書を見る</Link></Button> : paymentLink ? <Button asChild><Link href={paymentLink}>状況を確認する</Link></Button> : undefined,
-          secondaryAction: <Button variant="outline" asChild><a href="#offer-messages">メッセージを送る</a></Button>,
+          primaryAction: invoiceId ? <Button className={primaryActionClass} asChild><Link href={`/talent/invoices/${invoiceId}`}>請求書を見る</Link></Button> : paymentLink ? <Button className={primaryActionClass} asChild><Link href={paymentLink}>状況を確認する</Link></Button> : undefined,
+          secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
         }
       case 'review_available':
         return {
@@ -109,8 +112,8 @@ export default function StepDetailCard({
           description: '店舗からのレビューを確認しましょう。',
           badge: <Badge variant="success">レビューあり</Badge>,
           meta: [{ label: 'レビュー状態', value: '店舗レビューあり' }],
-          primaryAction: <Button asChild><Link href="/talent/reviews">レビューを確認する</Link></Button>,
-          secondaryAction: <Button variant="outline" asChild><a href="#offer-messages">メッセージを送る</a></Button>,
+          primaryAction: <Button className={primaryActionClass} asChild><Link href="/talent/reviews">レビューを確認する</Link></Button>,
+          secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
         }
       case 'completed':
         return {
@@ -118,8 +121,8 @@ export default function StepDetailCard({
           description: 'この案件はすべてのステップが完了しています。',
           badge: <Badge variant="success">全完了</Badge>,
           meta: [{ label: 'レビュー状態', value: '確認済み' }],
-          primaryAction: <Button asChild><Link href="/talent/reviews">レビューを確認する</Link></Button>,
-          secondaryAction: <Button variant="outline" asChild><a href="#offer-messages">メッセージを送る</a></Button>,
+          primaryAction: <Button className={primaryActionClass} asChild><Link href="/talent/reviews">レビューを確認する</Link></Button>,
+          secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
         }
       case 'payment_completed_review_waiting':
         return {
@@ -127,14 +130,14 @@ export default function StepDetailCard({
           description: '支払いは完了しています。店舗レビューの投稿をお待ちください。',
           badge: <Badge>レビュー待ち</Badge>,
           meta: [{ label: '支払い状態', value: offer.paymentStatusLabel }],
-          secondaryAction: <Button variant="outline" asChild><a href="#offer-messages">メッセージを送る</a></Button>,
+          secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
         }
       default:
         return {
           title: '請求書の準備がこれからです',
           description: 'まだ請求書が作成されていない状態です。進行ステップバーで状況を確認してください。',
           badge: <Badge variant="outline">準備中</Badge>,
-          secondaryAction: <Button variant="outline" asChild><a href="#offer-messages">メッセージを送る</a></Button>,
+          secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
         }
     }
   }, [offer.status, offer.invoiceStatus, offer.paid, offer.reviewCompleted, offer.invoiceStatusLabel, offer.paymentStatusLabel, offer.id, invoiceId, paymentLink])
@@ -153,7 +156,7 @@ export default function StepDetailCard({
           { label: '提出日時', value: formattedSubmittedAt },
           { label: '来店予定', value: formattedVisitDate },
         ],
-        secondaryAction: <Button variant="outline" asChild><a href="#offer-messages">メッセージを送る</a></Button>,
+        secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
       }
     }
 
@@ -168,12 +171,12 @@ export default function StepDetailCard({
           { label: '最終更新', value: formattedUpdatedAt },
         ],
         primaryAction: offer.status === 'pending' && onAcceptOffer ? (
-          <Button onClick={onAcceptOffer} disabled={actionLoading !== null}>{actionLoading === 'accept' ? '承諾中...' : '承諾'}</Button>
+          <Button className={primaryActionClass} onClick={onAcceptOffer} disabled={actionLoading !== null}>{actionLoading === 'accept' ? '承諾中...' : '承諾'}</Button>
         ) : undefined,
         secondaryAction: offer.status === 'pending' && onDeclineOffer ? (
-          <Button variant="outline" onClick={onDeclineOffer} disabled={actionLoading !== null}>{actionLoading === 'decline' ? '辞退中...' : '辞退'}</Button>
+          <Button variant="outline" className={secondaryActionClass} onClick={onDeclineOffer} disabled={actionLoading !== null}>{actionLoading === 'decline' ? '辞退中...' : '辞退'}</Button>
         ) : (
-          <Button variant="outline" asChild><a href="#offer-messages">メッセージを送る</a></Button>
+          <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>
         ),
       }
     }
@@ -186,31 +189,31 @@ export default function StepDetailCard({
         { label: '来店日時', value: formattedVisitDate },
         { label: '最終更新', value: formattedUpdatedAt },
       ],
-      secondaryAction: <Button variant="outline" asChild><a href="#offer-messages">メッセージを送る</a></Button>,
+      secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
     }
   }, [activeStep, activeStatus, mainActionDetail, formattedSubmittedAt, formattedUpdatedAt, formattedVisitDate, offer.status, onAcceptOffer, onDeclineOffer, actionLoading])
 
   return (
-    <Card className="rounded-2xl border border-slate-200 bg-white shadow-sm">
-      <CardHeader className="flex flex-col gap-2 border-b border-slate-100 p-6">
+    <Card className="rounded-xl border border-slate-200 bg-white shadow-sm">
+      <CardHeader className="flex flex-col gap-1.5 border-b border-slate-100 p-4 sm:p-5">
         <div className="flex flex-wrap items-center gap-3">
-          <CardTitle className="text-lg font-semibold text-slate-900">{detail.title}</CardTitle>
+          <CardTitle className="text-base font-semibold text-slate-900 sm:text-lg">{detail.title}</CardTitle>
           {detail.badge}
         </div>
-        <p className="text-sm text-muted-foreground">{detail.description}</p>
+        <p className="text-sm leading-relaxed text-muted-foreground">{detail.description}</p>
       </CardHeader>
-      <CardContent className="space-y-6 p-6">
+      <CardContent className="space-y-4 p-4 sm:p-5">
         {detail.meta && detail.meta.length > 0 && (
-          <dl className="grid gap-4 rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm sm:grid-cols-2">
+          <dl className="grid gap-3 rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm sm:grid-cols-2">
             {detail.meta.map(item => (
-              <div key={item.label} className="space-y-1">
+              <div key={item.label} className="space-y-0.5">
                 <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{item.label}</dt>
-                <dd className="text-base font-semibold text-slate-900">{item.value}</dd>
+                <dd className="text-sm font-semibold text-slate-900 sm:text-base">{item.value}</dd>
               </div>
             ))}
           </dl>
         )}
-        <div className="flex flex-wrap justify-end gap-3">
+        <div className="flex flex-wrap justify-end gap-2.5">
           {detail.secondaryAction && <div className="inline-flex">{detail.secondaryAction}</div>}
           {detail.primaryAction && <div className="inline-flex">{detail.primaryAction}</div>}
         </div>

--- a/talentify-next-frontend/app/talent/offers/[id]/TalentOfferProgressPanel.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/TalentOfferProgressPanel.tsx
@@ -6,7 +6,6 @@ import { ja } from 'date-fns/locale'
 import type { OfferProgressStep, OfferProgressStatus, OfferStepKey } from '@/utils/offerProgress'
 import ProgressCard from './ProgressCard'
 import StepDetailCard from './StepDetailCard'
-import MessageCard from './MessageCard'
 
 type TalentOfferProgressPanelProps = {
   steps: OfferProgressStep[]
@@ -26,12 +25,6 @@ type TalentOfferProgressPanelProps = {
   }
   invoiceId: string | null
   paymentLink?: string
-  message: {
-    offerId: string
-    currentUserId: string
-    storeName: string
-    talentName: string
-  }
   onAcceptOffer?: () => void
   onDeclineOffer?: () => void
   actionLoading?: 'accept' | 'decline' | null
@@ -43,7 +36,6 @@ export default function TalentOfferProgressPanel({
   offer,
   invoiceId,
   paymentLink,
-  message,
   onAcceptOffer,
   onDeclineOffer,
   actionLoading,
@@ -108,30 +100,18 @@ export default function TalentOfferProgressPanel({
   }, [progressSteps, activeStep])
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <ProgressCard steps={progressSteps} activeStep={activeStep} onStepChange={setActiveStep} />
-      <div className="grid gap-6 lg:grid-cols-3">
-        <div className="lg:col-span-2">
-          <StepDetailCard
-            activeStep={activeStep}
-            activeStatus={activeStatus}
-            offer={offer}
-            invoiceId={invoiceId}
-            paymentLink={paymentLink}
-            onAcceptOffer={onAcceptOffer}
-            onDeclineOffer={onDeclineOffer}
-            actionLoading={actionLoading}
-          />
-        </div>
-        <div className="lg:col-span-1">
-          <MessageCard
-            offerId={message.offerId}
-            currentUserId={message.currentUserId}
-            storeName={message.storeName}
-            talentName={message.talentName}
-          />
-        </div>
-      </div>
+      <StepDetailCard
+        activeStep={activeStep}
+        activeStatus={activeStatus}
+        offer={offer}
+        invoiceId={invoiceId}
+        paymentLink={paymentLink}
+        onAcceptOffer={onAcceptOffer}
+        onDeclineOffer={onDeclineOffer}
+        actionLoading={actionLoading}
+      />
     </div>
   )
 }

--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -6,12 +6,17 @@ import { createClient } from '@/utils/supabase/client'
 import { getOfferProgress } from '@/utils/offerProgress'
 import { toast } from 'sonner'
 import { toDbOfferStatus } from '@/app/lib/offerStatus'
+import { format } from 'date-fns'
+import { ja } from 'date-fns/locale'
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
 import TalentOfferProgressPanel from './TalentOfferProgressPanel'
 import {
   deriveOfferInvoiceProgressStatus,
   getInvoiceStatusLabel,
   getPaymentStatusLabel,
 } from '@/lib/invoices/status'
+import MessageCard from './MessageCard'
 
 export default function TalentOfferPage() {
   const params = useParams<{ id: string }>()
@@ -125,6 +130,12 @@ export default function TalentOfferPage() {
 
   const showActions = ['accepted', 'confirmed', 'completed'].includes(offer.status)
   const paymentLink = showActions && invoiceId ? `/talent/invoices/${invoiceId}` : undefined
+  const formattedUpdatedAt = format(new Date(offer.updatedAt), 'yyyy/MM/dd HH:mm', { locale: ja })
+  const formattedSubmittedAt = offer.submittedAt
+    ? format(new Date(offer.submittedAt), 'yyyy/MM/dd HH:mm', { locale: ja })
+    : '未提出'
+  const statusLabel = getStatusLabel(offer.status)
+  const statusClassName = getStatusBadgeClassName(offer.status)
 
   const { steps, current: currentStep } = getOfferProgress({
     status: offer.status,
@@ -134,37 +145,96 @@ export default function TalentOfferPage() {
   })
 
   return (
-    <div className="p-4 sm:p-6 lg:p-8">
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 lg:gap-8">
-        <TalentOfferProgressPanel
-          steps={steps}
-          initialActiveStep={currentStep}
-          offer={{
-            id: offer.id,
-            status: offer.status,
-            date: offer.date,
-            updatedAt: offer.updatedAt,
-            submittedAt: offer.submittedAt,
-            paid: offer.paid,
-            paidAt: offer.paidAt,
-            invoiceStatus: offer.invoiceStatus,
-            invoiceStatusLabel: offer.invoiceStatusLabel,
-            paymentStatusLabel: offer.paymentStatusLabel,
-            reviewCompleted: offer.reviewCompleted,
-          }}
-          invoiceId={invoiceId}
-          paymentLink={paymentLink}
-          message={{
-            offerId: offer.id,
-            currentUserId: userId,
-            storeName: offer.storeName,
-            talentName: offer.performerName,
-          }}
-          onAcceptOffer={handleAccept}
-          onDeclineOffer={handleDecline}
-          actionLoading={actionLoading}
-        />
+    <div className="bg-slate-50 p-3 sm:p-5 lg:p-6">
+      <div className="mx-auto grid w-full max-w-6xl gap-4 lg:grid-cols-3 lg:items-start">
+        <div className="space-y-4 lg:col-span-2">
+          <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm sm:p-5">
+            <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+              <div className="space-y-2">
+                <h1 className="text-xl font-bold text-slate-900 sm:text-2xl">オファー詳細</h1>
+                <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 text-sm text-slate-600">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-slate-900">{offer.storeName || '店舗未設定'}</span>
+                    <span className="text-slate-300">/</span>
+                    <span>{offer.performerName || 'タレント未設定'}</span>
+                  </div>
+                  <span className="inline-flex h-4 w-px bg-slate-200" aria-hidden="true" />
+                  <span>{formattedSubmittedAt}</span>
+                  <Badge className={cn('flex items-center gap-1', statusClassName)}>{statusLabel}</Badge>
+                </div>
+              </div>
+              <div className="text-xs text-slate-500 md:text-right">
+                <div className="font-medium text-slate-400">最終更新日時</div>
+                <div>{formattedUpdatedAt}</div>
+              </div>
+            </div>
+          </section>
+          <TalentOfferProgressPanel
+            steps={steps}
+            initialActiveStep={currentStep}
+            offer={{
+              id: offer.id,
+              status: offer.status,
+              date: offer.date,
+              updatedAt: offer.updatedAt,
+              submittedAt: offer.submittedAt,
+              paid: offer.paid,
+              paidAt: offer.paidAt,
+              invoiceStatus: offer.invoiceStatus,
+              invoiceStatusLabel: offer.invoiceStatusLabel,
+              paymentStatusLabel: offer.paymentStatusLabel,
+              reviewCompleted: offer.reviewCompleted,
+            }}
+            invoiceId={invoiceId}
+            paymentLink={paymentLink}
+            onAcceptOffer={handleAccept}
+            onDeclineOffer={handleDecline}
+            actionLoading={actionLoading}
+          />
+        </div>
+        <div className="lg:sticky lg:top-6">
+          <MessageCard
+            offerId={offer.id}
+            currentUserId={userId}
+            storeName={offer.storeName}
+            talentName={offer.performerName}
+          />
+        </div>
       </div>
     </div>
   )
+}
+
+function getStatusLabel(status: string) {
+  switch (status) {
+    case 'accepted':
+    case 'confirmed':
+      return '承認済み'
+    case 'completed':
+      return '完了'
+    case 'rejected':
+      return '辞退済み'
+    case 'canceled':
+      return 'キャンセル'
+    case 'draft':
+      return '下書き'
+    default:
+      return '承認待ち'
+  }
+}
+
+function getStatusBadgeClassName(status: string) {
+  switch (status) {
+    case 'completed':
+    case 'confirmed':
+    case 'accepted':
+      return 'bg-emerald-500 text-white'
+    case 'draft':
+      return 'bg-slate-200 text-slate-700'
+    case 'rejected':
+    case 'canceled':
+      return 'bg-slate-300 text-slate-700'
+    default:
+      return 'bg-orange-400 text-white'
+  }
 }

--- a/talentify-next-frontend/components/offer/OfferChatThread.tsx
+++ b/talentify-next-frontend/components/offer/OfferChatThread.tsx
@@ -170,15 +170,15 @@ export default function OfferChatThread({
   return (
     <div
       className={cn(
-        'flex h-full min-h-[520px] flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm',
+        'flex h-full min-h-[420px] flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm',
         className,
       )}
     >
-      <div className="flex items-center justify-between gap-4 border-b border-slate-100 px-5 py-4">
+      <div className="flex items-center justify-between gap-3 border-b border-slate-100 px-4 py-3.5">
         <div className="flex items-center gap-3">
           <div className="flex items-center gap-2">
             <MessageCircle className="h-5 w-5 text-slate-600" aria-hidden="true" />
-            <h3 className="text-base font-semibold text-slate-900">メッセージ</h3>
+            <h3 className="text-sm font-semibold text-slate-900 sm:text-base">メッセージ</h3>
             {unreadCount > 0 && (
               <span className="inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-red-500 px-1 text-xs font-semibold text-white">
                 {unreadCount}
@@ -186,12 +186,12 @@ export default function OfferChatThread({
             )}
           </div>
         </div>
-        <span className="text-xs text-slate-400">最終更新: {formatTimestamp(lastUpdatedAt)}</span>
+        <span className="text-[11px] text-slate-400 sm:text-xs">最終更新: {formatTimestamp(lastUpdatedAt)}</span>
       </div>
       <div
         ref={containerRef}
         onScroll={handleScroll}
-        className="flex-1 overflow-y-auto px-5 py-4"
+        className="flex-1 overflow-y-auto px-4 py-3.5"
         aria-live="polite"
       >
         {loading && <p>Loading...</p>}
@@ -212,7 +212,7 @@ export default function OfferChatThread({
           ))}
         </div>
       </div>
-      <div className="border-t border-slate-100 bg-slate-50 px-5 py-4">
+      <div className="border-t border-slate-100 bg-slate-50 px-4 py-3">
         <OfferChatInput offerId={offerId} senderRole={currentRole} onSent={handleSent} />
       </div>
     </div>

--- a/talentify-next-frontend/components/offer/OfferProgressTracker.tsx
+++ b/talentify-next-frontend/components/offer/OfferProgressTracker.tsx
@@ -44,15 +44,15 @@ export default function OfferProgressTracker({ steps, selectedStep, onStepSelect
   const completedCount = steps.filter(step => step.status === 'complete').length
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <div className="flex items-center justify-end">
         <span className="text-xs font-medium text-[#64748b]">
           {completedCount}/{steps.length}ステップ完了
         </span>
       </div>
       <div className="overflow-x-auto">
-        <div className="min-w-[640px] space-y-6">
-          <div className="flex justify-between gap-3">
+        <div className="min-w-[620px] space-y-4">
+          <div className="flex justify-between gap-2.5">
             {steps.map((step, index) => {
               const isSelected = step.key === activeStep
               const iconStyles = iconStylesByStatus[step.status]
@@ -66,14 +66,14 @@ export default function OfferProgressTracker({ steps, selectedStep, onStepSelect
                 <div key={step.key} className="relative flex min-w-0 flex-1 flex-col items-center text-center">
                   {index > 0 && (
                     <span
-                      className="absolute left-0 top-7 block h-1 w-1/2 -translate-y-1/2 rounded-full"
+                      className="absolute left-0 top-6 block h-1 w-1/2 -translate-y-1/2 rounded-full"
                       style={{ backgroundColor: leftConnectorActive ? '#2f4da0' : '#e2e8f0' }}
                       aria-hidden="true"
                     />
                   )}
                   {index < steps.length - 1 && (
                     <span
-                      className="absolute right-0 top-7 block h-1 w-1/2 -translate-y-1/2 rounded-full"
+                      className="absolute right-0 top-6 block h-1 w-1/2 -translate-y-1/2 rounded-full"
                       style={{ backgroundColor: rightConnectorActive ? '#2f4da0' : '#e2e8f0' }}
                       aria-hidden="true"
                     />
@@ -81,32 +81,32 @@ export default function OfferProgressTracker({ steps, selectedStep, onStepSelect
                   <button
                     type="button"
                     onClick={() => onStepSelect?.(step.key)}
-                    className="flex flex-col items-center gap-3 focus:outline-none"
+                    className="flex flex-col items-center gap-2 focus:outline-none"
                     aria-pressed={isSelected}
                   >
                     <div
                       className={cn(
-                        'relative z-10 flex h-14 w-14 items-center justify-center rounded-full transition-all',
+                        'relative z-10 flex h-12 w-12 items-center justify-center rounded-full transition-all',
                         iconStyles.outer,
                         isSelected && 'ring-2 ring-[#2f4da0] ring-opacity-35 ring-offset-2',
                       )}
                     >
                       <div
                         className={cn(
-                          'flex h-11 w-11 items-center justify-center rounded-full text-base font-semibold transition-all',
+                          'flex h-9 w-9 items-center justify-center rounded-full text-sm font-semibold transition-all',
                           iconStyles.inner,
                         )}
                       >
                         {step.status === 'complete' ? (
-                          <Check className="h-5 w-5" />
+                          <Check className="h-4 w-4" />
                         ) : (
                           <span>{index + 1}</span>
                         )}
                       </div>
                     </div>
-                    <div className="flex min-h-[3.5rem] flex-col items-center justify-start gap-1">
-                      <span className={cn('text-sm font-semibold', titleColorByStatus[step.status])}>{step.title}</span>
-                      <span className={cn('text-xs font-medium', dateColorByStatus[step.status])}>
+                    <div className="flex min-h-[3rem] flex-col items-center justify-start gap-0.5">
+                      <span className={cn('text-xs font-semibold sm:text-sm', titleColorByStatus[step.status])}>{step.title}</span>
+                      <span className={cn('text-[11px] font-medium sm:text-xs', dateColorByStatus[step.status])}>
                         {displaySubLabel || ' '}
                       </span>
                     </div>


### PR DESCRIPTION
### Motivation
- The offer detail pages had a double-card visual (gray wrapper + inner white cards), oversized cards, weak-looking white CTAs, and uneven two-column heights making the page hard to scan.  
- The goal is a clean SaaS-like layout: light-gray page background with white cards, denser vertical spacing, clearer button affordances, and a stable left=workflow / right=messages layout that also stacks to a single column on small screens.  

### Description
- Reworked store and talent offer pages to a two-column grid on large screens (left: offer summary → progress → main action; right: message card) and a single-column stack on narrow screens, moving the message UI out of the progress panel into a dedicated right column with optional `sticky` placement.  
- Compacted card visuals by reducing paddings/gaps, tightening headings and meta areas, switching many `rounded-2xl` → `rounded-xl`, and reducing the progress tracker icon/label sizes and connector spacing to save vertical space.  
- Improved CTA affordance by introducing local `primaryActionClass`/`secondaryActionClass` and applying them so primary actions are filled blue and secondary actions are bordered/clear, adjusting review/invoice/payment buttons in both store and talent flows.  
- Adjusted message/chat card height and internal padding and slimmed `OfferChatThread` spacing to better fit the right column; kept all logic and data contracts unchanged and avoided global CSS edits (only page-level components and related UI components were modified).  

### Testing
- Ran `npm run lint` in `talentify-next-frontend` and the linter completed successfully with only preexisting `no-img-element` warnings.  
- No automated visual snapshot or browser tests were available in this environment, so visual verification should be done in a running dev build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc9b23dbb8833298fac2d78ee5849a)