### PR TITLE
Improve /store reviews, invoices, and settings page UI

### DIFF
--- a/talentify-next-frontend/app/store/invoices/page.tsx
+++ b/talentify-next-frontend/app/store/invoices/page.tsx
@@ -12,12 +12,12 @@ import { formatJaDateTimeWithWeekday } from '@/utils/formatJaDateTimeWithWeekday
 import { getInvoiceStatusLabel, getPaymentStatusLabel } from '@/lib/invoices/status'
 
 function renderStatus(inv: Invoice) {
-  return <Badge variant='outline'>{getInvoiceStatusLabel(inv.status)}</Badge>
+  return <Badge variant='secondary'>{getInvoiceStatusLabel(inv.status)}</Badge>
 }
 
 function renderPaymentStatus(inv: Invoice) {
   return (
-    <Badge variant={inv.offers?.paid ? 'success' : 'secondary'}>
+    <Badge variant={inv.offers?.paid ? 'success' : 'outline'}>
       {getPaymentStatusLabel(inv.payment_status, inv.offers?.paid)}
     </Badge>
   )
@@ -35,49 +35,53 @@ export default function StoreInvoicesPage() {
   }, [])
 
   return (
-    <main className='p-6 space-y-4'>
-      <h1 className='text-xl font-bold'>請求一覧</h1>
-      {loading ? (
-        <TableSkeleton rows={3} />
-      ) : invoices.length === 0 ? (
-        <EmptyState title='まだ請求がありません' />
-      ) : (
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>作成日</TableHead>
-              <TableHead>金額</TableHead>
-              <TableHead>請求書ステータス</TableHead>
-              <TableHead>支払い状態</TableHead>
-              <TableHead>操作</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {invoices.map(inv => (
-              <TableRow key={inv.id}>
-                <TableCell>{formatJaDateTimeWithWeekday(inv.created_at ?? '')}</TableCell>
-                <TableCell>¥{inv.amount.toLocaleString('ja-JP')}</TableCell>
-                <TableCell>{renderStatus(inv)}</TableCell>
-                <TableCell>{renderPaymentStatus(inv)}</TableCell>
-                <TableCell>
-                  <div className='flex gap-2'>
-                    {inv.invoice_url && (
-                      <Button size='sm' variant='outline' asChild>
-                        <Link href={inv.invoice_url} target='_blank'>
-                          PDF
-                        </Link>
-                      </Button>
-                    )}
-                    <Button size='sm' asChild>
-                      <Link href={`/store/invoices/${inv.id}`}>詳細</Link>
-                    </Button>
-                  </div>
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      )}
+    <main className='min-h-screen bg-gray-100 p-6'>
+      <div className='max-w-4xl mx-auto space-y-4'>
+        <h1 className='text-xl font-bold'>請求一覧</h1>
+        <section className='rounded-2xl border border-gray-200 bg-white p-6 shadow-sm'>
+          {loading ? (
+            <TableSkeleton rows={3} />
+          ) : invoices.length === 0 ? (
+            <EmptyState title='まだ請求がありません' />
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>作成日</TableHead>
+                  <TableHead>金額</TableHead>
+                  <TableHead>請求書ステータス</TableHead>
+                  <TableHead>支払い状態</TableHead>
+                  <TableHead>操作</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {invoices.map(inv => (
+                  <TableRow key={inv.id} className='hover:bg-gray-50'>
+                    <TableCell>{formatJaDateTimeWithWeekday(inv.created_at ?? '')}</TableCell>
+                    <TableCell>¥{inv.amount.toLocaleString('ja-JP')}</TableCell>
+                    <TableCell>{renderStatus(inv)}</TableCell>
+                    <TableCell>{renderPaymentStatus(inv)}</TableCell>
+                    <TableCell>
+                      <div className='flex gap-2'>
+                        {inv.invoice_url && (
+                          <Button size='sm' variant='outline' asChild>
+                            <Link href={inv.invoice_url} target='_blank'>
+                              PDF
+                            </Link>
+                          </Button>
+                        )}
+                        <Button size='sm' asChild>
+                          <Link href={`/store/invoices/${inv.id}`}>詳細</Link>
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </section>
+      </div>
     </main>
   )
 }

--- a/talentify-next-frontend/app/store/reviews/page.tsx
+++ b/talentify-next-frontend/app/store/reviews/page.tsx
@@ -1,13 +1,38 @@
 'use client'
+
 import { useEffect, useState } from 'react'
 import { getCompletedOffersForStore, CompletedOffer } from '@/utils/getCompletedOffersForStore'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { Button } from '@/components/ui/button'
 import ReviewModal from '@/components/modals/ReviewModal'
+import {
+  Modal,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+} from '@/components/ui/modal'
+import { createClient } from '@/utils/supabase/client'
+
+type ReviewDetail = {
+  offer_id: string
+  rating: number
+  comment: string | null
+}
+
+const supabase = createClient()
+
+function renderStars(rating: number) {
+  return `${'★'.repeat(rating)}${'☆'.repeat(Math.max(5 - rating, 0))}`
+}
 
 export default function StoreReviewsPage() {
   const [offers, setOffers] = useState<CompletedOffer[]>([])
   const [loading, setLoading] = useState(true)
+  const [detailOpen, setDetailOpen] = useState(false)
+  const [selectedOffer, setSelectedOffer] = useState<CompletedOffer | null>(null)
+  const [selectedReview, setSelectedReview] = useState<ReviewDetail | null>(null)
+  const [detailLoading, setDetailLoading] = useState(false)
 
   useEffect(() => {
     const load = async () => {
@@ -18,52 +43,125 @@ export default function StoreReviewsPage() {
     load()
   }, [])
 
+  const openDetail = async (offer: CompletedOffer) => {
+    setSelectedOffer(offer)
+    setSelectedReview(null)
+    setDetailOpen(true)
+    setDetailLoading(true)
+
+    const { data, error } = await supabase
+      .from('reviews')
+      .select('offer_id, rating, comment')
+      .eq('offer_id', offer.id)
+      .order('created_at', { ascending: false })
+      .maybeSingle()
+
+    if (error) {
+      console.error('failed to fetch review detail', error)
+    }
+
+    setSelectedReview(data as ReviewDetail | null)
+    setDetailLoading(false)
+  }
+
   return (
-    <main className="p-6 space-y-4">
-      <h1 className="text-2xl font-bold">レビュー投稿済みオファー一覧</h1>
-      {loading ? (
-        <p>読み込み中...</p>
-      ) : offers.length === 0 ? (
-        <p>該当するオファーはありません。</p>
-      ) : (
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>日付</TableHead>
-              <TableHead>演者</TableHead>
-              <TableHead>レビュー</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {offers.map(o => (
-              <TableRow key={o.id}>
-                <TableCell>
-                  {new Date(o.date).toLocaleDateString('ja-JP', {
-                    year: 'numeric',
-                    month: '2-digit',
-                    day: '2-digit',
-                  })}
-                </TableCell>
-                <TableCell>{o.talent_name || o.talent_id}</TableCell>
-                <TableCell>
-                  {o.reviewed ? (
-                    <span className="text-sm text-gray-500">レビュー済</span>
-                  ) : (
-                    <ReviewModal
-                      offerId={o.id}
-                      talentId={o.talent_id}
-                      trigger={<Button size="sm">レビューする</Button>}
-                      onSubmitted={() => {
-                        setOffers(prev => prev.map(p => p.id === o.id ? { ...p, reviewed: true } : p))
-                      }}
-                    />
-                  )}
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      )}
+    <main className="min-h-screen bg-gray-100 p-6">
+      <div className="max-w-4xl mx-auto space-y-4">
+        <h1 className="text-2xl font-bold">レビュー投稿一覧</h1>
+        <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+          {loading ? (
+            <p>読み込み中...</p>
+          ) : offers.length === 0 ? (
+            <p>該当するオファーはありません。</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>日付</TableHead>
+                  <TableHead>演者</TableHead>
+                  <TableHead>レビュー</TableHead>
+                  <TableHead>詳細</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {offers.map(o => (
+                  <TableRow key={o.id} className="hover:bg-gray-50">
+                    <TableCell>
+                      {new Date(o.date).toLocaleDateString('ja-JP', {
+                        year: 'numeric',
+                        month: '2-digit',
+                        day: '2-digit',
+                      })}
+                    </TableCell>
+                    <TableCell>{o.talent_name || o.talent_id}</TableCell>
+                    <TableCell>
+                      {o.reviewed ? (
+                        <span className="text-sm text-gray-500">レビュー済</span>
+                      ) : (
+                        <ReviewModal
+                          offerId={o.id}
+                          talentId={o.talent_id}
+                          trigger={<Button size="sm">レビューする</Button>}
+                          onSubmitted={() => {
+                            setOffers(prev => prev.map(p => p.id === o.id ? { ...p, reviewed: true } : p))
+                          }}
+                        />
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={!o.reviewed}
+                        onClick={() => openDetail(o)}
+                      >
+                        詳細
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </section>
+      </div>
+
+      <Modal open={detailOpen} onOpenChange={setDetailOpen}>
+        <ModalContent>
+          <ModalHeader>
+            <ModalTitle>レビュー詳細</ModalTitle>
+          </ModalHeader>
+          {detailLoading ? (
+            <p className="text-sm text-gray-500">読み込み中...</p>
+          ) : !selectedOffer || !selectedReview ? (
+            <p className="text-sm text-gray-500">レビューが見つかりませんでした。</p>
+          ) : (
+            <div className="space-y-3 text-sm">
+              <p>
+                <span className="font-medium">日付：</span>
+                {new Date(selectedOffer.date).toLocaleDateString('ja-JP', {
+                  year: 'numeric',
+                  month: '2-digit',
+                  day: '2-digit',
+                })}
+              </p>
+              <p>
+                <span className="font-medium">評価：</span>
+                <span className="tracking-wide text-amber-500">{renderStars(selectedReview.rating)}</span>
+              </p>
+              <p>
+                <span className="font-medium">コメント：</span>
+                {selectedReview.comment || 'コメントはありません'}
+              </p>
+            </div>
+          )}
+          <ModalFooter>
+            <Button variant="outline" onClick={() => setDetailOpen(false)}>
+              閉じる
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
     </main>
   )
 }

--- a/talentify-next-frontend/app/store/settings/page.tsx
+++ b/talentify-next-frontend/app/store/settings/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
-import { SectionCard } from '@/components/settings/SectionCard'
 import { ToggleRow } from '@/components/settings/ToggleRow'
 import { Button } from '@/components/ui/button'
 import { toast } from 'sonner'
@@ -24,78 +23,76 @@ export default function StoreSettingsPage() {
   const handleTodo = () => toast('準備中（PR-1では未実装）')
 
   return (
-    <main className="max-w-screen-md mx-auto p-4 space-y-6">
-      <h1 className="text-2xl font-bold">設定</h1>
-      <p className="text-sm text-muted-foreground">
-        店舗情報の変更は
-        <Link href="/store/edit" className="underline">
-          「店舗情報」
-        </Link>
-        ページから行ってください。
-      </p>
+    <main className="min-h-screen bg-gray-100 p-6">
+      <div className="max-w-4xl mx-auto space-y-4">
+        <h1 className="text-2xl font-bold">設定</h1>
 
-      <SectionCard
-        title="アカウント設定"
-        description="メールやパスワードの変更は現在準備中です。"
-      >
-        <div className="space-y-4">
-          <div className="flex items-center justify-between py-2">
+        <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm space-y-6">
+          <p className="text-sm text-muted-foreground">
+            店舗情報の変更は
+            <Link href="/store/edit" className="underline">
+              「店舗情報」
+            </Link>
+            ページから行ってください。
+          </p>
+
+          <section className="border rounded-xl p-4 space-y-4">
             <div>
-              <p className="text-sm">メール変更</p>
-              <p className="text-xs text-muted-foreground">
-                この項目は今後有効になります（準備中）
-              </p>
+              <h2 className="text-lg font-semibold">アカウント設定</h2>
+              <p className="text-sm text-muted-foreground">メールやパスワードの変更は現在準備中です。</p>
             </div>
-            <Button variant="outline" onClick={handleTodo}>
-              変更
+            <div className="space-y-4">
+              <div className="flex items-center justify-between py-2">
+                <div>
+                  <p className="text-sm">メール変更</p>
+                  <p className="text-xs text-muted-foreground">この項目は今後有効になります（準備中）</p>
+                </div>
+                <Button variant="outline" onClick={handleTodo}>
+                  変更
+                </Button>
+              </div>
+              <div className="flex items-center justify-between py-2">
+                <div>
+                  <p className="text-sm">パスワード変更</p>
+                  <p className="text-xs text-muted-foreground">この項目は今後有効になります（準備中）</p>
+                </div>
+                <Button variant="outline" onClick={handleTodo}>
+                  変更
+                </Button>
+              </div>
+            </div>
+          </section>
+
+          <section className="border rounded-xl p-4 space-y-4">
+            <div>
+              <h2 className="text-lg font-semibold">通知設定</h2>
+              <p className="text-sm text-muted-foreground">通知のON/OFFは現在準備中です。</p>
+            </div>
+            <div className="divide-y">
+              <ToggleRow
+                id="store-notif-offer"
+                label="オファー通知"
+                description="この項目は今後有効になります（準備中）"
+                checked={notifications.offer}
+                onCheckedChange={(v) => setNotifications({ ...notifications, offer: v })}
+              />
+              <ToggleRow
+                id="store-notif-message"
+                label="メッセージ通知"
+                description="この項目は今後有効になります（準備中）"
+                checked={notifications.message}
+                onCheckedChange={(v) => setNotifications({ ...notifications, message: v })}
+              />
+            </div>
+          </section>
+
+          <div className="flex justify-end">
+            <Button onClick={handleSave} disabled={saving}>
+              {saving ? '保存中...' : '保存'}
             </Button>
           </div>
-          <div className="flex items-center justify-between py-2">
-            <div>
-              <p className="text-sm">パスワード変更</p>
-              <p className="text-xs text-muted-foreground">
-                この項目は今後有効になります（準備中）
-              </p>
-            </div>
-            <Button variant="outline" onClick={handleTodo}>
-              変更
-            </Button>
-          </div>
-        </div>
-      </SectionCard>
-
-      <SectionCard
-        title="通知設定"
-        description="通知のON/OFFは現在準備中です。"
-      >
-        <div className="divide-y">
-          <ToggleRow
-            id="store-notif-offer"
-            label="オファー通知"
-            description="この項目は今後有効になります（準備中）"
-            checked={notifications.offer}
-            onCheckedChange={(v) =>
-              setNotifications({ ...notifications, offer: v })
-            }
-          />
-          <ToggleRow
-            id="store-notif-message"
-            label="メッセージ通知"
-            description="この項目は今後有効になります（準備中）"
-            checked={notifications.message}
-            onCheckedChange={(v) =>
-              setNotifications({ ...notifications, message: v })
-            }
-          />
-        </div>
-      </SectionCard>
-
-      <div className="flex justify-end">
-        <Button onClick={handleSave} disabled={saving}>
-          {saving ? '保存中...' : '保存'}
-        </Button>
+        </section>
       </div>
     </main>
   )
 }
-


### PR DESCRIPTION
### Motivation
- Improve visibility and operability of the store-facing `reviews`, `invoices`, and `settings` pages while keeping changes scoped to those pages only.
- Apply a simple page-scoped card visual treatment (gray background + white card) and clearer sectioning to make scanning and actions faster.

### Description
- `app/store/reviews/page.tsx`: rename heading to `レビュー投稿一覧`, wrap content in a page-scoped container (`min-h-screen bg-gray-100` + `max-w-4xl mx-auto`) and a white card (`rounded-2xl border border-gray-200 bg-white p-6 shadow-sm`), add `hover:bg-gray-50` on rows, add a `詳細` button and implement a review detail modal that fetches and displays `日付 / 評価（★） / コメント` per offer using `supabase`.
- `app/store/invoices/page.tsx`: apply the same page-scoped container and white card, add row `hover:bg-gray-50`, and adjust badge variants for clearer invoice/status presentation while keeping existing actions intact.
- `app/store/settings/page.tsx`: convert to the page-scoped container and a white card, and reorganize content into bordered, rounded sub-sections for `アカウント設定` and `通知設定` (moved from `SectionCard` to in-card `section` blocks) without changing existing behavior.
- All changes are implemented within each page file so shared layouts and other pages are not modified.

### Testing
- Ran `npm run lint` in `talentify-next-frontend`, which completed successfully while pre-existing unrelated ESLint warnings remain. 
- No automated UI tests were added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca0d364408332bc78d942cc9effce)