### PR TITLE
Stabilize notification state flow with config-driven payloads and server-side role resolution

### DIFF
--- a/supabase/migrations/20260414103000_notifications_updated_at_safety.sql
+++ b/supabase/migrations/20260414103000_notifications_updated_at_safety.sql
@@ -1,0 +1,10 @@
+-- Ensure notifications.updated_at exists and is maintained for sorting/reconciliation.
+ALTER TABLE public.notifications
+  ADD COLUMN IF NOT EXISTS updated_at timestamptz NOT NULL DEFAULT now();
+
+UPDATE public.notifications
+SET updated_at = COALESCE(updated_at, created_at, now())
+WHERE updated_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_notifications_user_updated_at_desc
+  ON public.notifications (user_id, updated_at DESC, created_at DESC);

--- a/talentify-next-frontend/app/api/invoices/[id]/pay/route.ts
+++ b/talentify-next-frontend/app/api/invoices/[id]/pay/route.ts
@@ -65,7 +65,7 @@ export async function POST(
       if (talent?.user_id) {
         await createActionableNotification(
           talent.user_id,
-          { kind: 'payment_completed_to_talent', invoiceId: id, actorName: '店舗' },
+          { kind: 'payment_completed_to_talent', invoiceId: id, actorName: '店舗', actorId: user.id },
           'talent',
         )
       }

--- a/talentify-next-frontend/app/api/invoices/[id]/reject/route.ts
+++ b/talentify-next-frontend/app/api/invoices/[id]/reject/route.ts
@@ -57,7 +57,7 @@ export async function POST(
       if (talent?.user_id) {
         await createActionableNotification(
           talent.user_id,
-          { kind: 'invoice_rejected_to_talent', invoiceId: id, actorName: '店舗' },
+          { kind: 'invoice_rejected_to_talent', invoiceId: id, actorName: '店舗', actorId: user.id },
           'talent',
         )
       }

--- a/talentify-next-frontend/app/api/invoices/[id]/submit/route.ts
+++ b/talentify-next-frontend/app/api/invoices/[id]/submit/route.ts
@@ -62,7 +62,7 @@ export async function POST(
       if (store?.user_id) {
         await createActionableNotification(
           store.user_id,
-          { kind: 'invoice_submitted_to_store', invoiceId: id, actorName: '演者' },
+          { kind: 'invoice_submitted_to_store', invoiceId: id, actorName: '演者', actorId: user.id },
           'store',
         )
       }

--- a/talentify-next-frontend/app/api/messages/send/route.ts
+++ b/talentify-next-frontend/app/api/messages/send/route.ts
@@ -54,11 +54,11 @@ export async function POST(req: NextRequest) {
       {
         kind: 'message_received',
         actorName: senderName,
+        actorId: senderUserId,
         threadId: thread.id,
         messageId: message.id,
         offerId: offerId ?? null,
       },
-      'unknown',
     )
   } catch (e) {
     console.error('failed to insert message notification', e)

--- a/talentify-next-frontend/components/notifications/NotificationBell.tsx
+++ b/talentify-next-frontend/components/notifications/NotificationBell.tsx
@@ -75,16 +75,16 @@ export default function NotificationBell() {
   }
 
   const handleItemRead = (id: string) => {
-    setCount((c) => Math.max(0, c - 1))
     setItems((prev) => prev.map((n) => (n.id === id ? { ...n, is_read: true } : n)))
+    refreshCount()
+    refreshItems()
   }
 
   const handleReadAll = async () => {
     const unreadIds = items.filter((n) => !n.is_read).map((n) => n.id)
     if (unreadIds.length === 0) return
     await markAllNotificationsRead(unreadIds)
-    setItems((prev) => prev.map((n) => ({ ...n, is_read: true })))
-    setCount(0)
+    await Promise.all([refreshCount(), refreshItems()])
   }
 
   const notificationsPath = role ? `/${role}/notifications` : '/notifications'

--- a/talentify-next-frontend/components/notifications/NotificationsInboxPage.tsx
+++ b/talentify-next-frontend/components/notifications/NotificationsInboxPage.tsx
@@ -25,6 +25,7 @@ export default function NotificationsInboxPage() {
   const [items, setItems] = useState<NotificationRow[]>([])
   const [tab, setTab] = useState<TabType>('all')
   const [unreadCount, setUnreadCount] = useState(0)
+  const [isMutating, setIsMutating] = useState(false)
 
   const loadNotifications = async (currentTab: TabType) => {
     const data = await getNotifications({
@@ -64,10 +65,14 @@ export default function NotificationsInboxPage() {
   }, [tab])
 
   const markAsRead = async (notification: NotificationRow) => {
-    if (notification.is_read) return
-    await markNotificationRead(notification.id)
-    setItems((prev) => prev.map((item) => (item.id === notification.id ? { ...item, is_read: true } : item)).filter((item) => tab !== 'unread' || !item.is_read))
-    setUnreadCount((prev) => Math.max(0, prev - 1))
+    if (notification.is_read || isMutating) return
+    setIsMutating(true)
+    try {
+      await markNotificationRead(notification.id)
+      await Promise.all([loadNotifications(tab), refreshUnreadCount()])
+    } finally {
+      setIsMutating(false)
+    }
   }
 
   const handleRowClick = async (notification: NotificationRow) => {
@@ -76,10 +81,15 @@ export default function NotificationsInboxPage() {
   }
 
   const handleMarkAll = async () => {
+    if (isMutating) return
     const unreadIds = items.filter((item) => !item.is_read).map((item) => item.id)
-    await markAllNotificationsRead(unreadIds)
-    setItems((prev) => (tab === 'unread' ? [] : prev.map((item) => ({ ...item, is_read: true }))))
-    setUnreadCount(0)
+    setIsMutating(true)
+    try {
+      await markAllNotificationsRead(unreadIds)
+      await Promise.all([loadNotifications(tab), refreshUnreadCount()])
+    } finally {
+      setIsMutating(false)
+    }
   }
 
   const emptyStateText =
@@ -98,7 +108,7 @@ export default function NotificationsInboxPage() {
           <h1 className="text-2xl font-bold">通知</h1>
           <p className="text-sm text-muted-foreground">未読 {unreadCount} 件</p>
         </div>
-        <Button variant="outline" size="sm" onClick={handleMarkAll} disabled={unreadCount === 0}>
+        <Button variant="outline" size="sm" onClick={handleMarkAll} disabled={unreadCount === 0 || isMutating}>
           一括既読
         </Button>
       </div>

--- a/talentify-next-frontend/lib/notifications/config.ts
+++ b/talentify-next-frontend/lib/notifications/config.ts
@@ -1,0 +1,164 @@
+import type { NotificationType } from '@/types/notifications'
+import type { RecipientRole } from './payload'
+
+export type NotificationEvent =
+  | {
+      kind: 'message_received'
+      actorName?: string | null
+      actorId?: string | null
+      threadId: string
+      messageId: string
+      offerId?: string | null
+    }
+  | {
+      kind: 'invoice_submitted_to_store'
+      actorName?: string | null
+      actorId?: string | null
+      invoiceId: string
+    }
+  | {
+      kind: 'invoice_rejected_to_talent'
+      actorName?: string | null
+      actorId?: string | null
+      invoiceId: string
+    }
+  | {
+      kind: 'payment_completed_to_talent'
+      actorName?: string | null
+      actorId?: string | null
+      invoiceId: string
+    }
+  | {
+      kind: 'review_received'
+      actorName?: string | null
+      actorId?: string | null
+      reviewId: string
+      offerId: string
+    }
+
+type NotificationCategory = 'announcement' | 'notification'
+
+type BuildContext<E extends NotificationEvent> = {
+  actorName: string
+  recipientRole: RecipientRole
+  roleRootPath: string
+  notificationsRoot: string
+  event: E
+}
+
+type NotificationConfig<E extends NotificationEvent = NotificationEvent> = {
+  type: NotificationType
+  category: NotificationCategory
+  isActionable: boolean
+  priority: 'low' | 'medium' | 'high'
+  dedupeStrategy: (event: E) => string | null
+  build: (
+    ctx: BuildContext<E>,
+  ) => {
+    title: string
+    body: string
+    actionUrl: string | null
+    actionLabel: string | null
+    entityType: string | null
+    entityId: string | null
+    data: Record<string, unknown>
+  }
+}
+
+export const notificationConfig: {
+  [K in NotificationEvent['kind']]: NotificationConfig<Extract<NotificationEvent, { kind: K }>>
+} = {
+  message_received: {
+    type: 'message',
+    category: 'notification',
+    isActionable: true,
+    priority: 'high',
+    dedupeStrategy: (event) => `message:${event.threadId}`,
+    build: ({ actorName, roleRootPath, event }) => ({
+      title: `${actorName}さんからメッセージが届きました`,
+      body: '内容を確認して、必要であれば返信しましょう。',
+      actionUrl: `${roleRootPath}/messages`,
+      actionLabel: 'メッセージを確認',
+      entityType: 'message',
+      entityId: event.messageId,
+      data: {
+        thread_id: event.threadId,
+        message_id: event.messageId,
+        offer_id: event.offerId ?? null,
+      },
+    }),
+  },
+  invoice_submitted_to_store: {
+    type: 'invoice_submitted',
+    category: 'notification',
+    isActionable: true,
+    priority: 'medium',
+    dedupeStrategy: (event) => `invoice-submit:${event.invoiceId}`,
+    build: ({ roleRootPath, event }) => ({
+      title: '請求書が提出されました',
+      body: '内容を確認して、承認または差し戻しを行ってください。',
+      actionUrl: `${roleRootPath}/invoices/${event.invoiceId}`,
+      actionLabel: '請求書を確認',
+      entityType: 'invoice',
+      entityId: event.invoiceId,
+      data: {
+        invoice_id: event.invoiceId,
+      },
+    }),
+  },
+  invoice_rejected_to_talent: {
+    type: 'invoice_submitted',
+    category: 'notification',
+    isActionable: true,
+    priority: 'high',
+    dedupeStrategy: (event) => `invoice-reject:${event.invoiceId}`,
+    build: ({ roleRootPath, event }) => ({
+      title: '請求書が差し戻されました',
+      body: '修正内容を確認し、再提出をお願いします。',
+      actionUrl: `${roleRootPath}/invoices/${event.invoiceId}`,
+      actionLabel: '再提出する',
+      entityType: 'invoice',
+      entityId: event.invoiceId,
+      data: {
+        invoice_id: event.invoiceId,
+      },
+    }),
+  },
+  payment_completed_to_talent: {
+    type: 'payment_created',
+    category: 'notification',
+    isActionable: false,
+    priority: 'medium',
+    dedupeStrategy: (event) => `invoice-pay:${event.invoiceId}`,
+    build: ({ roleRootPath, event }) => ({
+      title: '支払いが完了しました',
+      body: '支払い内容を確認し、必要に応じて明細をチェックしてください。',
+      actionUrl: `${roleRootPath}/invoices/${event.invoiceId}`,
+      actionLabel: '明細を確認',
+      entityType: 'payment',
+      entityId: event.invoiceId,
+      data: {
+        invoice_id: event.invoiceId,
+      },
+    }),
+  },
+  review_received: {
+    type: 'review_received',
+    category: 'notification',
+    isActionable: false,
+    priority: 'low',
+    dedupeStrategy: (event) => `review:${event.offerId}`,
+    build: ({ roleRootPath, event }) => ({
+      title: 'レビューが届きました',
+      body: '内容を確認し、今後の案件に活かしましょう。',
+      actionUrl: `${roleRootPath}/reviews`,
+      actionLabel: 'レビューを見る',
+      entityType: 'review',
+      entityId: event.reviewId,
+      data: {
+        offer_id: event.offerId,
+        review_id: event.reviewId,
+      },
+    }),
+  },
+}

--- a/talentify-next-frontend/lib/notifications/payload.ts
+++ b/talentify-next-frontend/lib/notifications/payload.ts
@@ -1,38 +1,9 @@
 import type { Database } from '@/types/supabase'
+import { notificationConfig, type NotificationEvent } from './config'
 
 type NotificationInsert = Database['public']['Tables']['notifications']['Insert']
 
 export type RecipientRole = 'store' | 'talent' | 'company' | 'unknown'
-
-type NotificationEvent =
-  | {
-      kind: 'message_received'
-      actorName?: string | null
-      threadId: string
-      messageId: string
-      offerId?: string | null
-    }
-  | {
-      kind: 'invoice_submitted_to_store'
-      actorName?: string | null
-      invoiceId: string
-    }
-  | {
-      kind: 'invoice_rejected_to_talent'
-      actorName?: string | null
-      invoiceId: string
-    }
-  | {
-      kind: 'payment_completed_to_talent'
-      actorName?: string | null
-      invoiceId: string
-    }
-  | {
-      kind: 'review_received'
-      actorName?: string | null
-      reviewId: string
-      offerId: string
-    }
 
 export type NotificationPayload = Omit<NotificationInsert, 'user_id'>
 
@@ -44,7 +15,7 @@ function normalizeActorName(actorName?: string | null): string {
   return trimmed.length > 0 ? trimmed : DEFAULT_ACTOR_NAME
 }
 
-function roleToRootPath(role: RecipientRole): string {
+export function roleToRootPath(role: RecipientRole): string {
   if (role === 'store') return '/store'
   if (role === 'talent') return '/talent'
   if (role === 'company') return '/app'
@@ -61,126 +32,51 @@ function ensureSafeActionUrl(actionUrl: string | null | undefined, fallbackPath:
   return actionUrl
 }
 
-function buildBaseData(role: RecipientRole, actorName: string, category: 'announcement' | 'notification', isActionable: boolean) {
-  return {
-    recipient_role: role,
-    actor_name: actorName,
-    category,
-    is_actionable: isActionable,
-  }
-}
-
 export function buildNotificationPayload(event: NotificationEvent, recipientRole: RecipientRole): NotificationPayload {
+  const actorName = normalizeActorName(event.actorName)
+  const roleRootPath = roleToRootPath(recipientRole)
   const notificationsRoot = getNotificationsRootPath(recipientRole)
 
-  if (event.kind === 'message_received') {
-    const actorName = normalizeActorName(event.actorName ?? 'お相手')
-    const actionUrl = ensureSafeActionUrl(`${roleToRootPath(recipientRole)}/messages`, notificationsRoot)
-
-    return {
-      type: 'message',
-      title: `${actorName}さんからメッセージが届きました`,
-      body: '内容を確認して、必要であれば返信しましょう。',
-      priority: 'high',
-      action_url: actionUrl,
-      action_label: 'メッセージを確認',
-      entity_type: 'message',
-      entity_id: event.messageId,
-      actor_name: actorName,
-      group_key: `message:${event.threadId}`,
-      data: {
-        ...buildBaseData(recipientRole, actorName, 'notification', true),
-        thread_id: event.threadId,
-        message_id: event.messageId,
-        offer_id: event.offerId ?? null,
-      },
-    }
-  }
-
-  if (event.kind === 'invoice_submitted_to_store') {
-    const actorName = normalizeActorName(event.actorName ?? '演者')
-    const actionUrl = ensureSafeActionUrl(`${roleToRootPath(recipientRole)}/invoices/${event.invoiceId}`, notificationsRoot)
-
-    return {
-      type: 'invoice_submitted',
-      title: '請求書が提出されました',
-      body: '内容を確認して、承認または差し戻しを行ってください。',
-      priority: 'medium',
-      action_url: actionUrl,
-      action_label: '請求書を確認',
-      entity_type: 'invoice',
-      entity_id: event.invoiceId,
-      actor_name: actorName,
-      group_key: `invoice:${event.invoiceId}`,
-      data: {
-        ...buildBaseData(recipientRole, actorName, 'notification', true),
-        invoice_id: event.invoiceId,
-      },
-    }
-  }
-
-  if (event.kind === 'invoice_rejected_to_talent') {
-    const actorName = normalizeActorName(event.actorName ?? '店舗')
-    const actionUrl = ensureSafeActionUrl(`${roleToRootPath(recipientRole)}/invoices/${event.invoiceId}`, notificationsRoot)
-
-    return {
-      type: 'invoice_submitted',
-      title: '請求書が差し戻されました',
-      body: '修正内容を確認し、再提出をお願いします。',
-      priority: 'high',
-      action_url: actionUrl,
-      action_label: '再提出する',
-      entity_type: 'invoice',
-      entity_id: event.invoiceId,
-      actor_name: actorName,
-      group_key: `invoice:${event.invoiceId}`,
-      data: {
-        ...buildBaseData(recipientRole, actorName, 'notification', true),
-        invoice_id: event.invoiceId,
-      },
-    }
-  }
-
-  if (event.kind === 'payment_completed_to_talent') {
-    const actorName = normalizeActorName(event.actorName ?? '店舗')
-    const actionUrl = ensureSafeActionUrl(`${roleToRootPath(recipientRole)}/invoices/${event.invoiceId}`, notificationsRoot)
-
-    return {
-      type: 'payment_created',
-      title: '支払いが完了しました',
-      body: '支払い内容を確認し、必要に応じて明細をチェックしてください。',
-      priority: 'medium',
-      action_url: actionUrl,
-      action_label: '明細を確認',
-      entity_type: 'payment',
-      entity_id: event.invoiceId,
-      actor_name: actorName,
-      group_key: `payment:${event.invoiceId}`,
-      data: {
-        ...buildBaseData(recipientRole, actorName, 'notification', false),
-        invoice_id: event.invoiceId,
-      },
-    }
-  }
-
-  const actorName = normalizeActorName(event.actorName ?? '店舗')
-  const actionUrl = ensureSafeActionUrl(`${roleToRootPath(recipientRole)}/reviews`, notificationsRoot)
+  const config = notificationConfig[event.kind]
+  const built = (config.build as (ctx: {
+    actorName: string
+    recipientRole: RecipientRole
+    roleRootPath: string
+    notificationsRoot: string
+    event: NotificationEvent
+  }) => {
+    title: string
+    body: string
+    actionUrl: string | null
+    actionLabel: string | null
+    entityType: string | null
+    entityId: string | null
+    data: Record<string, unknown>
+  })({
+    actorName,
+    recipientRole,
+    roleRootPath,
+    notificationsRoot,
+    event,
+  })
 
   return {
-    type: 'review_received',
-    title: 'レビューが届きました',
-    body: '内容を確認し、今後の案件に活かしましょう。',
-    priority: 'low',
-    action_url: actionUrl,
-    action_label: 'レビューを見る',
-    entity_type: 'review',
-    entity_id: event.reviewId,
+    type: config.type,
+    title: built.title,
+    body: built.body,
+    priority: config.priority,
+    action_url: ensureSafeActionUrl(built.actionUrl, notificationsRoot),
+    action_label: built.actionLabel,
+    entity_type: built.entityType,
+    entity_id: built.entityId,
     actor_name: actorName,
-    group_key: `review:${event.offerId}`,
+    group_key: (config.dedupeStrategy as (input: NotificationEvent) => string | null)(event),
     data: {
-      ...buildBaseData(recipientRole, actorName, 'notification', false),
-      offer_id: event.offerId,
-      review_id: event.reviewId,
+      recipient_role: recipientRole,
+      actor_name: actorName,
+      category: config.category,
+      is_actionable: config.isActionable,
+      ...built.data,
     },
   }
 }

--- a/talentify-next-frontend/lib/notifications/resolve-recipient-role.ts
+++ b/talentify-next-frontend/lib/notifications/resolve-recipient-role.ts
@@ -1,0 +1,137 @@
+import { getPrismaClient } from '@/lib/prisma'
+import type { RecipientRole } from './payload'
+
+type ResolveRecipientRoleParams = {
+  entityType: string | null | undefined
+  entityId: string | null | undefined
+  actorId?: string | null
+}
+
+type ResolveActorNameParams = {
+  actorId?: string | null
+  fallbackName?: string | null
+}
+
+type UserIdRow = { user_id: string | null }
+type MessageParticipantRow = { participant_user_ids: string[] | null }
+type InvoiceUserRow = { store_user_id: string | null; talent_user_id: string | null }
+type ReviewUserRow = { store_user_id: string | null; talent_user_id: string | null }
+
+async function resolveRoleByUserId(userId: string | null | undefined): Promise<RecipientRole> {
+  if (!userId) return 'unknown'
+
+  const prisma = getPrismaClient()
+
+  const [talent, store, company] = await Promise.all([
+    prisma.talents.findFirst({ where: { user_id: userId }, select: { id: true } }),
+    prisma.stores.findFirst({ where: { user_id: userId }, select: { id: true } }),
+    prisma.companies.findFirst({ where: { user_id: userId }, select: { id: true } }),
+  ])
+
+  if (talent) return 'talent'
+  if (store) return 'store'
+  if (company) return 'company'
+  return 'unknown'
+}
+
+export async function resolveRecipientRole({
+  entityType,
+  entityId,
+  actorId,
+}: ResolveRecipientRoleParams): Promise<RecipientRole> {
+  if (!entityId || !entityType) return 'unknown'
+
+  const prisma = getPrismaClient()
+
+  if (entityType === 'message') {
+    const messageRows = await prisma.$queryRaw<UserIdRow[]>`
+      SELECT recipient_user_id AS user_id
+      FROM public.messages
+      WHERE id = ${entityId}::uuid
+      LIMIT 1
+    `
+
+    const directRecipientRole = await resolveRoleByUserId(messageRows[0]?.user_id ?? null)
+    if (directRecipientRole !== 'unknown') return directRecipientRole
+
+    const participantsRows = await prisma.$queryRaw<MessageParticipantRow[]>`
+      SELECT mt.participant_user_ids
+      FROM public.messages m
+      JOIN public.message_threads mt ON mt.id = m.thread_id
+      WHERE m.id = ${entityId}::uuid
+      LIMIT 1
+    `
+
+    const participants = participantsRows[0]?.participant_user_ids ?? []
+    const recipientUserId = participants.find((userId) => userId && userId !== actorId)
+    return resolveRoleByUserId(recipientUserId ?? null)
+  }
+
+  if (entityType === 'invoice' || entityType === 'payment') {
+    const rows = await prisma.$queryRaw<InvoiceUserRow[]>`
+      SELECT
+        s.user_id AS store_user_id,
+        t.user_id AS talent_user_id
+      FROM public.invoices i
+      LEFT JOIN public.stores s ON s.id = i.store_id
+      LEFT JOIN public.talents t ON t.id = i.talent_id
+      WHERE i.id = ${entityId}::uuid
+      LIMIT 1
+    `
+
+    const invoice = rows[0]
+    if (!invoice) return 'unknown'
+
+    if (actorId && actorId === invoice.store_user_id) return resolveRoleByUserId(invoice.talent_user_id)
+    if (actorId && actorId === invoice.talent_user_id) return resolveRoleByUserId(invoice.store_user_id)
+
+    const storeRole = await resolveRoleByUserId(invoice.store_user_id)
+    if (storeRole !== 'unknown') return storeRole
+    return resolveRoleByUserId(invoice.talent_user_id)
+  }
+
+  if (entityType === 'review') {
+    const rows = await prisma.$queryRaw<ReviewUserRow[]>`
+      SELECT
+        s.user_id AS store_user_id,
+        t.user_id AS talent_user_id
+      FROM public.reviews r
+      LEFT JOIN public.stores s ON s.id = r.store_id
+      LEFT JOIN public.talents t ON t.id = r.talent_id
+      WHERE r.id = ${entityId}::uuid
+      LIMIT 1
+    `
+
+    const review = rows[0]
+    if (!review) return 'unknown'
+
+    if (actorId && actorId === review.store_user_id) return resolveRoleByUserId(review.talent_user_id)
+    if (actorId && actorId === review.talent_user_id) return resolveRoleByUserId(review.store_user_id)
+
+    return resolveRoleByUserId(review.talent_user_id ?? review.store_user_id)
+  }
+
+  return 'unknown'
+}
+
+export async function resolveActorName({ actorId, fallbackName }: ResolveActorNameParams): Promise<string | null> {
+  if (!actorId) return fallbackName ?? null
+
+  const prisma = getPrismaClient()
+  const [talent, store, company] = await Promise.all([
+    prisma.talents.findFirst({ where: { user_id: actorId }, select: { stage_name: true, name: true, display_name: true } }),
+    prisma.stores.findFirst({ where: { user_id: actorId }, select: { store_name: true } }),
+    prisma.companies.findFirst({ where: { user_id: actorId }, select: { display_name: true, company_name: true } }),
+  ])
+
+  const name =
+    talent?.display_name?.trim() ||
+    talent?.stage_name?.trim() ||
+    talent?.name?.trim() ||
+    store?.store_name?.trim() ||
+    company?.display_name?.trim() ||
+    company?.company_name?.trim() ||
+    null
+
+  return name || fallbackName || null
+}

--- a/talentify-next-frontend/lib/notifications/service.ts
+++ b/talentify-next-frontend/lib/notifications/service.ts
@@ -1,40 +1,43 @@
 import { createNotification } from '@/lib/repositories/notifications'
 import { buildNotificationPayload, type RecipientRole } from './payload'
+import type { NotificationEvent } from './config'
+import { resolveActorName, resolveRecipientRole } from './resolve-recipient-role'
 
 export async function createActionableNotification(
   recipientUserId: string,
-  event:
-    | {
-        kind: 'message_received'
-        actorName?: string | null
-        threadId: string
-        messageId: string
-        offerId?: string | null
-      }
-    | {
-        kind: 'invoice_submitted_to_store'
-        actorName?: string | null
-        invoiceId: string
-      }
-    | {
-        kind: 'invoice_rejected_to_talent'
-        actorName?: string | null
-        invoiceId: string
-      }
-    | {
-        kind: 'payment_completed_to_talent'
-        actorName?: string | null
-        invoiceId: string
-      }
-    | {
-        kind: 'review_received'
-        actorName?: string | null
-        reviewId: string
-        offerId: string
-      },
-  recipientRole: RecipientRole,
+  event: NotificationEvent,
+  recipientRole?: RecipientRole,
 ) {
-  const payload = buildNotificationPayload(event, recipientRole)
+  const resolvedRole = await resolveRecipientRole({
+    entityType: (() => {
+      if (event.kind === 'message_received') return 'message'
+      if (event.kind === 'review_received') return 'review'
+      if (event.kind === 'payment_completed_to_talent') return 'payment'
+      return 'invoice'
+    })(),
+    entityId:
+      event.kind === 'message_received'
+        ? event.messageId
+        : event.kind === 'review_received'
+          ? event.reviewId
+          : event.invoiceId,
+    actorId: event.actorId,
+  })
+  const finalRecipientRole = resolvedRole === 'unknown' ? (recipientRole ?? 'unknown') : resolvedRole
+
+  const resolvedActorName = await resolveActorName({
+    actorId: event.actorId,
+    fallbackName: event.actorName,
+  })
+
+  const payload = buildNotificationPayload(
+    {
+      ...event,
+      actorName: resolvedActorName,
+    },
+    finalRecipientRole,
+  )
+
   return createNotification({
     user_id: recipientUserId,
     ...payload,

--- a/talentify-next-frontend/lib/repositories/notifications.ts
+++ b/talentify-next-frontend/lib/repositories/notifications.ts
@@ -50,6 +50,7 @@ type NotificationQueryRow = {
   body: string | null
   is_read: boolean
   created_at: Date
+  updated_at: Date
   read_at: Date | null
   priority: 'low' | 'medium' | 'high'
   action_url: string | null
@@ -83,6 +84,7 @@ function toNotificationRow(row: NotificationQueryRow): NotificationRow {
     body: row.body,
     is_read: row.is_read,
     created_at: row.created_at.toISOString(),
+    updated_at: row.updated_at.toISOString(),
     read_at: row.read_at?.toISOString() ?? null,
     priority: resolvePriority(row.priority ?? (typeof rawData?.priority === 'string' ? rawData.priority : null)),
     action_url: row.action_url ?? (typeof rawData?.url === 'string' ? rawData.url : null),
@@ -134,7 +136,7 @@ export async function findNotificationsByUser({
 
   const unreadClause = unreadOnly ? Prisma.sql`AND is_read = false` : Prisma.empty
 
-const actionableClause = actionableOnly
+  const actionableClause = actionableOnly
     ? Prisma.sql`AND (
       type = ANY (${ACTION_REQUIRED_TYPES}::public.notification_type[])
       OR COALESCE(
@@ -170,6 +172,7 @@ const actionableClause = actionableOnly
       body,
       is_read,
       created_at,
+      updated_at,
       read_at,
       priority,
       action_url,
@@ -184,7 +187,7 @@ const actionableClause = actionableOnly
     ${unreadClause}
     ${actionableClause}
     ${categoryClause}
-    ORDER BY created_at DESC
+    ORDER BY updated_at DESC, created_at DESC
     ${limitClause}
   `
 
@@ -253,7 +256,7 @@ export async function createNotification({
             (${entity_id ?? null}::text IS NULL AND entity_id IS NULL)
             OR entity_id = ${entity_id ?? null}
           )
-        ORDER BY created_at DESC
+        ORDER BY updated_at DESC, created_at DESC
         LIMIT 1
       )
       UPDATE public.notifications
@@ -268,7 +271,6 @@ export async function createNotification({
         entity_id = ${entity_id ?? null},
         actor_name = ${actor_name ?? null},
         expires_at = ${expires_at ?? null},
-        created_at = ${now},
         updated_at = ${now},
         read_at = NULL,
         is_read = false
@@ -282,6 +284,7 @@ export async function createNotification({
         body,
         is_read,
         created_at,
+        updated_at,
         read_at,
         priority,
         action_url,
@@ -305,6 +308,8 @@ export async function createNotification({
       title,
       body,
       data,
+      created_at,
+      updated_at,
       priority,
       action_url,
       action_label,
@@ -320,6 +325,8 @@ export async function createNotification({
       ${title},
       ${body ?? null},
       ${data ?? null}::jsonb,
+      ${now},
+      ${now},
       ${priority ?? 'medium'},
       ${action_url ?? null},
       ${action_label ?? null},
@@ -338,6 +345,7 @@ export async function createNotification({
       body,
       is_read,
       created_at,
+      updated_at,
       read_at,
       priority,
       action_url,
@@ -371,6 +379,7 @@ export async function markNotificationRead({
     data: {
       is_read: true,
       read_at: now,
+      updated_at: now,
     },
   })
 
@@ -391,6 +400,7 @@ export async function markNotificationUnread({
     data: {
       is_read: false,
       read_at: null,
+      updated_at: new Date(),
     },
   })
 
@@ -418,6 +428,7 @@ export async function markAllNotificationsRead({
     data: {
       is_read: true,
       read_at: now,
+      updated_at: now,
     },
   })
 

--- a/talentify-next-frontend/types/supabase.ts
+++ b/talentify-next-frontend/types/supabase.ts
@@ -510,6 +510,7 @@ export type Database = {
           body: string | null
           is_read: boolean
           created_at: string
+          updated_at: string
           read_at: string | null
           priority: 'low' | 'medium' | 'high'
           action_url: string | null
@@ -538,6 +539,7 @@ export type Database = {
           body?: string | null
           is_read?: boolean
           created_at?: string
+          updated_at?: string
           read_at?: string | null
           priority?: 'low' | 'medium' | 'high'
           action_url?: string | null
@@ -566,6 +568,7 @@ export type Database = {
           body?: string | null
           is_read?: boolean
           created_at?: string
+          updated_at?: string
           read_at?: string | null
           priority?: 'low' | 'medium' | 'high'
           action_url?: string | null

--- a/talentify-next-frontend/utils/notifications.ts
+++ b/talentify-next-frontend/utils/notifications.ts
@@ -37,12 +37,20 @@ type GetNotificationsOptions = {
 
 export const NOTIFICATIONS_CHANGED_EVENT = 'talentify:notifications-changed'
 
+const inFlightReadMutations = new Set<string>()
+let markAllInFlight = false
+
 function emitNotificationsChanged() {
   if (typeof window === 'undefined') return
+  // Event is only a "re-fetch trigger". Server-side DB is source of truth.
   window.dispatchEvent(new CustomEvent(NOTIFICATIONS_CHANGED_EVENT))
 }
 
-async function patchNotificationReadState(id: string, isRead: boolean): Promise<void> {
+async function patchNotificationReadState(id: string, isRead: boolean): Promise<boolean> {
+  const lockKey = `${id}:${isRead ? 'read' : 'unread'}`
+  if (inFlightReadMutations.has(lockKey)) return false
+  inFlightReadMutations.add(lockKey)
+
   try {
     const res = await fetch(`${API_BASE}/api/notifications/${id}/read`, {
       method: 'PATCH',
@@ -52,9 +60,15 @@ async function patchNotificationReadState(id: string, isRead: boolean): Promise<
 
     if (!res.ok && res.status !== 401) {
       console.error('failed to update notification read state', await res.text())
+      return false
     }
+
+    return res.ok
   } catch (error) {
     console.error('failed to update notification read state', error)
+    return false
+  } finally {
+    inFlightReadMutations.delete(lockKey)
   }
 }
 
@@ -108,18 +122,19 @@ export async function getUnreadNotificationCount(): Promise<number> {
 }
 
 export async function markNotificationRead(id: string) {
-  await patchNotificationReadState(id, true)
-  emitNotificationsChanged()
+  const ok = await patchNotificationReadState(id, true)
+  if (ok) emitNotificationsChanged()
 }
 
 export async function markNotificationUnread(id: string) {
-  await patchNotificationReadState(id, false)
-  emitNotificationsChanged()
+  const ok = await patchNotificationReadState(id, false)
+  if (ok) emitNotificationsChanged()
 }
 
 export async function markAllNotificationsRead(ids: string[]) {
-  if (ids.length === 0) return
+  if (ids.length === 0 || markAllInFlight) return
 
+  markAllInFlight = true
   try {
     const res = await fetch(`${API_BASE}/api/notifications/read-all`, {
       method: 'PATCH',
@@ -129,11 +144,15 @@ export async function markAllNotificationsRead(ids: string[]) {
 
     if (!res.ok && res.status !== 401) {
       console.error('failed to mark all notifications as read', await res.text())
+      return
     }
+
+    if (res.ok) emitNotificationsChanged()
   } catch (error) {
     console.error('failed to mark all notifications as read', error)
+  } finally {
+    markAllInFlight = false
   }
-  emitNotificationsChanged()
 }
 
 export async function addNotification(payload: AddNotificationPayload) {
@@ -145,11 +164,13 @@ export async function addNotification(payload: AddNotificationPayload) {
     })
     if (!res.ok) {
       console.error('failed to add notification', await res.text())
+      return
     }
+
+    emitNotificationsChanged()
   } catch (error) {
     console.error('failed to add notification', error)
   }
-  emitNotificationsChanged()
 }
 
 export function formatUnreadCount(count: number): string | null {


### PR DESCRIPTION
### Motivation
- Improve notification stability and correctness by separating event time (`created_at`) from resurface/update time (`updated_at`).
- Reduce `unknown` recipient roles and improve actor naming by resolving roles and names server-side from entities.
- Make notification types and dedupe/grouping rules extensible by moving type-specific logic into a single config.
- Reduce client-side race conditions by treating realtime events as fetch triggers and strengthening mutation reconciliation and in-flight guards.

### Description
- Introduced a config-driven notification schema in `lib/notifications/config.ts` that centralizes `type`, `category`, `isActionable`, `priority`, `dedupeStrategy` and `build` logic for each event kind, enabling consistent payload generation and clearer `group_key` granularity.
- Refactored `lib/notifications/payload.ts` to use the new `notificationConfig` for payload construction and to unify `data` and `action_url` handling via `ensureSafeActionUrl` and role-root resolution.
- Added server-side role and actor resolution in `lib/notifications/resolve-recipient-role.ts` with `resolveRecipientRole({ entityType, entityId, actorId })` and `resolveActorName(...)`, and updated `lib/notifications/service.ts` to call these before building notifications.
- Hardened DB persistence and ordering in `lib/repositories/notifications.ts` by using `updated_at` for resurface ordering, updating only `updated_at` on dedupe UPDATEs, setting both timestamps on INSERT, and updating `updated_at` when read/unread state changes.
- Added a safety migration `supabase/migrations/20260414103000_notifications_updated_at_safety.sql` to ensure `notifications.updated_at` exists and an index for `user_id, updated_at DESC, created_at DESC`.
- Strengthened client sync logic in `utils/notifications.ts` and UI components by introducing in-flight locks for read/mark-all operations, treating the event bus as a re-fetch trigger, and reconciling list/count from the server after mutations; updated `NotificationsInboxPage.tsx` and `NotificationBell.tsx` to use these behaviors and to avoid optimistic drift.
- Threaded `actorId` into API calls that create notifications (`app/api/messages/send/route.ts`, invoice submit/reject/pay endpoints) so server resolution can prefer canonical user records, and updated Supabase type definitions in `types/supabase.ts` to include `updated_at`.

### Testing
- Ran `npm run lint` in the frontend and it completed successfully with only unrelated image warnings; no lint errors were introduced.
- Attempted `npm run build` but it failed in this environment because `DATABASE_URL` is not set, causing `prisma generate` to abort; this is an environment issue and not a code regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf133afd0833286cefca54e70d507)