### PR TITLE
Notifications: add E2E tests, make read APIs idempotent, and extend offer notifications

### DIFF
--- a/talentify-next-frontend/__tests__/notification-offer-config.test.ts
+++ b/talentify-next-frontend/__tests__/notification-offer-config.test.ts
@@ -1,0 +1,73 @@
+import { buildNotificationPayload } from '@/lib/notifications/payload'
+
+jest.mock('@/lib/prisma', () => ({
+  getPrismaClient: jest.fn(),
+}))
+
+const { getPrismaClient } = jest.requireMock('@/lib/prisma') as {
+  getPrismaClient: jest.Mock
+}
+
+describe('offer notification config integration', () => {
+  it('builds offer created payload with role-aware action url', () => {
+    const payload = buildNotificationPayload(
+      {
+        kind: 'offer_created',
+        offerId: 'offer-1',
+        actorName: 'Store A',
+      },
+      'talent',
+    )
+
+    expect(payload.type).toBe('offer_created')
+    expect(payload.action_url).toBe('/talent/offers/offer-1')
+    expect(payload.entity_type).toBe('offer')
+    expect(payload.data).toMatchObject({ recipient_role: 'talent', is_actionable: true, offer_id: 'offer-1' })
+  })
+
+  it('builds offer updated payload with status information', () => {
+    const payload = buildNotificationPayload(
+      {
+        kind: 'offer_updated',
+        offerId: 'offer-2',
+        actorName: 'Talent B',
+        status: 'rejected',
+      },
+      'store',
+    )
+
+    expect(payload.type).toBe('offer_updated')
+    expect(payload.action_url).toBe('/store/offers/offer-2')
+    expect(payload.data).toMatchObject({ status: 'rejected', offer_id: 'offer-2', recipient_role: 'store' })
+  })
+
+  it('resolveRecipientRole resolves offer recipient from actor side', async () => {
+    const queryRaw = jest.fn().mockResolvedValue([
+      {
+        store_user_id: 'store-user',
+        talent_user_id: 'talent-user',
+      },
+    ])
+
+    const talentsFindFirst = jest.fn().mockImplementation(async ({ where }: { where: { user_id: string } }) => {
+      if (where.user_id === 'talent-user') return { id: 'talent-id' }
+      return null
+    })
+
+    getPrismaClient.mockReturnValue({
+      $queryRaw: queryRaw,
+      talents: { findFirst: talentsFindFirst },
+      stores: { findFirst: jest.fn().mockResolvedValue(null) },
+      companies: { findFirst: jest.fn().mockResolvedValue(null) },
+    })
+
+    const { resolveRecipientRole } = await import('@/lib/notifications/resolve-recipient-role')
+    const role = await resolveRecipientRole({
+      entityType: 'offer',
+      entityId: 'offer-1',
+      actorId: 'store-user',
+    })
+
+    expect(role).toBe('talent')
+  })
+})

--- a/talentify-next-frontend/__tests__/notifications-e2e.test.ts
+++ b/talentify-next-frontend/__tests__/notifications-e2e.test.ts
@@ -1,0 +1,228 @@
+import { NextRequest } from 'next/server'
+import { GET as getNotificationsRoute } from '@/app/api/notifications/route'
+import { PATCH as patchNotificationReadRoute } from '@/app/api/notifications/[id]/read/route'
+import { PATCH as patchNotificationsReadAllRoute } from '@/app/api/notifications/read-all/route'
+import { getNotificationLink, isActionRequired } from '@/components/notifications/notification-meta'
+import type { NotificationRow } from '@/utils/notifications'
+
+jest.mock('@/lib/auth/getCurrentUser', () => ({
+  getCurrentUser: jest.fn(),
+}))
+
+jest.mock('@/lib/repositories/notifications', () => ({
+  countUnreadNotificationsByUser: jest.fn(),
+  findNotificationsByUser: jest.fn(),
+  markNotificationRead: jest.fn(),
+  markNotificationUnread: jest.fn(),
+  markAllNotificationsRead: jest.fn(),
+  findNotificationOwner: jest.fn(),
+}))
+
+const { getCurrentUser } = jest.requireMock('@/lib/auth/getCurrentUser') as {
+  getCurrentUser: jest.Mock
+}
+
+const {
+  countUnreadNotificationsByUser,
+  findNotificationsByUser,
+  markNotificationRead,
+  markNotificationUnread,
+  markAllNotificationsRead,
+  findNotificationOwner,
+} = jest.requireMock('@/lib/repositories/notifications') as {
+  countUnreadNotificationsByUser: jest.Mock
+  findNotificationsByUser: jest.Mock
+  markNotificationRead: jest.Mock
+  markNotificationUnread: jest.Mock
+  markAllNotificationsRead: jest.Mock
+  findNotificationOwner: jest.Mock
+}
+
+function buildNotification(overrides: Partial<NotificationRow>): NotificationRow {
+  return {
+    id: 'n1',
+    user_id: 'u1',
+    type: 'message',
+    title: 'title',
+    body: 'body',
+    is_read: false,
+    data: { recipient_role: 'talent' },
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    read_at: null,
+    priority: 'medium',
+    action_url: null,
+    action_label: null,
+    entity_type: null,
+    entity_id: null,
+    actor_name: 'Actor',
+    expires_at: null,
+    group_key: null,
+    ...overrides,
+  }
+}
+
+describe('notifications quality e2e', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    getCurrentUser.mockResolvedValue({ user: { id: 'u1' } })
+  })
+
+  it('A. unread count on header and list stays aligned', async () => {
+    countUnreadNotificationsByUser.mockResolvedValue(3)
+    findNotificationsByUser.mockResolvedValue([
+      buildNotification({ id: 'n1' }),
+      buildNotification({ id: 'n2' }),
+      buildNotification({ id: 'n3' }),
+    ])
+
+    const countReq = new NextRequest('http://localhost/api/notifications?unread_count=true')
+    const countRes = await getNotificationsRoute(countReq)
+    await expect(countRes.json()).resolves.toMatchObject({ count: 3 })
+
+    const listReq = new NextRequest('http://localhost/api/notifications?unread_only=true')
+    const listRes = await getNotificationsRoute(listReq)
+    const listBody = await listRes.json()
+
+    expect(Array.isArray(listBody.data)).toBe(true)
+    expect(listBody.data).toHaveLength(3)
+  })
+
+  it('B/F. mark-as-read is idempotent under duplicate requests', async () => {
+    markNotificationRead
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(0)
+    findNotificationOwner.mockResolvedValue(true)
+
+    const firstReq = new NextRequest('http://localhost/api/notifications/n1/read', {
+      method: 'PATCH',
+      body: JSON.stringify({ is_read: true }),
+    })
+    const secondReq = new NextRequest('http://localhost/api/notifications/n1/read', {
+      method: 'PATCH',
+      body: JSON.stringify({ is_read: true }),
+    })
+
+    const first = await patchNotificationReadRoute(firstReq, { params: Promise.resolve({ id: 'n1' }) })
+    await expect(first.json()).resolves.toMatchObject({ ok: true, updated: 1, noop: false })
+
+    const second = await patchNotificationReadRoute(secondReq, { params: Promise.resolve({ id: 'n1' }) })
+    await expect(second.json()).resolves.toMatchObject({ ok: true, updated: 0, noop: true })
+  })
+
+  it('C/F. mark-all-read remains safe when unread is already zero', async () => {
+    markAllNotificationsRead
+      .mockResolvedValueOnce(2)
+      .mockResolvedValueOnce(0)
+
+    const req = new NextRequest('http://localhost/api/notifications/read-all', {
+      method: 'PATCH',
+      body: JSON.stringify({ ids: ['n1', 'n2'] }),
+    })
+
+    const first = await patchNotificationsReadAllRoute(req)
+    await expect(first.json()).resolves.toMatchObject({ ok: true, updated: 2 })
+
+    const second = await patchNotificationsReadAllRoute(req)
+    await expect(second.json()).resolves.toMatchObject({ ok: true, updated: 0 })
+  })
+
+  it('D. tab query options map consistently to repository filters', async () => {
+    findNotificationsByUser.mockResolvedValue([])
+
+    await getNotificationsRoute(new NextRequest('http://localhost/api/notifications'))
+    expect(findNotificationsByUser).toHaveBeenLastCalledWith(
+      expect.objectContaining({ unreadOnly: false, actionableOnly: false, category: undefined }),
+    )
+
+    await getNotificationsRoute(new NextRequest('http://localhost/api/notifications?unread_only=true'))
+    expect(findNotificationsByUser).toHaveBeenLastCalledWith(
+      expect.objectContaining({ unreadOnly: true, actionableOnly: false }),
+    )
+
+    await getNotificationsRoute(new NextRequest('http://localhost/api/notifications?actionable_only=true'))
+    expect(findNotificationsByUser).toHaveBeenLastCalledWith(
+      expect.objectContaining({ unreadOnly: false, actionableOnly: true, category: undefined }),
+    )
+
+    await getNotificationsRoute(new NextRequest('http://localhost/api/notifications?category=announcement'))
+    expect(findNotificationsByUser).toHaveBeenLastCalledWith(
+      expect.objectContaining({ category: 'announcement' }),
+    )
+  })
+
+  it('E. notification click links resolve to message/invoice/review/offer destinations', () => {
+    const message = buildNotification({ type: 'message', data: { recipient_role: 'store' } })
+    const invoice = buildNotification({
+      type: 'invoice_submitted',
+      data: { recipient_role: 'store', invoice_id: 'inv-1' },
+    })
+    const review = buildNotification({
+      type: 'review_received',
+      data: { recipient_role: 'talent' },
+      action_url: '/talent/reviews',
+    })
+    const offer = buildNotification({
+      type: 'offer_created',
+      data: { recipient_role: 'talent', offer_id: 'offer-1', status: 'pending' },
+    })
+
+    expect(getNotificationLink(message)).toBe('/store/messages')
+    expect(getNotificationLink(invoice)).toBe('/store/invoices/inv-1')
+    expect(getNotificationLink(review)).toBe('/talent/reviews')
+    expect(getNotificationLink(offer)).toBe('/talent/offers/offer-1')
+    expect(isActionRequired(offer)).toBe(true)
+  })
+
+  it('F. client mutation locks prevent duplicate network calls during rapid clicks', async () => {
+    jest.resetModules()
+
+    const deferred = (() => {
+      let resolve: ((value: Response) => void) | null = null
+      const promise = new Promise<Response>((r) => {
+        resolve = r
+      })
+      return { promise, resolve }
+    })()
+
+    global.fetch = jest.fn().mockReturnValue(deferred.promise)
+
+    const { markNotificationRead, markAllNotificationsRead } = await import('@/utils/notifications')
+
+    const p1 = markNotificationRead('n-rapid')
+    const p2 = markNotificationRead('n-rapid')
+
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+
+    deferred.resolve?.({ ok: true } as Response)
+    await Promise.all([p1, p2])
+
+    ;(global.fetch as jest.Mock).mockResolvedValue({ ok: true } as Response)
+    await Promise.all([
+      markAllNotificationsRead(['a', 'b']),
+      markAllNotificationsRead(['a', 'b']),
+      markAllNotificationsRead(['a', 'b']),
+    ])
+
+    expect(global.fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('G. second page can reconcile from DB source of truth after external mutation', async () => {
+    markNotificationUnread.mockResolvedValue(1)
+    markNotificationRead.mockResolvedValue(1)
+
+    const unreadReq = new NextRequest('http://localhost/api/notifications/n1/read', {
+      method: 'PATCH',
+      body: JSON.stringify({ is_read: false }),
+    })
+    const readReq = new NextRequest('http://localhost/api/notifications/n1/read', {
+      method: 'PATCH',
+      body: JSON.stringify({ is_read: true }),
+    })
+
+    await patchNotificationReadRoute(unreadReq, { params: Promise.resolve({ id: 'n1' }) })
+    const refreshed = await patchNotificationReadRoute(readReq, { params: Promise.resolve({ id: 'n1' }) })
+
+    await expect(refreshed.json()).resolves.toMatchObject({ ok: true, updated: 1 })
+  })
+})

--- a/talentify-next-frontend/__tests__/notifications-read-api.test.ts
+++ b/talentify-next-frontend/__tests__/notifications-read-api.test.ts
@@ -1,0 +1,79 @@
+import { NextRequest } from 'next/server'
+import { PATCH as patchNotificationReadRoute } from '@/app/api/notifications/[id]/read/route'
+import { PATCH as patchNotificationsReadAllRoute } from '@/app/api/notifications/read-all/route'
+import {
+  findNotificationOwner,
+  markAllNotificationsRead,
+  markNotificationRead,
+  markNotificationUnread,
+} from '@/lib/repositories/notifications'
+
+jest.mock('@/lib/auth/getCurrentUser', () => ({
+  getCurrentUser: jest.fn(),
+}))
+
+jest.mock('@/lib/repositories/notifications', () => ({
+  findNotificationOwner: jest.fn(),
+  markNotificationRead: jest.fn(),
+  markNotificationUnread: jest.fn(),
+  markAllNotificationsRead: jest.fn(),
+}))
+
+const { getCurrentUser } = jest.requireMock('@/lib/auth/getCurrentUser') as {
+  getCurrentUser: jest.Mock
+}
+
+const mockedFindNotificationOwner = findNotificationOwner as jest.MockedFunction<typeof findNotificationOwner>
+const mockedMarkNotificationRead = markNotificationRead as jest.MockedFunction<typeof markNotificationRead>
+const mockedMarkNotificationUnread = markNotificationUnread as jest.MockedFunction<typeof markNotificationUnread>
+const mockedMarkAllNotificationsRead = markAllNotificationsRead as jest.MockedFunction<typeof markAllNotificationsRead>
+
+describe('notification mutation api idempotency', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    getCurrentUser.mockResolvedValue({ user: { id: 'u1' } })
+  })
+
+  it('returns noop for already-read item instead of 404', async () => {
+    mockedMarkNotificationRead.mockResolvedValue(0)
+    mockedFindNotificationOwner.mockResolvedValue(true)
+
+    const req = new NextRequest('http://localhost/api/notifications/n1/read', {
+      method: 'PATCH',
+      body: JSON.stringify({ is_read: true }),
+    })
+
+    const res = await patchNotificationReadRoute(req, { params: Promise.resolve({ id: 'n1' }) })
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toMatchObject({ ok: true, noop: true, updated: 0 })
+  })
+
+  it('keeps 404 for truly missing notification', async () => {
+    mockedMarkNotificationUnread.mockResolvedValue(0)
+    mockedFindNotificationOwner.mockResolvedValue(false)
+
+    const req = new NextRequest('http://localhost/api/notifications/missing/read', {
+      method: 'PATCH',
+      body: JSON.stringify({ is_read: false }),
+    })
+
+    const res = await patchNotificationReadRoute(req, { params: Promise.resolve({ id: 'missing' }) })
+
+    expect(res.status).toBe(404)
+  })
+
+  it('allows mark-all on empty unread set', async () => {
+    mockedMarkAllNotificationsRead.mockResolvedValue(0)
+
+    const req = new NextRequest('http://localhost/api/notifications/read-all', {
+      method: 'PATCH',
+      body: JSON.stringify({ ids: ['n1'] }),
+    })
+
+    const res = await patchNotificationsReadAllRoute(req)
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toMatchObject({ ok: true, updated: 0 })
+  })
+})

--- a/talentify-next-frontend/__tests__/offers-id-put-api.test.ts
+++ b/talentify-next-frontend/__tests__/offers-id-put-api.test.ts
@@ -1,9 +1,11 @@
 import { NextRequest } from 'next/server'
 import { PUT } from '@/app/api/offers/[id]/route'
 import { findOfferAccessById, updateOfferById } from '@/lib/repositories/offers'
+import { createActionableNotification } from '@/lib/notifications/service'
+import { getCurrentUser } from '@/lib/auth/getCurrentUser'
 
-jest.mock('@/lib/supabase/server', () => ({
-  createClient: jest.fn(),
+jest.mock('@/lib/auth/getCurrentUser', () => ({
+  getCurrentUser: jest.fn(),
 }))
 
 jest.mock('@/lib/repositories/offers', () => ({
@@ -12,31 +14,25 @@ jest.mock('@/lib/repositories/offers', () => ({
   updateOfferById: jest.fn(),
 }))
 
-const { createClient } = jest.requireMock('@/lib/supabase/server') as {
-  createClient: jest.Mock
-}
+jest.mock('@/lib/notifications/service', () => ({
+  createActionableNotification: jest.fn(),
+}))
 
 const mockedFindOfferAccessById = findOfferAccessById as jest.MockedFunction<typeof findOfferAccessById>
 const mockedUpdateOfferById = updateOfferById as jest.MockedFunction<typeof updateOfferById>
-
-function buildSupabaseClient(userId: string | null) {
-  return {
-    client: {
-      auth: {
-        getUser: jest.fn().mockResolvedValue({ data: { user: userId ? { id: userId } : null }, error: null }),
-      },
-    },
-  }
-}
+const mockedCreateActionableNotification = createActionableNotification as jest.MockedFunction<
+  typeof createActionableNotification
+>
+const mockedGetCurrentUser = getCurrentUser as jest.MockedFunction<typeof getCurrentUser>
 
 describe('PUT /api/offers/[id]', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockedGetCurrentUser.mockResolvedValue({ user: { id: 'u-default' }, error: null })
   })
 
   it('returns 404 when offer does not exist', async () => {
-    const supabase = buildSupabaseClient('u1')
-    createClient.mockResolvedValue(supabase.client)
+    mockedGetCurrentUser.mockResolvedValue({ user: { id: 'u1' }, error: null })
     mockedFindOfferAccessById.mockResolvedValue(null)
 
     const req = new NextRequest('http://localhost/api/offers/offer-404', {
@@ -51,8 +47,7 @@ describe('PUT /api/offers/[id]', () => {
   })
 
   it('returns 403 when user is not store/talent owner', async () => {
-    const supabase = buildSupabaseClient('u-other')
-    createClient.mockResolvedValue(supabase.client)
+    mockedGetCurrentUser.mockResolvedValue({ user: { id: 'u-other' }, error: null })
     mockedFindOfferAccessById.mockResolvedValue({
       store_user_id: 'u-store',
       talent_user_id: 'u-talent',
@@ -70,8 +65,7 @@ describe('PUT /api/offers/[id]', () => {
   })
 
   it('returns 400 when no updatable fields are provided', async () => {
-    const supabase = buildSupabaseClient('u-store')
-    createClient.mockResolvedValue(supabase.client)
+    mockedGetCurrentUser.mockResolvedValue({ user: { id: 'u-store' }, error: null })
     mockedFindOfferAccessById.mockResolvedValue({
       store_user_id: 'u-store',
       talent_user_id: 'u-talent',
@@ -89,8 +83,7 @@ describe('PUT /api/offers/[id]', () => {
   })
 
   it('updates allowed fields for store owner', async () => {
-    const supabase = buildSupabaseClient('u-store')
-    createClient.mockResolvedValue(supabase.client)
+    mockedGetCurrentUser.mockResolvedValue({ user: { id: 'u-store' }, error: null })
     mockedUpdateOfferById.mockResolvedValue(1)
     mockedFindOfferAccessById.mockResolvedValue({
       store_user_id: 'u-store',
@@ -110,8 +103,7 @@ describe('PUT /api/offers/[id]', () => {
   })
 
   it('updates allowed fields for talent owner', async () => {
-    const supabase = buildSupabaseClient('u-talent')
-    createClient.mockResolvedValue(supabase.client)
+    mockedGetCurrentUser.mockResolvedValue({ user: { id: 'u-talent' }, error: null })
     mockedUpdateOfferById.mockResolvedValue(1)
     mockedFindOfferAccessById.mockResolvedValue({
       store_user_id: 'u-store',
@@ -129,8 +121,7 @@ describe('PUT /api/offers/[id]', () => {
   })
 
   it('normalizes status before updating', async () => {
-    const supabase = buildSupabaseClient('u-store')
-    createClient.mockResolvedValue(supabase.client)
+    mockedGetCurrentUser.mockResolvedValue({ user: { id: 'u-store' }, error: null })
     mockedUpdateOfferById.mockResolvedValue(1)
     mockedFindOfferAccessById.mockResolvedValue({
       store_user_id: 'u-store',
@@ -145,5 +136,6 @@ describe('PUT /api/offers/[id]', () => {
 
     expect(res.status).toBe(200)
     expect(mockedUpdateOfferById).toHaveBeenCalledWith('offer-1', { status: 'canceled' })
+    expect(mockedCreateActionableNotification).toHaveBeenCalled()
   })
 })

--- a/talentify-next-frontend/app/api/notifications/[id]/read/route.ts
+++ b/talentify-next-frontend/app/api/notifications/[id]/read/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/getCurrentUser'
 import {
+  findNotificationOwner,
   markNotificationRead,
   markNotificationUnread,
 } from '@/lib/repositories/notifications'
@@ -38,10 +39,14 @@ export async function PATCH(req: NextRequest, context: RouteContext) {
       : await markNotificationUnread({ id, userId: user.id })
 
     if (updatedCount === 0) {
+      const exists = await findNotificationOwner({ id, userId: user.id })
+      if (exists) {
+        return NextResponse.json({ ok: true, updated: 0, noop: true })
+      }
       return NextResponse.json({ error: 'notification not found' }, { status: 404 })
     }
 
-    return NextResponse.json({ ok: true })
+    return NextResponse.json({ ok: true, updated: updatedCount, noop: false })
   } catch (error) {
     console.error('failed to update notification read state', error)
     return NextResponse.json({ error: 'failed to update notification' }, { status: 500 })

--- a/talentify-next-frontend/app/api/offers/[id]/route.ts
+++ b/talentify-next-frontend/app/api/offers/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/getCurrentUser'
 import { toDbOfferStatus } from '@/app/lib/offerStatus'
 import { findOfferAccessById, findOfferByIdForAuthUser, updateOfferById } from '@/lib/repositories/offers'
+import { createActionableNotification } from '@/lib/notifications/service'
 
 export async function GET(
   _req: NextRequest,
@@ -86,6 +87,30 @@ export async function PUT(
     }
 
     await updateOfferById(id, updates)
+
+    const updatedStatus = typeof updates.status === 'string' ? updates.status : null
+    const recipientUserId = user.id === storeUserId ? talentUserId : storeUserId
+    if (updatedStatus && recipientUserId) {
+      try {
+        const event =
+          updatedStatus === 'accepted'
+            ? {
+                kind: 'offer_accepted' as const,
+                offerId: id,
+                actorId: user.id,
+              }
+            : {
+                kind: 'offer_updated' as const,
+                offerId: id,
+                actorId: user.id,
+                status: updatedStatus,
+              }
+
+        await createActionableNotification(recipientUserId, event)
+      } catch (notificationError) {
+        console.error('failed to create offer notification', notificationError)
+      }
+    }
 
     // Notify performer or store about status change via webhook if configured
     const webhook = process.env.NOTIFICATION_WEBHOOK_URL

--- a/talentify-next-frontend/components/notifications/NotificationBell.tsx
+++ b/talentify-next-frontend/components/notifications/NotificationBell.tsx
@@ -94,12 +94,14 @@ export default function NotificationBell() {
       <DropdownMenuTrigger asChild>
         <button
           aria-label="通知"
+          data-testid="header-notification-bell"
           className="relative p-2 rounded-full hover:bg-muted focus:outline-none"
         >
           <Bell className="h-6 w-6" />
           {count > 0 && (
             <span
               aria-live="polite"
+              data-testid="header-notification-badge"
               className="absolute -top-1 -right-1 flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-red-500 px-1 text-xs text-white"
             >
               {formatUnreadCount(count)}

--- a/talentify-next-frontend/components/notifications/NotificationsInboxPage.tsx
+++ b/talentify-next-frontend/components/notifications/NotificationsInboxPage.tsx
@@ -106,9 +106,17 @@ export default function NotificationsInboxPage() {
       <div className="flex items-center justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold">通知</h1>
-          <p className="text-sm text-muted-foreground">未読 {unreadCount} 件</p>
+          <p className="text-sm text-muted-foreground" data-testid="notifications-unread-count">
+            未読 {unreadCount} 件
+          </p>
         </div>
-        <Button variant="outline" size="sm" onClick={handleMarkAll} disabled={unreadCount === 0 || isMutating}>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleMarkAll}
+          disabled={unreadCount === 0 || isMutating}
+          data-testid="notifications-mark-all-read"
+        >
           一括既読
         </Button>
       </div>
@@ -125,6 +133,7 @@ export default function NotificationsInboxPage() {
             variant={tab === option.key ? 'default' : 'outline'}
             size="sm"
             onClick={() => setTab(option.key as TabType)}
+            data-testid={`notifications-tab-${option.key}`}
           >
             {option.label}
           </Button>
@@ -135,6 +144,7 @@ export default function NotificationsInboxPage() {
         {items.map((notification) => (
           <div
             key={notification.id}
+            data-testid={`notification-row-${notification.id}`}
             className={`cursor-pointer rounded-lg border p-4 transition hover:bg-accent/40 ${
               notification.is_read ? 'bg-white' : 'bg-blue-50/70 border-blue-100'
             } ${notification.priority === 'high' ? 'border-l-4 border-l-amber-500' : ''}`}

--- a/talentify-next-frontend/components/notifications/notification-meta.ts
+++ b/talentify-next-frontend/components/notifications/notification-meta.ts
@@ -24,7 +24,10 @@ export function getNotificationLink(notification: NotificationRow): string {
 
   const role = resolveRoleFromNotification(notification)
   if (notification.type === 'message') return role === 'store' || role === 'talent' ? `/${role}/messages` : '/app/messages'
-  if (offerId) return `/offers/${offerId}`
+  if (offerId) {
+    if (role === 'store' || role === 'talent') return `/${role}/offers/${offerId}`
+    return `/offers/${offerId}`
+  }
   if (invoiceId) return role === 'store' || role === 'talent' ? `/${role}/invoices/${invoiceId}` : `/invoices/${invoiceId}`
   return resolveFallbackLink(notification)
 }
@@ -35,6 +38,11 @@ export function isActionRequired(notification: NotificationRow): boolean {
   if (data.category === 'announcement' || notification.entity_type === 'announcement') return false
   if (notification.entity_type === 'announcement') return false
   if (isActionRequiredNotification(notification.type)) return true
+  if (notification.type === 'offer_accepted') return false
+  if (notification.type === 'offer_updated') {
+    const status = typeof data.status === 'string' ? data.status.toLowerCase() : ''
+    return ['pending', 'offer_created', 'submitted'].includes(status)
+  }
   return notification.priority === 'high'
 }
 

--- a/talentify-next-frontend/lib/notifications/config.ts
+++ b/talentify-next-frontend/lib/notifications/config.ts
@@ -35,6 +35,25 @@ export type NotificationEvent =
       reviewId: string
       offerId: string
     }
+  | {
+      kind: 'offer_created'
+      actorName?: string | null
+      actorId?: string | null
+      offerId: string
+    }
+  | {
+      kind: 'offer_updated'
+      actorName?: string | null
+      actorId?: string | null
+      offerId: string
+      status?: string | null
+    }
+  | {
+      kind: 'offer_accepted'
+      actorName?: string | null
+      actorId?: string | null
+      offerId: string
+    }
 
 type NotificationCategory = 'announcement' | 'notification'
 
@@ -158,6 +177,61 @@ export const notificationConfig: {
       data: {
         offer_id: event.offerId,
         review_id: event.reviewId,
+      },
+    }),
+  },
+  offer_created: {
+    type: 'offer_created',
+    category: 'notification',
+    isActionable: true,
+    priority: 'high',
+    dedupeStrategy: (event) => `offer-created:${event.offerId}`,
+    build: ({ roleRootPath, event }) => ({
+      title: '新しいオファーが届きました',
+      body: '内容を確認して、回答をお願いします。',
+      actionUrl: `${roleRootPath}/offers/${event.offerId}`,
+      actionLabel: 'オファーを確認',
+      entityType: 'offer',
+      entityId: event.offerId,
+      data: {
+        offer_id: event.offerId,
+      },
+    }),
+  },
+  offer_updated: {
+    type: 'offer_updated',
+    category: 'notification',
+    isActionable: true,
+    priority: 'medium',
+    dedupeStrategy: (event) => `offer-updated:${event.offerId}:${event.status ?? 'unknown'}`,
+    build: ({ roleRootPath, event }) => ({
+      title: 'オファーのステータスが更新されました',
+      body: event.status ? `現在のステータス: ${event.status}` : '最新状態を確認してください。',
+      actionUrl: `${roleRootPath}/offers/${event.offerId}`,
+      actionLabel: 'オファー詳細を見る',
+      entityType: 'offer',
+      entityId: event.offerId,
+      data: {
+        offer_id: event.offerId,
+        status: event.status ?? null,
+      },
+    }),
+  },
+  offer_accepted: {
+    type: 'offer_accepted',
+    category: 'notification',
+    isActionable: false,
+    priority: 'medium',
+    dedupeStrategy: (event) => `offer-accepted:${event.offerId}`,
+    build: ({ roleRootPath, event }) => ({
+      title: 'オファーが承認されました',
+      body: '進行中の作業内容を確認してください。',
+      actionUrl: `${roleRootPath}/offers/${event.offerId}`,
+      actionLabel: 'オファーを見る',
+      entityType: 'offer',
+      entityId: event.offerId,
+      data: {
+        offer_id: event.offerId,
       },
     }),
   },

--- a/talentify-next-frontend/lib/notifications/resolve-recipient-role.ts
+++ b/talentify-next-frontend/lib/notifications/resolve-recipient-role.ts
@@ -16,6 +16,7 @@ type UserIdRow = { user_id: string | null }
 type MessageParticipantRow = { participant_user_ids: string[] | null }
 type InvoiceUserRow = { store_user_id: string | null; talent_user_id: string | null }
 type ReviewUserRow = { store_user_id: string | null; talent_user_id: string | null }
+type OfferUserRow = { store_user_id: string | null; talent_user_id: string | null }
 
 async function resolveRoleByUserId(userId: string | null | undefined): Promise<RecipientRole> {
   if (!userId) return 'unknown'
@@ -109,6 +110,29 @@ export async function resolveRecipientRole({
     if (actorId && actorId === review.talent_user_id) return resolveRoleByUserId(review.store_user_id)
 
     return resolveRoleByUserId(review.talent_user_id ?? review.store_user_id)
+  }
+
+  if (entityType === 'offer') {
+    const rows = await prisma.$queryRaw<OfferUserRow[]>`
+      SELECT
+        s.user_id AS store_user_id,
+        t.user_id AS talent_user_id
+      FROM public.offers o
+      LEFT JOIN public.stores s ON s.id = o.store_id
+      LEFT JOIN public.talents t ON t.id = o.talent_id
+      WHERE o.id = ${entityId}::uuid
+      LIMIT 1
+    `
+
+    const offer = rows[0]
+    if (!offer) return 'unknown'
+
+    if (actorId && actorId === offer.store_user_id) return resolveRoleByUserId(offer.talent_user_id)
+    if (actorId && actorId === offer.talent_user_id) return resolveRoleByUserId(offer.store_user_id)
+
+    const storeRole = await resolveRoleByUserId(offer.store_user_id)
+    if (storeRole !== 'unknown') return storeRole
+    return resolveRoleByUserId(offer.talent_user_id)
   }
 
   return 'unknown'

--- a/talentify-next-frontend/lib/notifications/service.ts
+++ b/talentify-next-frontend/lib/notifications/service.ts
@@ -13,6 +13,9 @@ export async function createActionableNotification(
       if (event.kind === 'message_received') return 'message'
       if (event.kind === 'review_received') return 'review'
       if (event.kind === 'payment_completed_to_talent') return 'payment'
+      if (event.kind === 'offer_created' || event.kind === 'offer_updated' || event.kind === 'offer_accepted') {
+        return 'offer'
+      }
       return 'invoice'
     })(),
     entityId:
@@ -20,7 +23,9 @@ export async function createActionableNotification(
         ? event.messageId
         : event.kind === 'review_received'
           ? event.reviewId
-          : event.invoiceId,
+          : event.kind === 'offer_created' || event.kind === 'offer_updated' || event.kind === 'offer_accepted'
+            ? event.offerId
+            : event.invoiceId,
     actorId: event.actorId,
   })
   const finalRecipientRole = resolvedRole === 'unknown' ? (recipientRole ?? 'unknown') : resolvedRole

--- a/talentify-next-frontend/lib/repositories/notifications.ts
+++ b/talentify-next-frontend/lib/repositories/notifications.ts
@@ -68,6 +68,25 @@ type OfferVisibilityQueryRow = {
   accepted_at: Date | null
 }
 
+export async function findNotificationOwner({
+  id,
+  userId,
+}: {
+  id: string
+  userId: string
+}): Promise<boolean> {
+  const prisma = getPrismaClient()
+  const row = await prisma.notifications.findFirst({
+    where: {
+      id,
+      user_id: userId,
+    },
+    select: { id: true },
+  })
+
+  return Boolean(row)
+}
+
 function resolvePriority(value: string | null): NotificationRow['priority'] {
   return value === 'low' || value === 'high' ? value : 'medium'
 }
@@ -375,6 +394,7 @@ export async function markNotificationRead({
     where: {
       id,
       user_id: userId,
+      is_read: false,
     },
     data: {
       is_read: true,
@@ -396,6 +416,7 @@ export async function markNotificationUnread({
     where: {
       id,
       user_id: userId,
+      is_read: true,
     },
     data: {
       is_read: false,


### PR DESCRIPTION
### Motivation
- Improve notification reliability by adding automated E2E-style checks so unread counts, read/unread flows, and multi-view synchronization are guarded by tests.
- Harden mutation endpoints so double-clicks / retries / concurrent requests do not produce 404s or corrupt unread counts.
- Treat offer-related events with the same notification-quality as message/invoice/review by routing them through the common notification layer and resolving recipient role/action URLs.

### Description
- Added Jest-based end-to-end scenarios that cover unread count/list alignment, single-item read idempotency, bulk-read idempotency, tab query mapping, click-to-destination resolution (message/invoice/review/offer), client-side mutation locking, and simple multi-context reconciliation in `__tests__/notifications-e2e.test.ts` and `__tests__/notifications-read-api.test.ts`.
- Strengthened API-level idempotency by making `markNotificationRead` / `markNotificationUnread` state-aware (only update when state differs) and introduced `findNotificationOwner` to disambiguate `updated=0` results; `PATCH /api/notifications/[id]/read` now returns `ok/updated/noop` (200) for ownership-but-no-op and 404 when missing. (`lib/repositories/notifications.ts`, `app/api/notifications/[id]/read/route.ts`).
- Extended notification coverage for offers by adding `offer_created`, `offer_updated`, and `offer_accepted` events to `notificationConfig`, wiring offers into `createActionableNotification` (entity type resolution), adding offer reverse lookups in `resolveRecipientRole`, and sending offer notifications on offer status updates in the offers API (`lib/notifications/config.ts`, `lib/notifications/service.ts`, `lib/notifications/resolve-recipient-role.ts`, `app/api/offers/[id]/route.ts`).
- Improved UI testability by adding minimal `data-testid` attributes to the inbox and header bell and by making notification click/link resolution role-aware for offers (`components/notifications/NotificationsInboxPage.tsx`, `components/notifications/NotificationBell.tsx`, `components/notifications/notification-meta.ts`).
- Updated existing server tests to mock `getCurrentUser` / notification service as needed so offer API tests remain stable after adding notification creation behavior (`__tests__/offers-id-put-api.test.ts`).

### Testing
- Ran the new and updated Jest suites with: `npm test -- --runInBand __tests__/notifications-read-api.test.ts __tests__/notifications-e2e.test.ts __tests__/notification-offer-config.test.ts __tests__/offers-id-put-api.test.ts`.
- Result: all test suites passed: `4 suites / 19 tests` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf809826c83329edea51dff77ec82)