### PR TITLE
Compact LINE-like chat UI for offer messages (store & talent)

### DIFF
--- a/talentify-next-frontend/components/offer/ChatMessageBubble.tsx
+++ b/talentify-next-frontend/components/offer/ChatMessageBubble.tsx
@@ -20,57 +20,44 @@ export default function ChatMessageBubble({
 }: ChatMessageBubbleProps) {
   const isMine = message.sender_user === currentUserId
   const supabase = createClient()
-  const time = format(new Date(message.created_at), 'yyyy/MM/dd HH:mm')
+  const time = format(new Date(message.created_at), 'HH:mm')
   const read = isMine && peerLastReadAt && new Date(peerLastReadAt) >= new Date(message.created_at)
 
   return (
-    <div className={clsx('mb-3 flex', isMine ? 'justify-end' : 'justify-start')}>
-      <div
-        className={clsx(
-          'max-w-[80%] rounded-3xl px-5 py-4 text-sm shadow-md',
-          isMine ? 'bg-blue-600 text-white' : 'bg-slate-100 text-slate-900'
-        )}
-      >
-        <div className="space-y-1">
-          <p className={clsx('text-sm font-semibold', isMine ? 'text-white' : 'text-slate-900')}>{senderName}</p>
-          <p className={clsx('text-xs', isMine ? 'text-white/80' : 'text-slate-500')}>{time}</p>
-        </div>
-        {message.body && (
-          <p className={clsx('mt-3 whitespace-pre-wrap break-words text-sm', isMine ? 'text-white' : 'text-slate-900')}>
-            {message.body}
-          </p>
-        )}
-        {message.attachments?.map(att => {
-          const { data } = supabase.storage.from('offer-attachments').getPublicUrl(att.path)
-          const url = data.publicUrl
-          if (att.type.startsWith('image/')) {
+    <div className={clsx('flex', isMine ? 'justify-end' : 'justify-start')}>
+      <div className={clsx('flex max-w-[72%] flex-col', isMine ? 'items-end' : 'items-start')}>
+        {!isMine && <p className="mb-1 px-1 text-[11px] font-medium text-slate-500">{senderName}</p>}
+
+        <div
+          className={clsx(
+            'rounded-2xl px-3 py-2 text-sm leading-relaxed',
+            isMine ? 'bg-emerald-500 text-white' : 'bg-slate-100 text-slate-900',
+          )}
+        >
+          {message.body && <p className="whitespace-pre-wrap break-words">{message.body}</p>}
+          {message.attachments?.map(att => {
+            const { data } = supabase.storage.from('offer-attachments').getPublicUrl(att.path)
+            const url = data.publicUrl
+            if (att.type.startsWith('image/')) {
+              return <img key={att.path} src={url} alt={att.name} className="mt-2 max-w-full rounded-md" />
+            }
             return (
-              <img
+              <a
                 key={att.path}
-                src={url}
-                alt={att.name}
-                className="mt-3 max-w-full rounded-md"
-              />
+                href={url}
+                target="_blank"
+                rel="noreferrer"
+                className={clsx('mt-2 block text-xs underline', isMine ? 'text-white' : 'text-emerald-700')}
+              >
+                {att.name} ({Math.round(att.size / 1024)}KB)
+              </a>
             )
-          }
-          return (
-            <a
-              key={att.path}
-              href={url}
-              target="_blank"
-              rel="noreferrer"
-              className={clsx(
-                'mt-3 block text-sm underline',
-                isMine ? 'text-white' : 'text-blue-600'
-              )}
-            >
-              {att.name} ({Math.round(att.size / 1024)}KB)
-            </a>
-          )
-        })}
-        {isMine && read && (
-          <div className="mt-3 text-right text-[11px] text-white/80">既読</div>
-        )}
+          })}
+        </div>
+
+        <p className={clsx('mt-1 px-1 text-[10px]', isMine ? 'text-right text-slate-400' : 'text-slate-400')}>
+          {isMine && read ? `既読 ${time}` : time}
+        </p>
       </div>
     </div>
   )

--- a/talentify-next-frontend/components/offer/OfferChatInput.tsx
+++ b/talentify-next-frontend/components/offer/OfferChatInput.tsx
@@ -44,23 +44,23 @@ export default function OfferChatInput({ offerId, senderRole, receiverUserId, on
   }
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-2.5">
       <Textarea
         value={body}
         onChange={e => setBody(e.target.value)}
         onKeyDown={onKeyDown}
-        placeholder="メッセージを入力..."
-        rows={3}
-        className="min-h-[96px] resize-none rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-inner"
+        placeholder="メッセージを入力"
+        rows={2}
+        className="min-h-[72px] resize-none rounded-3xl border border-slate-200 bg-white px-4 py-2.5 text-sm shadow-sm focus-visible:border-emerald-400 focus-visible:ring-emerald-200"
       />
-      <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-slate-500">
-        <p>{receiverUserId ? 'Enter + Shift で改行、Enter で送信' : '送信先ユーザー情報を読み込み中です。'}</p>
+      <div className="flex flex-wrap items-center justify-between gap-2 text-[11px] text-slate-400">
+        <p>{receiverUserId ? 'Shift + Enter で改行 / Enter で送信' : '送信先ユーザー情報を読み込み中です。'}</p>
         <Button
           onClick={handleSend}
           disabled={sending || !body.trim() || !receiverUserId}
-          className="rounded-full bg-slate-800 px-6 text-white hover:bg-slate-700"
+          className="rounded-full bg-emerald-500 px-5 text-white transition hover:bg-emerald-600 disabled:bg-slate-300"
         >
-          送信
+          {sending ? '送信中...' : '送信'}
         </Button>
       </div>
     </div>

--- a/talentify-next-frontend/components/offer/OfferChatThread.tsx
+++ b/talentify-next-frontend/components/offer/OfferChatThread.tsx
@@ -151,8 +151,16 @@ export default function OfferChatThread({
     if (!iso) return '-'
     try {
       return format(new Date(iso), 'yyyy/MM/dd HH:mm')
-    } catch (e) {
+    } catch {
       return '-'
+    }
+  }
+
+  const formatDaySeparator = (iso: string) => {
+    try {
+      return format(new Date(iso), 'yyyy/MM/dd')
+    } catch {
+      return ''
     }
   }
 
@@ -172,49 +180,56 @@ export default function OfferChatThread({
   return (
     <div
       className={cn(
-        'flex h-full min-h-[420px] flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm',
+        'flex h-full min-h-[420px] flex-col overflow-hidden rounded-xl border border-slate-200 bg-slate-50/40',
         className,
       )}
     >
-      <div className="flex items-center justify-between gap-3 border-b border-slate-100 px-4 py-3.5">
-        <div className="flex items-center gap-3">
-          <div className="flex items-center gap-2">
-            <MessageCircle className="h-5 w-5 text-slate-600" aria-hidden="true" />
-            <h3 className="text-sm font-semibold text-slate-900 sm:text-base">メッセージ</h3>
-            {unreadCount > 0 && (
-              <span className="inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-red-500 px-1 text-xs font-semibold text-white">
-                {unreadCount}
-              </span>
-            )}
-          </div>
+      <div className="flex items-center justify-between gap-3 border-b border-slate-200/80 bg-white/85 px-4 py-2.5">
+        <div className="flex items-center gap-2">
+          <MessageCircle className="h-4.5 w-4.5 text-slate-600" aria-hidden="true" />
+          <h3 className="text-sm font-semibold text-slate-900">メッセージ</h3>
+          {unreadCount > 0 && (
+            <span className="inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-rose-500 px-1 text-xs font-semibold text-white">
+              {unreadCount}
+            </span>
+          )}
         </div>
-        <span className="text-[11px] text-slate-400 sm:text-xs">最終更新: {formatTimestamp(lastUpdatedAt)}</span>
+        <span className="text-[10px] text-slate-400 sm:text-xs">最終更新: {formatTimestamp(lastUpdatedAt)}</span>
       </div>
       <div
         ref={containerRef}
         onScroll={handleScroll}
-        className="flex-1 overflow-y-auto px-4 py-3.5"
+        className="flex-1 overflow-y-auto bg-[#f7f8fa] px-3 py-3"
         aria-live="polite"
       >
-        {loading && <p>Loading...</p>}
+        {loading && <p className="text-sm text-slate-500">Loading...</p>}
         {!loading && messages.length === 0 && (
           <p className="text-center text-sm leading-relaxed text-slate-500">
             このオファーに関する連絡はまだありません。下の入力欄からメッセージを送信しましょう。
           </p>
         )}
-        <div className="flex flex-col gap-4">
-          {messages.map(m => (
-            <ChatMessageBubble
-              key={m.id}
-              message={m}
-              currentUserId={currentUserId}
-              peerLastReadAt={peerLastReadAt}
-              senderName={resolveSenderName(m)}
-            />
-          ))}
+        <div className="flex flex-col gap-2.5">
+          {messages.map((m, index) => {
+            const prev = messages[index - 1]
+            const showDateSeparator = !prev || formatDaySeparator(prev.created_at) !== formatDaySeparator(m.created_at)
+
+            return (
+              <div key={m.id} className="space-y-1.5">
+                {showDateSeparator && (
+                  <div className="my-1 text-center text-[11px] text-slate-400">—— {formatDaySeparator(m.created_at)} ——</div>
+                )}
+                <ChatMessageBubble
+                  message={m}
+                  currentUserId={currentUserId}
+                  peerLastReadAt={peerLastReadAt}
+                  senderName={resolveSenderName(m)}
+                />
+              </div>
+            )
+          })}
         </div>
       </div>
-      <div className="border-t border-slate-100 px-4 py-3">
+      <div className="border-t border-slate-200 bg-white px-3 py-3">
         <OfferChatInput offerId={offerId} senderRole={currentRole} receiverUserId={peerUserId} onSent={handleSent} />
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- 現状のオファー詳細メッセージUIがカード寄りで情報が詰まり読みづらいため、LINEライクな自然な会話表示に寄せて可読性と情報密度を改善する。 
- 既存のメッセージ取得/送信/既読ロジックは変更せず、表示レイヤー中心の改修を行う。 

### Description
- 主要変更は `components/offer/ChatMessageBubble.tsx`、`components/offer/OfferChatThread.tsx`、`components/offer/OfferChatInput.tsx` の3ファイルで、両方のストア／タレント画面に適用される共有チャット実装を更新した。 
- 吹き出しをコンパクト化（`max-w-[72%]`, `px-3 py-2`, `rounded-2xl` 等）、影を弱め背景を淡くして1件あたりの縦幅を削減した。 
- メタ情報を吹き出し外に整理し、相手メッセージのみ上部に名前表示、自分メッセージは名前非表示、時刻は小さく吹き出し下に表示し既読は控えめに表示するよう変更した。 
- 入力欄を丸み強めにし送信ボタンを色付きで明確化、日付跨ぎ時の簡易日付セパレーターを追加しグローバルCSSやAPI契約は触っていない。 

### Testing
- 実行した自動チェックは `cd talentify-next-frontend && npm run lint` で、コマンドは成功し ESLint の `<img>` に関する既存の警告が残る状態を確認した。 
- 変更は表示/レイアウト中心のためユニットテスト追加は行っておらず、既存のメッセージ送受信ロジックの自動テストは実施していない。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddbb756cb8833282aa592476bbd460)