### PR TITLE
最終調整: オファー詳細UIで重複日時・二重メッセージ導線・内側背景を整理

### DIFF
--- a/talentify-next-frontend/app/store/offers/[id]/StepDetailCard.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/StepDetailCard.tsx
@@ -53,12 +53,10 @@ type StepDetail = {
   badge?: ReactNode
   meta?: { label: string; value: string }[]
   primaryAction?: ReactNode
-  secondaryAction?: ReactNode
   footer?: ReactNode
 }
 
 const primaryActionClass = 'h-9 bg-blue-700 px-4 text-white hover:bg-blue-800 focus-visible:ring-blue-300'
-const secondaryActionClass = 'h-9 border-slate-300 bg-white px-4 text-slate-700 hover:bg-slate-100'
 
 const statusBadge = (status: string) => {
   switch (status) {
@@ -74,6 +72,20 @@ const statusBadge = (status: string) => {
   }
 }
 
+const getStatusText = (status: string) => {
+  switch (status) {
+    case 'confirmed':
+    case 'accepted':
+      return '承認済み'
+    case 'rejected':
+      return '辞退済み'
+    case 'canceled':
+      return 'キャンセル済み'
+    default:
+      return '承認待ち'
+  }
+}
+
 export default function StepDetailCard({ activeStep, activeStatus, offer, invoice, paymentLink, cancelation }: StepDetailCardProps) {
   const router = useRouter()
 
@@ -81,12 +93,7 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
     router.refresh()
   }, [router])
 
-  const formattedSubmittedAt = useMemo(() => {
-    return offer.submittedAt ? format(new Date(offer.submittedAt), 'yyyy/MM/dd HH:mm', { locale: ja }) : '未提出'
-  }, [offer.submittedAt])
-  const formattedUpdatedAt = useMemo(() => format(new Date(offer.updatedAt), 'yyyy/MM/dd HH:mm', { locale: ja }), [offer.updatedAt])
   const formattedVisitDate = useMemo(() => offer.date ? format(new Date(offer.date), 'yyyy/MM/dd (EEE) HH:mm', { locale: ja }) : '未設定', [offer.date])
-  const formattedRespondDeadline = useMemo(() => offer.respondDeadline ? format(new Date(offer.respondDeadline), 'yyyy/MM/dd', { locale: ja }) : '未設定', [offer.respondDeadline])
   const paymentCompletedLabel = useMemo(() => offer.paidAt ? format(new Date(offer.paidAt), 'yyyy/MM/dd', { locale: ja }) : undefined, [offer.paidAt])
 
   const mainActionDetail = useMemo<StepDetail>(() => {
@@ -106,7 +113,6 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
           badge: <Badge variant="outline">請求待ち</Badge>,
           meta: [{ label: '請求書ステータス', value: offer.invoiceStatusLabel }],
           primaryAction: undefined,
-          secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
         }
       case 'invoice_submitted':
         return {
@@ -119,7 +125,6 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
             { label: '支払い状況', value: offer.paymentStatusLabel },
           ],
           primaryAction: invoice ? <Button className={primaryActionClass} asChild><Link href={`/store/invoices/${invoice.id}`}>請求書を見る</Link></Button> : undefined,
-          secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
         }
       case 'payment_waiting':
         return {
@@ -131,7 +136,6 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
             ...(invoice?.amount != null ? [{ label: '支払い予定額', value: `¥${invoice.amount.toLocaleString('ja-JP')}` }] : []),
           ],
           primaryAction: paymentLink ? <Button className={primaryActionClass} asChild><Link href={paymentLink}>支払いを確認する</Link></Button> : invoice ? <Button className={primaryActionClass} asChild><Link href={`/store/invoices/${invoice.id}`}>請求書を見る</Link></Button> : undefined,
-          secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
         }
       case 'payment_completed_review_waiting':
         return {
@@ -150,7 +154,6 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
               onSubmitted={handleReviewSubmitted}
             />
           ) : undefined,
-          secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
         }
       case 'completed':
         return {
@@ -159,7 +162,6 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
           badge: <Badge variant="success">全完了</Badge>,
           meta: [{ label: 'レビュー状態', value: offer.reviewCompleted ? 'レビュー済み' : '未実施' }],
           primaryAction: <Button className={primaryActionClass} asChild><Link href="/store/reviews">レビューを見る</Link></Button>,
-          secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
         }
       default:
         return {
@@ -167,7 +169,6 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
           description: 'まだ請求書が作成されていない状態です。進行ステップバーで状況を確認してください。',
           badge: <Badge variant="outline">準備中</Badge>,
           meta: [{ label: '現在ステップ', value: activeStep }],
-          secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
         }
     }
   }, [activeStep, offer.status, offer.invoiceStatus, offer.paid, offer.reviewCompleted, offer.invoiceStatusLabel, offer.paymentStatusLabel, offer.id, offer.talentId, invoice, paymentLink, paymentCompletedLabel, handleReviewSubmitted])
@@ -192,7 +193,6 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
     let result: StepDetail = {
       title: '進行中',
       description: '進行ステップを確認してください。',
-      secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
     }
 
     if (activeStep === 'offer_submitted') {
@@ -201,11 +201,9 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
         description: '店舗からタレントへオファーを送信しました。返信内容はメッセージで確認できます。',
         badge: activeStatus === 'complete' ? <Badge variant="success">完了</Badge> : undefined,
         meta: [
-          { label: '提出日時', value: formattedSubmittedAt },
           { label: 'オファー金額', value: offer.reward != null ? `¥${offer.reward.toLocaleString('ja-JP')}` : '未設定' },
           { label: '提出者', value: offer.storeName || '未設定' },
         ],
-        secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
       }
     }
 
@@ -214,11 +212,7 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
         title: '承認',
         description: '承認状況を確認し、必要に応じてメッセージで調整してください。',
         badge: statusBadge(offer.status),
-        meta: [
-          { label: '承認期限', value: formattedRespondDeadline },
-          { label: '最終更新', value: formattedUpdatedAt },
-        ],
-        secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
+        meta: [{ label: '承認状況', value: getStatusText(offer.status) }],
       }
     }
 
@@ -229,9 +223,7 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
         badge: activeStatus === 'complete' ? <Badge variant="success">完了</Badge> : undefined,
         meta: [
           { label: '来店日時', value: formattedVisitDate },
-          { label: '最終更新', value: formattedUpdatedAt },
         ],
-        secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
       }
     }
 
@@ -247,7 +239,7 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
           ),
         }
       : result
-  }, [activeStep, activeStatus, cancelation, formattedRespondDeadline, formattedSubmittedAt, formattedUpdatedAt, formattedVisitDate, mainActionDetail, offer.id, offer.reward, offer.status, offer.storeName])
+  }, [activeStep, activeStatus, cancelation, formattedVisitDate, mainActionDetail, offer.id, offer.reward, offer.status, offer.storeName])
 
   return (
     <Card className="rounded-xl border border-slate-200 bg-white shadow-sm">
@@ -260,7 +252,7 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
       </CardHeader>
       <CardContent className="space-y-4 p-4 sm:p-5">
         {detail.meta && detail.meta.length > 0 && (
-          <dl className="grid gap-3 rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm sm:grid-cols-2">
+          <dl className="grid gap-3 text-sm sm:grid-cols-2">
             {detail.meta.map(item => (
               <div key={item.label} className="space-y-0.5">
                 <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{item.label}</dt>
@@ -270,7 +262,6 @@ export default function StepDetailCard({ activeStep, activeStatus, offer, invoic
           </dl>
         )}
         <div className="flex flex-wrap justify-end gap-2.5">
-          {detail.secondaryAction && <div className="inline-flex">{detail.secondaryAction}</div>}
           {detail.primaryAction && <div className="inline-flex">{detail.primaryAction}</div>}
         </div>
         {detail.footer && <div className="space-y-4 border-t border-dashed border-slate-200 pt-4">{detail.footer}</div>}

--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -109,9 +109,6 @@ export default async function StoreOfferPage({ params }: PageProps) {
   })
 
   const formattedUpdatedAt = format(new Date(offer.updatedAt), 'yyyy/MM/dd HH:mm', { locale: ja })
-  const formattedSubmittedAt = offer.submittedAt
-    ? format(new Date(offer.submittedAt), 'yyyy/MM/dd HH:mm', { locale: ja })
-    : '未提出'
 
   const statusLabel = getStatusLabel(offer.status)
   const statusClassName = getStatusBadgeClassName(offer.status)
@@ -132,15 +129,13 @@ export default async function StoreOfferPage({ params }: PageProps) {
                   <span className="text-slate-300">/</span>
                   <span>{offer.storeName || '店舗未設定'}</span>
                 </div>
-                <span className="inline-flex h-4 w-px bg-slate-200" aria-hidden="true" />
-                <span>{formattedSubmittedAt}</span>
                 <Badge className={cn('flex items-center gap-1', statusClassName)}>{statusLabel}</Badge>
               </div>
             </div>
-            <div className="text-xs text-slate-500 md:text-right">
-              <div className="font-medium text-slate-400">最終更新日時</div>
-              <div>{formattedUpdatedAt}</div>
-            </div>
+              <div className="text-xs text-slate-500 md:text-right">
+                <div className="font-medium text-slate-400">最終更新日時</div>
+                <div>{formattedUpdatedAt}</div>
+              </div>
           </div>
           </section>
 

--- a/talentify-next-frontend/app/talent/offers/[id]/StepDetailCard.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/StepDetailCard.tsx
@@ -74,8 +74,6 @@ export default function StepDetailCard({
   onDeclineOffer,
   actionLoading,
 }: StepDetailCardProps) {
-  const formattedSubmittedAt = useMemo(() => offer.submittedAt ? format(new Date(offer.submittedAt), 'yyyy/MM/dd HH:mm', { locale: ja }) : '未提出', [offer.submittedAt])
-  const formattedUpdatedAt = useMemo(() => format(new Date(offer.updatedAt), 'yyyy/MM/dd HH:mm', { locale: ja }), [offer.updatedAt])
   const formattedVisitDate = useMemo(() => offer.date ? format(new Date(offer.date), 'yyyy/MM/dd (EEE) HH:mm', { locale: ja }) : '未設定', [offer.date])
 
   const mainActionDetail = useMemo<StepDetail>(() => {
@@ -95,7 +93,6 @@ export default function StepDetailCard({
           badge: <Badge variant="outline">請求待ち</Badge>,
           meta: [{ label: '請求書ステータス', value: offer.invoiceStatusLabel }],
           primaryAction: <Button className={primaryActionClass} asChild><Link href={`/talent/invoices/new?offerId=${offer.id}`}>請求書を作成する</Link></Button>,
-          secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
         }
       case 'payment_waiting':
         return {
@@ -104,7 +101,6 @@ export default function StepDetailCard({
           badge: <Badge variant="outline">支払い待ち</Badge>,
           meta: [{ label: '支払い状態', value: offer.paymentStatusLabel }],
           primaryAction: invoiceId ? <Button className={primaryActionClass} asChild><Link href={`/talent/invoices/${invoiceId}`}>請求書を見る</Link></Button> : paymentLink ? <Button className={primaryActionClass} asChild><Link href={paymentLink}>状況を確認する</Link></Button> : undefined,
-          secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
         }
       case 'review_available':
         return {
@@ -113,7 +109,6 @@ export default function StepDetailCard({
           badge: <Badge variant="success">レビューあり</Badge>,
           meta: [{ label: 'レビュー状態', value: '店舗レビューあり' }],
           primaryAction: <Button className={primaryActionClass} asChild><Link href="/talent/reviews">レビューを確認する</Link></Button>,
-          secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
         }
       case 'completed':
         return {
@@ -122,7 +117,6 @@ export default function StepDetailCard({
           badge: <Badge variant="success">全完了</Badge>,
           meta: [{ label: 'レビュー状態', value: '確認済み' }],
           primaryAction: <Button className={primaryActionClass} asChild><Link href="/talent/reviews">レビューを確認する</Link></Button>,
-          secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
         }
       case 'payment_completed_review_waiting':
         return {
@@ -130,14 +124,12 @@ export default function StepDetailCard({
           description: '支払いは完了しています。店舗レビューの投稿をお待ちください。',
           badge: <Badge>レビュー待ち</Badge>,
           meta: [{ label: '支払い状態', value: offer.paymentStatusLabel }],
-          secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
         }
       default:
         return {
           title: '請求書の準備がこれからです',
           description: 'まだ請求書が作成されていない状態です。進行ステップバーで状況を確認してください。',
           badge: <Badge variant="outline">準備中</Badge>,
-          secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
         }
     }
   }, [offer.status, offer.invoiceStatus, offer.paid, offer.reviewCompleted, offer.invoiceStatusLabel, offer.paymentStatusLabel, offer.id, invoiceId, paymentLink])
@@ -153,10 +145,8 @@ export default function StepDetailCard({
         description: '店舗からオファーが届きました。内容を確認して、承諾または辞退を選択してください。',
         badge: activeStatus === 'complete' ? <Badge variant="success">完了</Badge> : undefined,
         meta: [
-          { label: '提出日時', value: formattedSubmittedAt },
           { label: '来店予定', value: formattedVisitDate },
         ],
-        secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
       }
     }
 
@@ -168,16 +158,13 @@ export default function StepDetailCard({
         badge: status.badge,
         meta: [
           { label: 'ステータス', value: status.text },
-          { label: '最終更新', value: formattedUpdatedAt },
         ],
         primaryAction: offer.status === 'pending' && onAcceptOffer ? (
           <Button className={primaryActionClass} onClick={onAcceptOffer} disabled={actionLoading !== null}>{actionLoading === 'accept' ? '承諾中...' : '承諾'}</Button>
         ) : undefined,
         secondaryAction: offer.status === 'pending' && onDeclineOffer ? (
           <Button variant="outline" className={secondaryActionClass} onClick={onDeclineOffer} disabled={actionLoading !== null}>{actionLoading === 'decline' ? '辞退中...' : '辞退'}</Button>
-        ) : (
-          <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>
-        ),
+        ) : undefined,
       }
     }
 
@@ -187,11 +174,9 @@ export default function StepDetailCard({
       badge: activeStatus === 'complete' ? <Badge variant="success">完了</Badge> : undefined,
       meta: [
         { label: '来店日時', value: formattedVisitDate },
-        { label: '最終更新', value: formattedUpdatedAt },
       ],
-      secondaryAction: <Button variant="outline" className={secondaryActionClass} asChild><a href="#offer-messages">メッセージを送る</a></Button>,
     }
-  }, [activeStep, activeStatus, mainActionDetail, formattedSubmittedAt, formattedUpdatedAt, formattedVisitDate, offer.status, onAcceptOffer, onDeclineOffer, actionLoading])
+  }, [activeStep, activeStatus, mainActionDetail, formattedVisitDate, offer.status, onAcceptOffer, onDeclineOffer, actionLoading])
 
   return (
     <Card className="rounded-xl border border-slate-200 bg-white shadow-sm">
@@ -204,7 +189,7 @@ export default function StepDetailCard({
       </CardHeader>
       <CardContent className="space-y-4 p-4 sm:p-5">
         {detail.meta && detail.meta.length > 0 && (
-          <dl className="grid gap-3 rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm sm:grid-cols-2">
+          <dl className="grid gap-3 text-sm sm:grid-cols-2">
             {detail.meta.map(item => (
               <div key={item.label} className="space-y-0.5">
                 <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{item.label}</dt>

--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -131,9 +131,6 @@ export default function TalentOfferPage() {
   const showActions = ['accepted', 'confirmed', 'completed'].includes(offer.status)
   const paymentLink = showActions && invoiceId ? `/talent/invoices/${invoiceId}` : undefined
   const formattedUpdatedAt = format(new Date(offer.updatedAt), 'yyyy/MM/dd HH:mm', { locale: ja })
-  const formattedSubmittedAt = offer.submittedAt
-    ? format(new Date(offer.submittedAt), 'yyyy/MM/dd HH:mm', { locale: ja })
-    : '未提出'
   const statusLabel = getStatusLabel(offer.status)
   const statusClassName = getStatusBadgeClassName(offer.status)
 
@@ -158,8 +155,6 @@ export default function TalentOfferPage() {
                     <span className="text-slate-300">/</span>
                     <span>{offer.performerName || 'タレント未設定'}</span>
                   </div>
-                  <span className="inline-flex h-4 w-px bg-slate-200" aria-hidden="true" />
-                  <span>{formattedSubmittedAt}</span>
                   <Badge className={cn('flex items-center gap-1', statusClassName)}>{statusLabel}</Badge>
                 </div>
               </div>


### PR DESCRIPTION
### Motivation

- オファー詳細ページ（store / talent）で同じ意味の日時が複数箇所に出て冗長になっているため表示を整理しました。 
- メッセージ送信導線が左カラムと右カラムの二重になっているため導線を一本化しました。 
- カード内に残っている二重背景（内側の薄グレーのラッパー）を削除して視認性を向上しました。

### Description

- `app/store/offers/[id]/page.tsx` と `app/talent/offers/[id]/page.tsx` のヘッダー表示を統一し、ヘッダーは「最終更新日時」のみ表示するように変更しました。 
- `app/store/offers/[id]/StepDetailCard.tsx` と `app/talent/offers/[id]/StepDetailCard.tsx` でステップ詳細内の重複日時メタを削除または最小化し、各ステップは必要最小限の日時のみになるよう整理しました（例: 来店実施は「来店日時」のみ保持、承認や提出の重複日時を削除）。 
- 上記 `StepDetailCard` ファイル群で各フェーズにあった左カラム側の「メッセージを送る」ボタン（`secondaryAction`）を撤去して、メッセージ送信を右カラムの `MessageCard` に一本化しました。 
- ステップ詳細のメタ情報を包んでいた内側の薄グレー背景と枠（`bg-slate-50`, 内側 `dl` のボーダー/パディング）を削除して、白カード直下に情報が並ぶフラットな構造に変更しました。 
- 不要になった日時フォーマット変数を削除し、必要な箇所のみで `formattedVisitDate` / `formattedUpdatedAt` を使用するようにリファクタリングし、小さな補助関数（`getStatusText`）を追加しました。 
- 変更対象ファイル: `app/store/offers/[id]/page.tsx`, `app/store/offers/[id]/StepDetailCard.tsx`, `app/talent/offers/[id]/page.tsx`, `app/talent/offers/[id]/StepDetailCard.tsx`。

### Testing

- `cd talentify-next-frontend && npx eslint app/store/offers/[id]/page.tsx app/talent/offers/[id]/page.tsx app/store/offers/[id]/StepDetailCard.tsx app/talent/offers/[id]/StepDetailCard.tsx` を実行し、ESLint による指摘はありませんでした。 
- ユニットテスト/ビルドは今回実行しておらず、影響範囲の確認は lint 結果と目視差分での確認にとどめています。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca01df2a88332993d3cfa9f744153)