### PR TITLE
Soften own chat bubble color to #C4F69D and switch text to dark gray

### DIFF
--- a/talentify-next-frontend/components/offer/ChatMessageBubble.tsx
+++ b/talentify-next-frontend/components/offer/ChatMessageBubble.tsx
@@ -31,7 +31,7 @@ export default function ChatMessageBubble({
         <div
           className={clsx(
             'rounded-2xl px-3 py-2 text-sm leading-relaxed',
-            isMine ? 'bg-[#06C755] text-[#062110]' : 'bg-[#E2E2E2] text-[#111827]',
+            isMine ? 'bg-[#C4F69D] text-[#111827]' : 'bg-[#E2E2E2] text-[#111827]',
           )}
         >
           {message.body && <p className="whitespace-pre-wrap break-words">{message.body}</p>}
@@ -47,7 +47,7 @@ export default function ChatMessageBubble({
                 href={url}
                 target="_blank"
                 rel="noreferrer"
-                className={clsx('mt-2 block text-xs underline', isMine ? 'text-[#062110]' : 'text-[#1F2937]')}
+                className={clsx('mt-2 block text-xs underline', isMine ? 'text-[#111827]' : 'text-[#1F2937]')}
               >
                 {att.name} ({Math.round(att.size / 1024)}KB)
               </a>


### PR DESCRIPTION
### Motivation
- Tone down the current user's chat bubble from a strong LINE green to a softer, less assertive `#C4F69D` and ensure text remains clearly readable with a dark gray color, while keeping layout and auxiliary UI unchanged.

### Description
- Updated `talentify-next-frontend/components/offer/ChatMessageBubble.tsx` to use `bg-[#C4F69D]` and `text-[#111827]` for messages sent by the current user, and aligned the attachment link color for the current user to `#111827`; peer bubble, metadata, and spacing remain unchanged.

### Testing
- Ran `cd talentify-next-frontend && npm run -s lint -- --file components/offer/ChatMessageBubble.tsx`, which completed successfully and only reported an existing `no-img-element` warning unrelated to this color-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddd1bcb7bc83328af0a806eba3ca76)