### PR TITLE
Unify layout for four store pages and improve reviews table UX

### DIFF
--- a/talentify-next-frontend/app/store/edit/EditClient.tsx
+++ b/talentify-next-frontend/app/store/edit/EditClient.tsx
@@ -200,65 +200,67 @@ export default function StoreProfileEditPage() {
   if (loading) return <p className="p-4">読み込み中...</p>
 
   return (
-    <main className="bg-gray-100 px-4 py-8 sm:px-6">
-      <div className="mx-auto w-full max-w-2xl rounded-2xl border border-gray-200 bg-white p-6 shadow-sm space-y-6">
-        {errorMessage && <p className="text-sm text-red-500">{errorMessage}</p>}
-        {showIncomplete && !errorMessage && (
-          <div className="rounded-lg bg-yellow-100 p-2 text-sm text-yellow-800">
-            プロフィールが未完成です
-          </div>
-        )}
-        <h1 className="text-xl font-semibold">店舗プロフィール編集</h1>
+    <main className="min-h-screen bg-gray-100 px-4 py-10">
+      <div className="mx-auto w-full max-w-5xl">
+        <h1 className="mb-6 text-3xl font-bold tracking-tight">店舗プロフィール編集</h1>
+        <section className="space-y-6 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+          {errorMessage && <p className="text-sm text-red-500">{errorMessage}</p>}
+          {showIncomplete && !errorMessage && (
+            <div className="rounded-lg bg-yellow-100 p-2 text-sm text-yellow-800">
+              プロフィールが未完成です
+            </div>
+          )}
 
-        <div className="space-y-4">
-          <div className="space-y-1.5">
-            <label className="block text-sm font-medium">店舗名（表示名）</label>
-            <Input
-              name="store_name"
-              value={profile.store_name}
-              onChange={handleChange}
-              className="rounded-lg border border-gray-300 bg-white focus-visible:ring-2 focus-visible:ring-blue-500"
-            />
-          </div>
-
-          <div className="space-y-1.5">
-            <label className="block text-sm font-medium">自己紹介</label>
-            <Textarea
-              name="bio"
-              value={profile.bio}
-              onChange={handleChange}
-              rows={4}
-              className="rounded-lg border border-gray-300 bg-white focus-visible:ring-2 focus-visible:ring-blue-500"
-            />
-          </div>
-
-          <div className="space-y-1.5">
-            <label className="block text-sm font-medium">アバター画像</label>
-            {avatarPreview && (
-              <img
-                src={avatarPreview}
-                alt="avatar preview"
-                className="mb-2 h-24 w-24 rounded-lg object-cover"
+          <div className="space-y-4">
+            <div className="space-y-1.5">
+              <label className="block text-sm font-medium">店舗名（表示名）</label>
+              <Input
+                name="store_name"
+                value={profile.store_name}
+                onChange={handleChange}
+                className="rounded-lg border border-gray-300 bg-white focus-visible:ring-2 focus-visible:ring-blue-500"
               />
-            )}
-            <Input
-              type="file"
-              accept="image/png,image/jpeg,image/webp"
-              onChange={handleAvatar}
-              className="rounded-lg border border-gray-300 bg-white focus-visible:ring-2 focus-visible:ring-blue-500"
-            />
-            <p className="text-sm text-gray-500">5MBまで／対応：PNG・JPG・WEBP</p>
-            {errors.avatar && <p className="text-sm text-red-500">{errors.avatar}</p>}
-          </div>
+            </div>
 
-          <Button
-            onClick={handleSave}
-            className="mt-4 w-full bg-blue-600 text-white hover:bg-blue-700"
-            disabled={saving}
-          >
-            {saving ? '保存中...' : '保存する'}
-          </Button>
-        </div>
+            <div className="space-y-1.5">
+              <label className="block text-sm font-medium">自己紹介</label>
+              <Textarea
+                name="bio"
+                value={profile.bio}
+                onChange={handleChange}
+                rows={4}
+                className="rounded-lg border border-gray-300 bg-white focus-visible:ring-2 focus-visible:ring-blue-500"
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <label className="block text-sm font-medium">アバター画像</label>
+              {avatarPreview && (
+                <img
+                  src={avatarPreview}
+                  alt="avatar preview"
+                  className="mb-2 h-24 w-24 rounded-lg object-cover"
+                />
+              )}
+              <Input
+                type="file"
+                accept="image/png,image/jpeg,image/webp"
+                onChange={handleAvatar}
+                className="rounded-lg border border-gray-300 bg-white focus-visible:ring-2 focus-visible:ring-blue-500"
+              />
+              <p className="text-sm text-gray-500">5MBまで／対応：PNG・JPG・WEBP</p>
+              {errors.avatar && <p className="text-sm text-red-500">{errors.avatar}</p>}
+            </div>
+
+            <Button
+              onClick={handleSave}
+              className="mt-4 w-full bg-blue-600 text-white hover:bg-blue-700"
+              disabled={saving}
+            >
+              {saving ? '保存中...' : '保存する'}
+            </Button>
+          </div>
+        </section>
       </div>
     </main>
   )

--- a/talentify-next-frontend/app/store/invoices/page.tsx
+++ b/talentify-next-frontend/app/store/invoices/page.tsx
@@ -35,9 +35,9 @@ export default function StoreInvoicesPage() {
   }, [])
 
   return (
-    <main className='min-h-screen bg-gray-100 p-6'>
-      <div className='max-w-4xl mx-auto space-y-4'>
-        <h1 className='text-xl font-bold'>請求一覧</h1>
+    <main className='min-h-screen bg-gray-100 px-4 py-10'>
+      <div className='mx-auto w-full max-w-5xl'>
+        <h1 className='mb-6 text-3xl font-bold tracking-tight'>請求一覧</h1>
         <section className='rounded-2xl border border-gray-200 bg-white p-6 shadow-sm'>
           {loading ? (
             <TableSkeleton rows={3} />

--- a/talentify-next-frontend/app/store/reviews/page.tsx
+++ b/talentify-next-frontend/app/store/reviews/page.tsx
@@ -20,6 +20,11 @@ type ReviewDetail = {
   comment: string | null
 }
 
+type ReviewSummary = {
+  offer_id: string
+  rating: number
+}
+
 const supabase = createClient()
 
 function renderStars(rating: number) {
@@ -28,6 +33,7 @@ function renderStars(rating: number) {
 
 export default function StoreReviewsPage() {
   const [offers, setOffers] = useState<CompletedOffer[]>([])
+  const [reviewByOfferId, setReviewByOfferId] = useState<Record<string, ReviewSummary>>({})
   const [loading, setLoading] = useState(true)
   const [detailOpen, setDetailOpen] = useState(false)
   const [selectedOffer, setSelectedOffer] = useState<CompletedOffer | null>(null)
@@ -38,6 +44,24 @@ export default function StoreReviewsPage() {
     const load = async () => {
       const data = await getCompletedOffersForStore()
       setOffers(data)
+      if (data.length > 0) {
+        const offerIds = data.map((offer) => offer.id)
+        const { data: reviewData, error } = await supabase
+          .from('reviews')
+          .select('offer_id, rating')
+          .in('offer_id', offerIds)
+        if (error) {
+          console.error('failed to fetch review summary', error)
+        } else {
+          const summaryMap = (reviewData ?? []).reduce<Record<string, ReviewSummary>>((acc, item) => {
+            if (!acc[item.offer_id]) {
+              acc[item.offer_id] = item as ReviewSummary
+            }
+            return acc
+          }, {})
+          setReviewByOfferId(summaryMap)
+        }
+      }
       setLoading(false)
     }
     load()
@@ -65,9 +89,9 @@ export default function StoreReviewsPage() {
   }
 
   return (
-    <main className="min-h-screen bg-gray-100 p-6">
-      <div className="max-w-4xl mx-auto space-y-4">
-        <h1 className="text-2xl font-bold">レビュー投稿一覧</h1>
+    <main className="min-h-screen bg-gray-100 px-4 py-10">
+      <div className="mx-auto w-full max-w-5xl">
+        <h1 className="mb-6 text-3xl font-bold tracking-tight">レビュー投稿一覧</h1>
         <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
           {loading ? (
             <p>読み込み中...</p>
@@ -79,7 +103,7 @@ export default function StoreReviewsPage() {
                 <TableRow>
                   <TableHead>日付</TableHead>
                   <TableHead>演者</TableHead>
-                  <TableHead>レビュー</TableHead>
+                  <TableHead>評価</TableHead>
                   <TableHead>詳細</TableHead>
                 </TableRow>
               </TableHeader>
@@ -95,15 +119,29 @@ export default function StoreReviewsPage() {
                     </TableCell>
                     <TableCell>{o.talent_name || o.talent_id}</TableCell>
                     <TableCell>
-                      {o.reviewed ? (
-                        <span className="text-sm text-gray-500">レビュー済</span>
+                      {reviewByOfferId[o.id] ? (
+                        <span className="tracking-wide text-amber-500">
+                          {renderStars(reviewByOfferId[o.id].rating)}
+                        </span>
                       ) : (
                         <ReviewModal
                           offerId={o.id}
                           talentId={o.talent_id}
                           trigger={<Button size="sm">レビューする</Button>}
-                          onSubmitted={() => {
+                          onSubmitted={async () => {
                             setOffers(prev => prev.map(p => p.id === o.id ? { ...p, reviewed: true } : p))
+                            const { data: latestReview } = await supabase
+                              .from('reviews')
+                              .select('offer_id, rating')
+                              .eq('offer_id', o.id)
+                              .order('created_at', { ascending: false })
+                              .maybeSingle()
+                            if (latestReview) {
+                              setReviewByOfferId((prev) => ({
+                                ...prev,
+                                [o.id]: latestReview as ReviewSummary,
+                              }))
+                            }
                           }}
                         />
                       )}
@@ -112,7 +150,7 @@ export default function StoreReviewsPage() {
                       <Button
                         size="sm"
                         variant="outline"
-                        disabled={!o.reviewed}
+                        disabled={!reviewByOfferId[o.id]}
                         onClick={() => openDetail(o)}
                       >
                         詳細

--- a/talentify-next-frontend/app/store/settings/page.tsx
+++ b/talentify-next-frontend/app/store/settings/page.tsx
@@ -23,9 +23,9 @@ export default function StoreSettingsPage() {
   const handleTodo = () => toast('準備中（PR-1では未実装）')
 
   return (
-    <main className="min-h-screen bg-gray-100 p-6">
-      <div className="max-w-4xl mx-auto space-y-4">
-        <h1 className="text-2xl font-bold">設定</h1>
+    <main className="min-h-screen bg-gray-100 px-4 py-10">
+      <div className="mx-auto w-full max-w-5xl">
+        <h1 className="mb-6 text-3xl font-bold tracking-tight">設定</h1>
 
         <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm space-y-6">
           <p className="text-sm text-muted-foreground">
@@ -36,7 +36,7 @@ export default function StoreSettingsPage() {
             ページから行ってください。
           </p>
 
-          <section className="border rounded-xl p-4 space-y-4">
+          <section className="space-y-4 rounded-xl border border-gray-200 p-4">
             <div>
               <h2 className="text-lg font-semibold">アカウント設定</h2>
               <p className="text-sm text-muted-foreground">メールやパスワードの変更は現在準備中です。</p>
@@ -63,7 +63,7 @@ export default function StoreSettingsPage() {
             </div>
           </section>
 
-          <section className="border rounded-xl p-4 space-y-4">
+          <section className="space-y-4 rounded-xl border border-gray-200 p-4">
             <div>
               <h2 className="text-lg font-semibold">通知設定</h2>
               <p className="text-sm text-muted-foreground">通知のON/OFFは現在準備中です。</p>


### PR DESCRIPTION
### Motivation
- Make the four store management pages `/store/edit`, `/store/reviews`, `/store/invoices`, and `/store/settings` share a consistent visual hierarchy and spacing while keeping the change scoped to those pages only.
- Ensure page titles live outside the content card and the content itself is presented inside a white rounded card to clarify hierarchy between page heading and content.
- Improve the reviews listing to show meaningful columns (date / performer / rating / detail) and remove the previous unhelpful “レビュー済” display.

### Description
- Standardized outer shell on the four pages to `min-h-screen bg-gray-100 px-4 py-10` with an inner wrapper `w-full max-w-5xl mx-auto` and moved the `h1` outside the white card with `mb-6 text-3xl font-bold tracking-tight` styling.
- Wrapped each page’s content region in a white card using `rounded-2xl shadow-sm border border-gray-200 bg-white p-6` and kept page-specific internals inside that card without touching global layout components.
- `/store/edit`: moved the page title outside the card, kept the form inside the white card, preserved the existing save button appearance while adjusting surrounding spacing. (`app/store/edit/EditClient.tsx`)
- `/store/reviews`: changed table columns to `日付 / 演者 / 評価 / 詳細`, removed the old “レビュー済” label, added a backend fetch to preload review ratings per offer and render star summaries, and kept the modal detail view reachable from the `詳細` button; the detail button is enabled only when a review exists and new reviews update the summary map after submission. (`app/store/reviews/page.tsx`)
- `/store/invoices` and `/store/settings`: moved headings outside the card and aligned width / spacing / heading sizes to match the other pages, while preserving internal sections and controls. (`app/store/invoices/page.tsx`, `app/store/settings/page.tsx`)
- All edits are limited to the four files and avoid large changes to shared components.

### Testing
- Ran lint with `npm run lint` in `talentify-next-frontend`, which completed successfully; existing non-blocking warnings about using raw `<img>` elements (including one in the edited edit page) remain but were not introduced by this PR.
- No other automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcab7b4d4c83329964595850050793)