### PR TITLE
Fix offer chat visibility between store/talent and remove nested gray chat background

### DIFF
--- a/talentify-next-frontend/app/store/offers/[id]/MessageCard.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/MessageCard.tsx
@@ -5,16 +5,18 @@ import OfferChatThread from '@/components/offer/OfferChatThread'
 type MessageCardProps = {
   offerId: string
   currentUserId: string
+  peerUserId: string
   storeName: string
   talentName: string
 }
 
-export default function MessageCard({ offerId, currentUserId, storeName, talentName }: MessageCardProps) {
+export default function MessageCard({ offerId, currentUserId, peerUserId, storeName, talentName }: MessageCardProps) {
   return (
     <div id="offer-messages" className="h-full">
       <OfferChatThread
         offerId={offerId}
         currentUserId={currentUserId}
+        peerUserId={peerUserId}
         currentRole="store"
         storeName={storeName}
         talentName={talentName}

--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -30,8 +30,8 @@ export default async function StoreOfferPage({ params }: PageProps) {
     .select(
       `
       id,status,date,respond_deadline,reward,created_at,updated_at,message,talent_id,user_id,canceled_at,accepted_at,paid,paid_at,
-      reviews(id), talents(stage_name,avatar_url),
-      store:stores!offers_store_id_fkey(id, store_name)
+      reviews(id), talents(stage_name,avatar_url,user_id),
+      store:stores!offers_store_id_fkey(id, store_name, user_id)
     `
     )
     .eq('id', params.id)
@@ -77,6 +77,7 @@ export default async function StoreOfferPage({ params }: PageProps) {
     reward: data.reward as number | null,
     talentId: data.talent_id as string | null,
     reviewCompleted,
+    talentUserId: data.talents?.user_id as string | null,
   }
 
   const invoiceData = invoice
@@ -168,6 +169,7 @@ export default async function StoreOfferPage({ params }: PageProps) {
           <MessageCard
             offerId={offer.id}
             currentUserId={user.id}
+            peerUserId={offer.talentUserId ?? ''}
             storeName={offer.storeName}
             talentName={offer.performerName}
           />

--- a/talentify-next-frontend/app/talent/offers/[id]/MessageCard.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/MessageCard.tsx
@@ -5,16 +5,18 @@ import OfferChatThread from '@/components/offer/OfferChatThread'
 type MessageCardProps = {
   offerId: string
   currentUserId: string
+  peerUserId: string
   storeName: string
   talentName: string
 }
 
-export default function MessageCard({ offerId, currentUserId, storeName, talentName }: MessageCardProps) {
+export default function MessageCard({ offerId, currentUserId, peerUserId, storeName, talentName }: MessageCardProps) {
   return (
     <div id="offer-messages" className="h-full">
       <OfferChatThread
         offerId={offerId}
         currentUserId={currentUserId}
+        peerUserId={peerUserId}
         currentRole="talent"
         storeName={storeName}
         talentName={talentName}

--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -34,8 +34,8 @@ export default function TalentOfferPage() {
         `
         id,status,date,updated_at,created_at,message,talent_id,user_id,paid,paid_at,
         reviews(id),
-        talents(stage_name,avatar_url),
-        store:stores!offers_store_id_fkey(id, store_name)
+        talents(stage_name,avatar_url,user_id),
+        store:stores!offers_store_id_fkey(id, store_name, user_id)
       `
       )
       .eq('id', params.id)
@@ -68,6 +68,7 @@ export default function TalentOfferPage() {
         invoiceStatus,
         invoiceStatusLabel: getInvoiceStatusLabel(invoice?.status),
         paymentStatusLabel: getPaymentStatusLabel(invoice?.payment_status, data.paid),
+        storeUserId: data.store?.user_id ?? null,
       })
       setInvoiceId(invoice?.id ?? null)
     } else {
@@ -191,6 +192,7 @@ export default function TalentOfferPage() {
           <MessageCard
             offerId={offer.id}
             currentUserId={userId}
+            peerUserId={offer.storeUserId ?? ''}
             storeName={offer.storeName}
             talentName={offer.performerName}
           />

--- a/talentify-next-frontend/components/offer/OfferChatInput.tsx
+++ b/talentify-next-frontend/components/offer/OfferChatInput.tsx
@@ -9,21 +9,23 @@ import { createClient } from '@/utils/supabase/client'
 interface OfferChatInputProps {
   offerId: string
   senderRole: 'store' | 'talent' | 'admin'
+  receiverUserId: string
   onSent?: (msg: any) => void
 }
 
-export default function OfferChatInput({ offerId, senderRole, onSent }: OfferChatInputProps) {
+export default function OfferChatInput({ offerId, senderRole, receiverUserId, onSent }: OfferChatInputProps) {
   const [body, setBody] = useState('')
   const [sending, setSending] = useState(false)
   const supabase = createClient()
 
   const handleSend = async () => {
-    if (!body.trim()) return
+    if (!body.trim() || !receiverUserId) return
     setSending(true)
     try {
       const message = await sendOfferMessage(supabase, {
         offerId,
         senderRole,
+        receiverUserId,
         body: body.trim() || null,
         attachments: [],
       })
@@ -52,10 +54,10 @@ export default function OfferChatInput({ offerId, senderRole, onSent }: OfferCha
         className="min-h-[96px] resize-none rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-inner"
       />
       <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-slate-500">
-        <p>Enter + Shift で改行、Enter で送信</p>
+        <p>{receiverUserId ? 'Enter + Shift で改行、Enter で送信' : '送信先ユーザー情報を読み込み中です。'}</p>
         <Button
           onClick={handleSend}
-          disabled={sending || !body.trim()}
+          disabled={sending || !body.trim() || !receiverUserId}
           className="rounded-full bg-slate-800 px-6 text-white hover:bg-slate-700"
         >
           送信

--- a/talentify-next-frontend/components/offer/OfferChatThread.tsx
+++ b/talentify-next-frontend/components/offer/OfferChatThread.tsx
@@ -18,6 +18,7 @@ import { MessageCircle } from 'lucide-react'
 interface OfferChatThreadProps {
   offerId: string
   currentUserId: string
+  peerUserId: string
   currentRole: 'store' | 'talent' | 'admin'
   storeName: string
   talentName: string
@@ -27,6 +28,7 @@ interface OfferChatThreadProps {
 export default function OfferChatThread({
   offerId,
   currentUserId,
+  peerUserId,
   currentRole,
   storeName,
   talentName,
@@ -212,8 +214,8 @@ export default function OfferChatThread({
           ))}
         </div>
       </div>
-      <div className="border-t border-slate-100 bg-slate-50 px-4 py-3">
-        <OfferChatInput offerId={offerId} senderRole={currentRole} onSent={handleSent} />
+      <div className="border-t border-slate-100 px-4 py-3">
+        <OfferChatInput offerId={offerId} senderRole={currentRole} receiverUserId={peerUserId} onSent={handleSent} />
       </div>
     </div>
   )

--- a/talentify-next-frontend/lib/supabase/offerMessages.ts
+++ b/talentify-next-frontend/lib/supabase/offerMessages.ts
@@ -12,6 +12,7 @@ export type OfferMessage = {
   id: string
   offer_id: string
   sender_user: string
+  receiver_user: string
   sender_role: 'store' | 'talent' | 'admin'
   body: string | null
   attachments: Attachment[]
@@ -41,6 +42,7 @@ export async function sendOfferMessage(
   params: {
     offerId: string
     senderRole: 'store' | 'talent' | 'admin'
+    receiverUserId: string
     body: string | null
     attachments: Attachment[]
   }
@@ -52,6 +54,7 @@ export async function sendOfferMessage(
     .insert({
       offer_id: params.offerId,
       sender_user: user.id,
+      receiver_user: params.receiverUserId,
       sender_role: params.senderRole,
       body: params.body,
       attachments: params.attachments,


### PR DESCRIPTION
### Motivation
- The offer chat thread was effectively one-sided because `receiver_user` was not being stored when sending offer messages, causing RLS/participant checks to hide the other side's messages.
- The offer detail pages for `store` and `talent` still had a thin gray wrapper behind the white chat card, producing a "card inside card" appearance.

### Description
- Persist `receiver_user` when creating offer messages by adding `receiver_user` to the `OfferMessage` type and `sendOfferMessage` params and inserting `receiver_user` in the DB insert. (`lib/supabase/offerMessages.ts`, `sendOfferMessage`)
- Wire counterparty user id through the stack by adding `peerUserId` to `OfferChatThread` and `MessageCard`, retrieving `talents.user_id` on store pages and `store.user_id` on talent pages and passing them as `peerUserId` to the chat components. (`app/store/offers/[id]/page.tsx`, `app/talent/offers/[id]/page.tsx`, `app/*/MessageCard.tsx`, `components/offer/OfferChatThread.tsx`)
- Make the chat composer include `receiverUserId` in `sendOfferMessage` calls and prevent sending until the receiver id is available. (`components/offer/OfferChatInput.tsx`)
- Remove the thin gray sub-background behind the chat input by deleting `bg-slate-50` from the chat thread footer so the layout is page-gray background → white cards only. (`components/offer/OfferChatThread.tsx`)
- Preserve existing thread retrieval semantics by continuing to load messages by `offer_id` only (no sender-based narrowing), while keeping left/right bubble alignment based on `message.sender_user`. (`lib/supabase/offerMessages.ts`, `components/offer/ChatMessageBubble.tsx`)

### Testing
- Ran `npm run lint` in `talentify-next-frontend`, which completed successfully with only existing non-blocking warnings about `<img>` usage unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca63ae7248332b306f7f90d5fc58d)