### PR TITLE
メッセージUIをLINE風配色に調整

### DIFF
--- a/talentify-next-frontend/components/offer/ChatMessageBubble.tsx
+++ b/talentify-next-frontend/components/offer/ChatMessageBubble.tsx
@@ -26,12 +26,12 @@ export default function ChatMessageBubble({
   return (
     <div className={clsx('flex', isMine ? 'justify-end' : 'justify-start')}>
       <div className={clsx('flex max-w-[72%] flex-col', isMine ? 'items-end' : 'items-start')}>
-        {!isMine && <p className="mb-1 px-1 text-[11px] font-medium text-slate-500">{senderName}</p>}
+        {!isMine && <p className="mb-1 px-1 text-[11px] font-medium text-[#6B7280]">{senderName}</p>}
 
         <div
           className={clsx(
             'rounded-2xl px-3 py-2 text-sm leading-relaxed',
-            isMine ? 'bg-emerald-500 text-white' : 'bg-slate-100 text-slate-900',
+            isMine ? 'bg-[#9EEA6A] text-[#111827]' : 'bg-[#ECECEC] text-[#1F2937]',
           )}
         >
           {message.body && <p className="whitespace-pre-wrap break-words">{message.body}</p>}
@@ -47,7 +47,7 @@ export default function ChatMessageBubble({
                 href={url}
                 target="_blank"
                 rel="noreferrer"
-                className={clsx('mt-2 block text-xs underline', isMine ? 'text-white' : 'text-emerald-700')}
+                className={clsx('mt-2 block text-xs underline', isMine ? 'text-[#1F2937]' : 'text-[#374151]')}
               >
                 {att.name} ({Math.round(att.size / 1024)}KB)
               </a>
@@ -55,7 +55,7 @@ export default function ChatMessageBubble({
           })}
         </div>
 
-        <p className={clsx('mt-1 px-1 text-[10px]', isMine ? 'text-right text-slate-400' : 'text-slate-400')}>
+        <p className={clsx('mt-1 px-1 text-[10px]', isMine ? 'text-right text-[#9CA3AF]' : 'text-[#9CA3AF]')}>
           {isMine && read ? `既読 ${time}` : time}
         </p>
       </div>

--- a/talentify-next-frontend/components/offer/OfferChatThread.tsx
+++ b/talentify-next-frontend/components/offer/OfferChatThread.tsx
@@ -180,11 +180,11 @@ export default function OfferChatThread({
   return (
     <div
       className={cn(
-        'flex h-full min-h-[420px] flex-col overflow-hidden rounded-xl border border-slate-200 bg-slate-50/40',
+        'flex h-full min-h-[420px] flex-col overflow-hidden rounded-xl border border-[#E5E7EB] bg-[#FDFDFD]',
         className,
       )}
     >
-      <div className="flex items-center justify-between gap-3 border-b border-slate-200/80 bg-white/85 px-4 py-2.5">
+      <div className="flex items-center justify-between gap-3 border-b border-[#E5E7EB] bg-white px-4 py-2.5">
         <div className="flex items-center gap-2">
           <MessageCircle className="h-4.5 w-4.5 text-slate-600" aria-hidden="true" />
           <h3 className="text-sm font-semibold text-slate-900">メッセージ</h3>
@@ -194,12 +194,12 @@ export default function OfferChatThread({
             </span>
           )}
         </div>
-        <span className="text-[10px] text-slate-400 sm:text-xs">最終更新: {formatTimestamp(lastUpdatedAt)}</span>
+        <span className="text-[10px] text-[#9CA3AF] sm:text-xs">最終更新: {formatTimestamp(lastUpdatedAt)}</span>
       </div>
       <div
         ref={containerRef}
         onScroll={handleScroll}
-        className="flex-1 overflow-y-auto bg-[#f7f8fa] px-3 py-3"
+        className="flex-1 overflow-y-auto bg-[#F7F7F7] px-3 py-3"
         aria-live="polite"
       >
         {loading && <p className="text-sm text-slate-500">Loading...</p>}
@@ -216,7 +216,7 @@ export default function OfferChatThread({
             return (
               <div key={m.id} className="space-y-1.5">
                 {showDateSeparator && (
-                  <div className="my-1 text-center text-[11px] text-slate-400">—— {formatDaySeparator(m.created_at)} ——</div>
+                  <div className="my-1 text-center text-[11px] text-[#9CA3AF]">—— {formatDaySeparator(m.created_at)} ——</div>
                 )}
                 <ChatMessageBubble
                   message={m}
@@ -229,7 +229,7 @@ export default function OfferChatThread({
           })}
         </div>
       </div>
-      <div className="border-t border-slate-200 bg-white px-3 py-3">
+      <div className="border-t border-[#E5E7EB] bg-white px-3 py-3">
         <OfferChatInput offerId={offerId} senderRole={currentRole} receiverUserId={peerUserId} onSent={handleSent} />
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- オファー詳細ページのメッセージUIを、機能やレイアウトを維持したままユーザーに馴染みのあるLINEの色味に寄せて見た目のチャット感を向上させるため。
- 今回はブランド整合よりもLINEらしさ（色味・文字色・吹き出しの見え方）を優先して調整する方針とした。 

### Description
- 自分の吹き出しの背景色をLINE寄りの明るいグリーンにして文字色を白から濃い `#111827` に変更し可読性を高めた（`bg-[#9EEA6A]` / `text-[#111827]`）。
- 相手の吹き出しは背景の埋没を防ぐ柔らかいグレー `#ECECEC` と濃い文字 `#1F2937` に変更した。 
- 日付セパレーター／時刻／既読／最終更新の補助テキスト色を控えめだが読める `#9CA3AF` に統一し、メッセージエリア背景を `#F7F7F7`、境界線を `#E5E7EB` に調整した。 
- 変更ファイルは `components/offer/ChatMessageBubble.tsx` と `components/offer/OfferChatThread.tsx` で、どちらも store / talent 両方で使われる共通コンポーネントのため両方に反映される。 

### Testing
- `npm run lint` を実行し正常終了（既存の `no-img-element` に関する警告のみ表示）。
- ビジュアルスナップショット等の自動UIテストは実行しておらず、見た目確認はローカル起動またはスクリーンショットでの確認を推奨する。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddbf2f8ac08332ade88f2176ae58e6)