### PR TITLE
Improve store profile edit page visual hierarchy with card layout and refined form styles

### DIFF
--- a/talentify-next-frontend/app/store/edit/EditClient.tsx
+++ b/talentify-next-frontend/app/store/edit/EditClient.tsx
@@ -200,47 +200,65 @@ export default function StoreProfileEditPage() {
   if (loading) return <p className="p-4">読み込み中...</p>
 
   return (
-    <main className="max-w-2xl mx-auto p-6 space-y-6">
-      {errorMessage && <p className="text-red-500 text-sm">{errorMessage}</p>}
-      {showIncomplete && !errorMessage && (
-        <div className="rounded bg-yellow-100 p-2 text-yellow-800">
-          プロフィールが未完成です
-        </div>
-      )}
-      <h1 className="text-2xl font-bold">店舗プロフィール編集</h1>
+    <main className="bg-gray-100 px-4 py-8 sm:px-6">
+      <div className="mx-auto w-full max-w-2xl rounded-2xl border border-gray-200 bg-white p-6 shadow-sm space-y-6">
+        {errorMessage && <p className="text-sm text-red-500">{errorMessage}</p>}
+        {showIncomplete && !errorMessage && (
+          <div className="rounded-lg bg-yellow-100 p-2 text-sm text-yellow-800">
+            プロフィールが未完成です
+          </div>
+        )}
+        <h1 className="text-xl font-semibold">店舗プロフィール編集</h1>
 
-      <div className="space-y-4">
-        <div>
-          <label className="block font-medium">店舗名（表示名）</label>
-          <Input name="store_name" value={profile.store_name} onChange={handleChange} />
-        </div>
-
-        <div>
-          <label className="block font-medium">自己紹介</label>
-          <Textarea name="bio" value={profile.bio} onChange={handleChange} rows={4} />
-        </div>
-
-        <div>
-          <label className="block font-medium">アバター画像</label>
-          {avatarPreview && (
-            <img
-              src={avatarPreview}
-              alt="avatar preview"
-              className="w-24 h-24 object-cover mb-2"
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <label className="block text-sm font-medium">店舗名（表示名）</label>
+            <Input
+              name="store_name"
+              value={profile.store_name}
+              onChange={handleChange}
+              className="rounded-lg border border-gray-300 bg-white focus-visible:ring-2 focus-visible:ring-blue-500"
             />
-          )}
-          <Input
-            type="file"
-            accept="image/png,image/jpeg,image/webp"
-            onChange={handleAvatar}
-          />
-          <p className="text-sm text-gray-500">5MBまで／対応：PNG・JPG・WEBP</p>
-          {errors.avatar && <p className="text-red-500 text-sm">{errors.avatar}</p>}
-        </div>
+          </div>
 
-        <Button onClick={handleSave} className="mt-4" disabled={saving}>
-          {saving ? '保存中...' : '保存する'}
-        </Button>
+          <div className="space-y-1.5">
+            <label className="block text-sm font-medium">自己紹介</label>
+            <Textarea
+              name="bio"
+              value={profile.bio}
+              onChange={handleChange}
+              rows={4}
+              className="rounded-lg border border-gray-300 bg-white focus-visible:ring-2 focus-visible:ring-blue-500"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="block text-sm font-medium">アバター画像</label>
+            {avatarPreview && (
+              <img
+                src={avatarPreview}
+                alt="avatar preview"
+                className="mb-2 h-24 w-24 rounded-lg object-cover"
+              />
+            )}
+            <Input
+              type="file"
+              accept="image/png,image/jpeg,image/webp"
+              onChange={handleAvatar}
+              className="rounded-lg border border-gray-300 bg-white focus-visible:ring-2 focus-visible:ring-blue-500"
+            />
+            <p className="text-sm text-gray-500">5MBまで／対応：PNG・JPG・WEBP</p>
+            {errors.avatar && <p className="text-sm text-red-500">{errors.avatar}</p>}
+          </div>
+
+          <Button
+            onClick={handleSave}
+            className="mt-4 w-full bg-blue-600 text-white hover:bg-blue-700"
+            disabled={saving}
+          >
+            {saving ? '保存中...' : '保存する'}
+          </Button>
+        </div>
       </div>
     </main>
   )


### PR DESCRIPTION
### Motivation
- フォームの背景・要素がグレーに埋もれて入力エリアの視認性が低かったため、カードベースのレイアウトと明確なフォームスタイルで視認性とプロダクトらしさを向上させる。 
- 既存の構造／保存ロジックはそのままに、スタイルと間隔中心で改善する目的。 

### Description
- 更新ファイル: `talentify-next-frontend/app/store/edit/EditClient.tsx` にスタイル変更を適用した。 
- ページの外枠を `bg-gray-100` にし、中央寄せの白カードを `max-w-2xl rounded-2xl border border-gray-200 bg-white p-6 shadow-sm` で実装した。 
- タイポグラフィを調整し、タイトルを `text-xl font-semibold`、ラベルを `text-sm font-medium` に統一した。 
- `Input`/`Textarea` とファイル入力に `rounded-lg border border-gray-300 bg-white focus-visible:ring-2 focus-visible:ring-blue-500` を追加して入力エリアの視認性とフォーカス時のリング表示を強化した。 
- 「保存する」ボタンを横幅いっぱいの主要アクションにし、`w-full bg-blue-600 text-white hover:bg-blue-700` を適用した。 

### Testing
- 実行した自動テスト: `cd talentify-next-frontend && npm run -s lint` が成功したが、複数ファイル（本ページ含む）で `<img>` 使用に関する ESLint の警告が出ている; エラーは発生していない。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc9d2178948332838cbe6a3d70a9e1)