### PR TITLE
オファーチャット吹き出しの配色をLINE寄せに調整

### DIFF
--- a/talentify-next-frontend/components/offer/ChatMessageBubble.tsx
+++ b/talentify-next-frontend/components/offer/ChatMessageBubble.tsx
@@ -31,7 +31,7 @@ export default function ChatMessageBubble({
         <div
           className={clsx(
             'rounded-2xl px-3 py-2 text-sm leading-relaxed',
-            isMine ? 'bg-[#9EEA6A] text-[#111827]' : 'bg-[#ECECEC] text-[#1F2937]',
+            isMine ? 'bg-[#06C755] text-[#062110]' : 'bg-[#E2E2E2] text-[#111827]',
           )}
         >
           {message.body && <p className="whitespace-pre-wrap break-words">{message.body}</p>}
@@ -47,7 +47,7 @@ export default function ChatMessageBubble({
                 href={url}
                 target="_blank"
                 rel="noreferrer"
-                className={clsx('mt-2 block text-xs underline', isMine ? 'text-[#1F2937]' : 'text-[#374151]')}
+                className={clsx('mt-2 block text-xs underline', isMine ? 'text-[#062110]' : 'text-[#1F2937]')}
               >
                 {att.name} ({Math.round(att.size / 1024)}KB)
               </a>


### PR DESCRIPTION
### Motivation
- オファー詳細のメッセージUIをLINEらしい緑寄せに近づけ、相手の吹き出しの存在感を上げて可読性を確保するため。

### Description
- `talentify-next-frontend/components/offer/ChatMessageBubble.tsx` を編集し、自分吹き出し背景を `#06C755`（LINEフォレストグリーン）に、文字色を濃色 `#062110` に調整し、相手吹き出し背景を `#E2E2E2`、文字色を `#111827` に変更して添付リンク色も自分吹き出しでは同系の濃色に合わせました。

### Testing
- `cd talentify-next-frontend && npm run lint` を実行してリンターは成功しました（既存の `no-img-element` 警告は別ファイル由来で継続）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddc57b4c988332b70856c1a34138cc)