### PR TITLE
Remove gray wrapper background from offer detail pages

### DIFF
--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -115,7 +115,7 @@ export default async function StoreOfferPage({ params }: PageProps) {
   const statusClassName = getStatusBadgeClassName(offer.status)
 
   return (
-    <div className="bg-slate-50 p-3 sm:p-5 lg:p-6">
+    <div className="p-3 sm:p-5 lg:p-6">
       <div className="mx-auto grid w-full max-w-6xl gap-4 lg:grid-cols-3 lg:items-start">
         <div className="space-y-4 lg:col-span-2">
           <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm sm:p-5">

--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -143,7 +143,7 @@ export default function TalentOfferPage() {
   })
 
   return (
-    <div className="bg-slate-50 p-3 sm:p-5 lg:p-6">
+    <div className="p-3 sm:p-5 lg:p-6">
       <div className="mx-auto grid w-full max-w-6xl gap-4 lg:grid-cols-3 lg:items-start">
         <div className="space-y-4 lg:col-span-2">
           <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm sm:p-5">


### PR DESCRIPTION
### Motivation
- Remove the extra light-gray wrapper behind the white cards on offer detail pages so the visual structure is: page background (light gray) → white cards.

### Description
- Removed the `bg-slate-50` class from the top-level wrapper in `app/store/offers/[id]/page.tsx` and `app/talent/offers/[id]/page.tsx`, while preserving the padding (`p-3 sm:p-5 lg:p-6`) and existing grid/layout classes.

### Testing
- Ran `npm run lint -- --file app/store/offers/[id]/page.tsx --file app/talent/offers/[id]/page.tsx` and ESLint reported no warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcac5559b083328d01b8820c44cdd6)