### PR TITLE
Introduce Playwright E2E, centralize notification emission, and add API idempotency

### DIFF
--- a/supabase/migrations/20260414120000_notification_emit_idempotency_policy.sql
+++ b/supabase/migrations/20260414120000_notification_emit_idempotency_policy.sql
@@ -1,0 +1,38 @@
+-- Centralize notification emission in API/application code and introduce API idempotency-key storage.
+
+-- 1) API idempotency key table for notification endpoints.
+create table if not exists public.notification_idempotency_keys (
+  key text not null,
+  user_id uuid not null,
+  endpoint text not null,
+  response_snapshot jsonb not null,
+  created_at timestamptz not null default now(),
+  expires_at timestamptz not null,
+  primary key (key, user_id, endpoint)
+);
+
+create index if not exists idx_notification_idempo_user_expires
+  on public.notification_idempotency_keys (user_id, expires_at);
+
+-- 2) Do not emit offer_created from DB trigger. Emission is centralized in app/lib/notifications/emit.ts.
+do $$
+declare
+  trigger_name text;
+begin
+  for trigger_name in
+    select t.tgname
+    from pg_trigger t
+    join pg_proc p on p.oid = t.tgfoid
+    join pg_class c on c.oid = t.tgrelid
+    join pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = 'public'
+      and c.relname = 'offers'
+      and p.proname = 'notify_talent_on_offer_created'
+      and not t.tgisinternal
+  loop
+    execute format('drop trigger if exists %I on public.offers', trigger_name);
+  end loop;
+end
+$$;
+
+drop function if exists public.notify_talent_on_offer_created();

--- a/talentify-next-frontend/__tests__/notifications-e2e.test.ts
+++ b/talentify-next-frontend/__tests__/notifications-e2e.test.ts
@@ -18,6 +18,11 @@ jest.mock('@/lib/repositories/notifications', () => ({
   findNotificationOwner: jest.fn(),
 }))
 
+jest.mock('@/lib/notification-idempotency', () => ({
+  getIdempotentResponse: jest.fn().mockResolvedValue(null),
+  persistIdempotentResponse: jest.fn().mockResolvedValue(undefined),
+}))
+
 const { getCurrentUser } = jest.requireMock('@/lib/auth/getCurrentUser') as {
   getCurrentUser: jest.Mock
 }

--- a/talentify-next-frontend/__tests__/notifications-read-api.test.ts
+++ b/talentify-next-frontend/__tests__/notifications-read-api.test.ts
@@ -19,6 +19,11 @@ jest.mock('@/lib/repositories/notifications', () => ({
   markAllNotificationsRead: jest.fn(),
 }))
 
+jest.mock('@/lib/notification-idempotency', () => ({
+  getIdempotentResponse: jest.fn().mockResolvedValue(null),
+  persistIdempotentResponse: jest.fn().mockResolvedValue(undefined),
+}))
+
 const { getCurrentUser } = jest.requireMock('@/lib/auth/getCurrentUser') as {
   getCurrentUser: jest.Mock
 }

--- a/talentify-next-frontend/__tests__/offers-get-api.test.ts
+++ b/talentify-next-frontend/__tests__/offers-get-api.test.ts
@@ -1,6 +1,11 @@
 import { NextRequest } from 'next/server'
 import { GET } from '@/app/api/offers/route'
+import { getCurrentUser } from '@/lib/auth/getCurrentUser'
 import { findStoreOffersByAuthUser } from '@/lib/repositories/offers'
+
+jest.mock('@/lib/auth/getCurrentUser', () => ({
+  getCurrentUser: jest.fn(),
+}))
 
 jest.mock('@/lib/supabase/server', () => ({
   createClient: jest.fn(),
@@ -26,19 +31,17 @@ const { createClient } = jest.requireMock('@/lib/supabase/server') as {
   createClient: jest.Mock
 }
 
+const mockedGetCurrentUser = getCurrentUser as jest.MockedFunction<typeof getCurrentUser>
 const mockedFindStoreOffersByAuthUser = findStoreOffersByAuthUser as jest.MockedFunction<typeof findStoreOffersByAuthUser>
 
 describe('GET /api/offers', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockedGetCurrentUser.mockResolvedValue({ user: { id: 'u-default' }, error: null })
   })
 
   it('returns 401 when unauthenticated', async () => {
-    createClient.mockResolvedValue({
-      auth: {
-        getUser: jest.fn().mockResolvedValue({ data: { user: null } }),
-      },
-    })
+    mockedGetCurrentUser.mockResolvedValue({ user: null, error: null })
 
     const req = new NextRequest('http://localhost/api/offers')
     const res = await GET(req)
@@ -52,11 +55,7 @@ describe('GET /api/offers', () => {
   })
 
   it('returns 400 for invalid status query', async () => {
-    createClient.mockResolvedValue({
-      auth: {
-        getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'u1' } } }),
-      },
-    })
+    mockedGetCurrentUser.mockResolvedValue({ user: { id: 'u1' }, error: null })
 
     const req = new NextRequest('http://localhost/api/offers?status=invalid')
     const res = await GET(req)
@@ -70,11 +69,7 @@ describe('GET /api/offers', () => {
   })
 
   it('normalizes status query and returns offer list', async () => {
-    createClient.mockResolvedValue({
-      auth: {
-        getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'u2' } } }),
-      },
-    })
+    mockedGetCurrentUser.mockResolvedValue({ user: { id: 'u2' }, error: null })
     mockedFindStoreOffersByAuthUser.mockResolvedValue([
       {
         id: 'offer-1',
@@ -104,11 +99,7 @@ describe('GET /api/offers', () => {
   })
 
   it('returns empty list when store is not linked', async () => {
-    createClient.mockResolvedValue({
-      auth: {
-        getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'u3' } } }),
-      },
-    })
+    mockedGetCurrentUser.mockResolvedValue({ user: { id: 'u3' }, error: null })
     mockedFindStoreOffersByAuthUser.mockResolvedValue([])
 
     const req = new NextRequest('http://localhost/api/offers')

--- a/talentify-next-frontend/__tests__/offers-id-get-api.test.ts
+++ b/talentify-next-frontend/__tests__/offers-id-get-api.test.ts
@@ -1,6 +1,11 @@
 import { NextRequest } from 'next/server'
 import { GET } from '@/app/api/offers/[id]/route'
+import { getCurrentUser } from '@/lib/auth/getCurrentUser'
 import { findOfferByIdForAuthUser } from '@/lib/repositories/offers'
+
+jest.mock('@/lib/auth/getCurrentUser', () => ({
+  getCurrentUser: jest.fn(),
+}))
 
 jest.mock('@/lib/supabase/server', () => ({
   createClient: jest.fn(),
@@ -14,19 +19,17 @@ const { createClient } = jest.requireMock('@/lib/supabase/server') as {
   createClient: jest.Mock
 }
 
+const mockedGetCurrentUser = getCurrentUser as jest.MockedFunction<typeof getCurrentUser>
 const mockedFindOfferByIdForAuthUser = findOfferByIdForAuthUser as jest.MockedFunction<typeof findOfferByIdForAuthUser>
 
 describe('GET /api/offers/[id]', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockedGetCurrentUser.mockResolvedValue({ user: { id: 'u-default' }, error: null })
   })
 
   it('returns 401 when unauthenticated', async () => {
-    createClient.mockResolvedValue({
-      auth: {
-        getUser: jest.fn().mockResolvedValue({ data: { user: null }, error: null }),
-      },
-    })
+    mockedGetCurrentUser.mockResolvedValue({ user: null, error: null })
 
     const req = new NextRequest('http://localhost/api/offers/offer-1')
     const res = await GET(req, { params: { id: 'offer-1' } })
@@ -37,11 +40,7 @@ describe('GET /api/offers/[id]', () => {
   })
 
   it('returns 404 when offer is not accessible or does not exist', async () => {
-    createClient.mockResolvedValue({
-      auth: {
-        getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'u1' } }, error: null }),
-      },
-    })
+    mockedGetCurrentUser.mockResolvedValue({ user: { id: 'u1' }, error: null })
     mockedFindOfferByIdForAuthUser.mockResolvedValue(null)
 
     const req = new NextRequest('http://localhost/api/offers/offer-404')
@@ -53,11 +52,7 @@ describe('GET /api/offers/[id]', () => {
   })
 
   it('returns offer detail for authorized user', async () => {
-    createClient.mockResolvedValue({
-      auth: {
-        getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'u2' } }, error: null }),
-      },
-    })
+    mockedGetCurrentUser.mockResolvedValue({ user: { id: 'u2' }, error: null })
     mockedFindOfferByIdForAuthUser.mockResolvedValue({
       id: 'offer-2',
       store_id: 'store-1',
@@ -92,11 +87,7 @@ describe('GET /api/offers/[id]', () => {
   })
 
   it('returns 404 for out-of-scope user access', async () => {
-    createClient.mockResolvedValue({
-      auth: {
-        getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'u-no-access' } }, error: null }),
-      },
-    })
+    mockedGetCurrentUser.mockResolvedValue({ user: { id: 'u-no-access' }, error: null })
     mockedFindOfferByIdForAuthUser.mockResolvedValue(null)
 
     const req = new NextRequest('http://localhost/api/offers/offer-private')

--- a/talentify-next-frontend/__tests__/offers-id-put-api.test.ts
+++ b/talentify-next-frontend/__tests__/offers-id-put-api.test.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server'
 import { PUT } from '@/app/api/offers/[id]/route'
 import { findOfferAccessById, updateOfferById } from '@/lib/repositories/offers'
-import { createActionableNotification } from '@/lib/notifications/service'
+import { emitNotification } from '@/lib/notifications/emit'
 import { getCurrentUser } from '@/lib/auth/getCurrentUser'
 
 jest.mock('@/lib/auth/getCurrentUser', () => ({
@@ -14,15 +14,13 @@ jest.mock('@/lib/repositories/offers', () => ({
   updateOfferById: jest.fn(),
 }))
 
-jest.mock('@/lib/notifications/service', () => ({
-  createActionableNotification: jest.fn(),
+jest.mock('@/lib/notifications/emit', () => ({
+  emitNotification: jest.fn(),
 }))
 
 const mockedFindOfferAccessById = findOfferAccessById as jest.MockedFunction<typeof findOfferAccessById>
 const mockedUpdateOfferById = updateOfferById as jest.MockedFunction<typeof updateOfferById>
-const mockedCreateActionableNotification = createActionableNotification as jest.MockedFunction<
-  typeof createActionableNotification
->
+const mockedEmitNotification = emitNotification as jest.MockedFunction<typeof emitNotification>
 const mockedGetCurrentUser = getCurrentUser as jest.MockedFunction<typeof getCurrentUser>
 
 describe('PUT /api/offers/[id]', () => {
@@ -136,6 +134,6 @@ describe('PUT /api/offers/[id]', () => {
 
     expect(res.status).toBe(200)
     expect(mockedUpdateOfferById).toHaveBeenCalledWith('offer-1', { status: 'canceled' })
-    expect(mockedCreateActionableNotification).toHaveBeenCalled()
+    expect(mockedEmitNotification).toHaveBeenCalled()
   })
 })

--- a/talentify-next-frontend/__tests__/offers-post-api.test.ts
+++ b/talentify-next-frontend/__tests__/offers-post-api.test.ts
@@ -1,6 +1,12 @@
 import { NextRequest } from 'next/server'
 import { POST } from '@/app/api/offers/route'
-import { createOffer, findExistingOfferForCreate, findStoreByIdForAuthUser } from '@/lib/repositories/offers'
+import { getCurrentUser } from '@/lib/auth/getCurrentUser'
+import { createOffer, findExistingOfferForCreate, findOfferAccessById, findStoreByIdForAuthUser } from '@/lib/repositories/offers'
+import { emitNotification } from '@/lib/notifications/emit'
+
+jest.mock('@/lib/auth/getCurrentUser', () => ({
+  getCurrentUser: jest.fn(),
+}))
 
 jest.mock('@/lib/supabase/server', () => ({
   createClient: jest.fn(),
@@ -10,6 +16,7 @@ jest.mock('@/lib/repositories/offers', () => ({
   createOffer: jest.fn(),
   findExistingOfferForCreate: jest.fn(),
   findStoreByIdForAuthUser: jest.fn(),
+  findOfferAccessById: jest.fn(),
   findStoreOffersByAuthUser: jest.fn(),
   OfferCreateConflictError: class OfferCreateConflictError extends Error {},
   OFFER_STATUS_TYPES: [
@@ -26,19 +33,29 @@ jest.mock('@/lib/repositories/offers', () => ({
   ],
 }))
 
+jest.mock('@/lib/notifications/emit', () => ({
+  emitNotification: jest.fn(),
+}))
+
 const { createClient } = jest.requireMock('@/lib/supabase/server') as {
   createClient: jest.Mock
 }
 
+const mockedGetCurrentUser = getCurrentUser as jest.MockedFunction<typeof getCurrentUser>
 const mockedFindStoreByIdForAuthUser = findStoreByIdForAuthUser as jest.MockedFunction<typeof findStoreByIdForAuthUser>
 const mockedFindExistingOfferForCreate = findExistingOfferForCreate as jest.MockedFunction<
   typeof findExistingOfferForCreate
 >
+const mockedFindOfferAccessById = findOfferAccessById as jest.MockedFunction<typeof findOfferAccessById>
 const mockedCreateOffer = createOffer as jest.MockedFunction<typeof createOffer>
+const mockedEmitNotification = emitNotification as jest.MockedFunction<typeof emitNotification>
 
 describe('POST /api/offers', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockedGetCurrentUser.mockResolvedValue({ user: { id: 'u-default' }, error: null })
+    mockedFindOfferAccessById.mockResolvedValue({ store_user_id: 'u1', talent_user_id: 'u2' })
+    mockedEmitNotification.mockResolvedValue(undefined as never)
   })
 
   it('returns 400 for validation error', async () => {
@@ -64,11 +81,7 @@ describe('POST /api/offers', () => {
   })
 
   it('returns 401 when unauthenticated', async () => {
-    createClient.mockResolvedValue({
-      auth: {
-        getUser: jest.fn().mockResolvedValue({ data: { user: null } }),
-      },
-    })
+    mockedGetCurrentUser.mockResolvedValue({ user: null, error: null })
 
     const req = new NextRequest('http://localhost/api/offers', {
       method: 'POST',
@@ -90,11 +103,7 @@ describe('POST /api/offers', () => {
   })
 
   it('returns 403 when store ownership does not match', async () => {
-    createClient.mockResolvedValue({
-      auth: {
-        getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'u1' } } }),
-      },
-    })
+    mockedGetCurrentUser.mockResolvedValue({ user: { id: 'u1' }, error: null })
     mockedFindStoreByIdForAuthUser.mockResolvedValue(null)
 
     const req = new NextRequest('http://localhost/api/offers', {
@@ -118,11 +127,7 @@ describe('POST /api/offers', () => {
   })
 
   it('returns existing offer for idempotent create', async () => {
-    createClient.mockResolvedValue({
-      auth: {
-        getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'u1' } } }),
-      },
-    })
+    mockedGetCurrentUser.mockResolvedValue({ user: { id: 'u1' }, error: null })
     mockedFindStoreByIdForAuthUser.mockResolvedValue({ id: 'store-1', user_id: 'u1' })
     mockedFindExistingOfferForCreate.mockResolvedValue({
       id: 'offer-existing',
@@ -157,11 +162,7 @@ describe('POST /api/offers', () => {
   })
 
   it('creates new offer successfully', async () => {
-    createClient.mockResolvedValue({
-      auth: {
-        getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'u1' } } }),
-      },
-    })
+    mockedGetCurrentUser.mockResolvedValue({ user: { id: 'u1' }, error: null })
     mockedFindStoreByIdForAuthUser.mockResolvedValue({ id: 'store-1', user_id: 'u1' })
     mockedFindExistingOfferForCreate.mockResolvedValue(null)
     mockedCreateOffer.mockResolvedValue({

--- a/talentify-next-frontend/app/api/invoices/[id]/pay/route.ts
+++ b/talentify-next-frontend/app/api/invoices/[id]/pay/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/getCurrentUser'
 import { createClient } from '@/lib/supabase/server'
 import { createServiceClient } from '@/lib/supabase/service'
-import { createActionableNotification } from '@/lib/notifications/service'
+import { emitNotification } from '@/lib/notifications/emit'
 
 export async function POST(
   req: NextRequest,
@@ -63,11 +63,11 @@ export async function POST(
         .eq('id', invoice.talent_id)
         .single()
       if (talent?.user_id) {
-        await createActionableNotification(
-          talent.user_id,
-          { kind: 'payment_completed_to_talent', invoiceId: id, actorName: '店舗', actorId: user.id },
-          'talent',
-        )
+        await emitNotification({
+          recipientUserId: talent.user_id,
+          event: { kind: 'payment_completed_to_talent', invoiceId: id, actorName: '店舗', actorId: user.id },
+          recipientRole: 'talent',
+        })
       }
     } catch (e) {
       console.error('failed to send notification', e)

--- a/talentify-next-frontend/app/api/invoices/[id]/reject/route.ts
+++ b/talentify-next-frontend/app/api/invoices/[id]/reject/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/getCurrentUser'
 import { createClient } from '@/lib/supabase/server'
 import { createServiceClient } from '@/lib/supabase/service'
-import { createActionableNotification } from '@/lib/notifications/service'
+import { emitNotification } from '@/lib/notifications/emit'
 
 export async function POST(
   req: NextRequest,
@@ -55,11 +55,11 @@ export async function POST(
         .eq('id', invoice.talent_id)
         .single()
       if (talent?.user_id) {
-        await createActionableNotification(
-          talent.user_id,
-          { kind: 'invoice_rejected_to_talent', invoiceId: id, actorName: '店舗', actorId: user.id },
-          'talent',
-        )
+        await emitNotification({
+          recipientUserId: talent.user_id,
+          event: { kind: 'invoice_rejected_to_talent', invoiceId: id, actorName: '店舗', actorId: user.id },
+          recipientRole: 'talent',
+        })
       }
     } catch (e) {
       console.error('failed to send notification', e)

--- a/talentify-next-frontend/app/api/invoices/[id]/submit/route.ts
+++ b/talentify-next-frontend/app/api/invoices/[id]/submit/route.ts
@@ -3,7 +3,7 @@ import { getCurrentUser } from '@/lib/auth/getCurrentUser'
 import { createClient } from '@/lib/supabase/server'
 import { createServiceClient } from '@/lib/supabase/service'
 import { getSubmitStatus } from '../../utils'
-import { createActionableNotification } from '@/lib/notifications/service'
+import { emitNotification } from '@/lib/notifications/emit'
 
 export async function POST(
   req: NextRequest,
@@ -60,11 +60,11 @@ export async function POST(
         .eq('id', invoice.store_id)
         .single()
       if (store?.user_id) {
-        await createActionableNotification(
-          store.user_id,
-          { kind: 'invoice_submitted_to_store', invoiceId: id, actorName: '演者', actorId: user.id },
-          'store',
-        )
+        await emitNotification({
+          recipientUserId: store.user_id,
+          event: { kind: 'invoice_submitted_to_store', invoiceId: id, actorName: '演者', actorId: user.id },
+          recipientRole: 'store',
+        })
       }
     } catch (e) {
       console.error('failed to send notification', e)

--- a/talentify-next-frontend/app/api/messages/send/route.ts
+++ b/talentify-next-frontend/app/api/messages/send/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { messages, threads, nextMessageId, nextThreadId, ThreadType } from '../data'
-import { createActionableNotification } from '@/lib/notifications/service'
+import { emitNotification } from '@/lib/notifications/emit'
 
 export const runtime = 'nodejs'
 
@@ -49,9 +49,9 @@ export async function POST(req: NextRequest) {
   thread.lastMessageAt = message.createdAt
 
   try {
-    await createActionableNotification(
-      receiverUserId,
-      {
+    await emitNotification({
+      recipientUserId: receiverUserId,
+      event: {
         kind: 'message_received',
         actorName: senderName,
         actorId: senderUserId,
@@ -59,7 +59,7 @@ export async function POST(req: NextRequest) {
         messageId: message.id,
         offerId: offerId ?? null,
       },
-    )
+    })
   } catch (e) {
     console.error('failed to insert message notification', e)
   }

--- a/talentify-next-frontend/app/api/notifications/[id]/read/route.ts
+++ b/talentify-next-frontend/app/api/notifications/[id]/read/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/getCurrentUser'
+import { getIdempotentResponse, persistIdempotentResponse } from '@/lib/notification-idempotency'
 import {
   findNotificationOwner,
   markNotificationRead,
@@ -22,6 +23,11 @@ export async function PATCH(req: NextRequest, context: RouteContext) {
       return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
     }
 
+    const idempotent = await getIdempotentResponse(req, user.id)
+    if (idempotent) {
+      return idempotent
+    }
+
     const { id } = await context.params
     if (!id) {
       return NextResponse.json({ error: 'invalid request' }, { status: 400 })
@@ -41,12 +47,16 @@ export async function PATCH(req: NextRequest, context: RouteContext) {
     if (updatedCount === 0) {
       const exists = await findNotificationOwner({ id, userId: user.id })
       if (exists) {
-        return NextResponse.json({ ok: true, updated: 0, noop: true })
+        const response = NextResponse.json({ ok: true, updated: 0, noop: true })
+        await persistIdempotentResponse(req, user.id, response)
+        return response
       }
       return NextResponse.json({ error: 'notification not found' }, { status: 404 })
     }
 
-    return NextResponse.json({ ok: true, updated: updatedCount, noop: false })
+    const response = NextResponse.json({ ok: true, updated: updatedCount, noop: false })
+    await persistIdempotentResponse(req, user.id, response)
+    return response
   } catch (error) {
     console.error('failed to update notification read state', error)
     return NextResponse.json({ error: 'failed to update notification' }, { status: 500 })

--- a/talentify-next-frontend/app/api/notifications/read-all/route.ts
+++ b/talentify-next-frontend/app/api/notifications/read-all/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/getCurrentUser'
+import { getIdempotentResponse, persistIdempotentResponse } from '@/lib/notification-idempotency'
 import { markAllNotificationsRead } from '@/lib/repositories/notifications'
 
 export const runtime = 'nodejs'
@@ -12,6 +13,11 @@ export async function PATCH(req: NextRequest) {
       return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
     }
 
+    const idempotent = await getIdempotentResponse(req, user.id)
+    if (idempotent) {
+      return idempotent
+    }
+
     const body = (await req.json().catch(() => ({}))) as { ids?: unknown }
     const ids = Array.isArray(body.ids)
       ? body.ids.filter((id): id is string => typeof id === 'string')
@@ -19,7 +25,9 @@ export async function PATCH(req: NextRequest) {
 
     const updatedCount = await markAllNotificationsRead({ userId: user.id, ids })
 
-    return NextResponse.json({ ok: true, updated: updatedCount })
+    const response = NextResponse.json({ ok: true, updated: updatedCount })
+    await persistIdempotentResponse(req, user.id, response)
+    return response
   } catch (error) {
     console.error('failed to mark all notifications as read', error)
     return NextResponse.json({ error: 'failed to update notifications' }, { status: 500 })

--- a/talentify-next-frontend/app/api/notifications/review-received/route.ts
+++ b/talentify-next-frontend/app/api/notifications/review-received/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createActionableNotification } from '@/lib/notifications/service'
+import { emitNotification } from '@/lib/notifications/emit'
 
 export const runtime = 'nodejs'
 
@@ -11,11 +11,11 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'missing fields' }, { status: 400 })
     }
 
-    await createActionableNotification(
+    await emitNotification({
       recipientUserId,
-      { kind: 'review_received', offerId, reviewId, actorName: '店舗' },
-      'talent',
-    )
+      event: { kind: 'review_received', offerId, reviewId, actorName: '店舗' },
+      recipientRole: 'talent',
+    })
 
     return NextResponse.json({ ok: true })
   } catch (e) {

--- a/talentify-next-frontend/app/api/notifications/route.ts
+++ b/talentify-next-frontend/app/api/notifications/route.ts
@@ -7,6 +7,7 @@ import {
 } from '@/lib/repositories/notifications'
 import type { Json } from '@/types/supabase'
 import { isNotificationType } from '@/types/notifications'
+import { getIdempotentResponse, persistIdempotentResponse } from '@/lib/notification-idempotency'
 
 export const runtime = 'nodejs'
 
@@ -101,6 +102,11 @@ export async function POST(req: NextRequest) {
       group_key,
     } = await req.json()
 
+    const idempotent = await getIdempotentResponse(req, user.id)
+    if (idempotent) {
+      return idempotent
+    }
+
     if (!title || !isNotificationType(type)) {
       return NextResponse.json({ error: 'invalid request' }, { status: 400 })
     }
@@ -131,7 +137,9 @@ export async function POST(req: NextRequest) {
         group_key: typeof group_key === 'string' ? group_key : null,
       })
 
-      return NextResponse.json({ data })
+      const response = NextResponse.json({ data })
+      await persistIdempotentResponse(req, user.id, response)
+      return response
     } catch (error) {
       const message = error instanceof Error ? error.message : 'failed to insert notification'
       console.error('failed to insert notification', { user_id: user.id, type, error })

--- a/talentify-next-frontend/app/api/offers/[id]/route.ts
+++ b/talentify-next-frontend/app/api/offers/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth/getCurrentUser'
 import { toDbOfferStatus } from '@/app/lib/offerStatus'
 import { findOfferAccessById, findOfferByIdForAuthUser, updateOfferById } from '@/lib/repositories/offers'
-import { createActionableNotification } from '@/lib/notifications/service'
+import { emitNotification } from '@/lib/notifications/emit'
 
 export async function GET(
   _req: NextRequest,
@@ -106,7 +106,7 @@ export async function PUT(
                 status: updatedStatus,
               }
 
-        await createActionableNotification(recipientUserId, event)
+        await emitNotification({ recipientUserId, event })
       } catch (notificationError) {
         console.error('failed to create offer notification', notificationError)
       }

--- a/talentify-next-frontend/app/api/offers/route.ts
+++ b/talentify-next-frontend/app/api/offers/route.ts
@@ -8,7 +8,9 @@ import {
   OFFER_STATUS_TYPES,
   OfferCreateConflictError,
   OfferStatusType,
+  findOfferAccessById,
 } from '@/lib/repositories/offers'
+import { emitNotification } from '@/lib/notifications/emit'
 
 export const runtime = 'nodejs'
 
@@ -112,7 +114,22 @@ export async function POST(req: NextRequest) {
       status: 'pending',
     })
 
-    // Notification creation is handled by a database trigger
+    const access = await findOfferAccessById(offer.id)
+    if (access?.talent_user_id) {
+      try {
+        await emitNotification({
+          recipientUserId: access.talent_user_id,
+          event: {
+            kind: 'offer_created',
+            offerId: offer.id,
+            actorId: user.id,
+          },
+        })
+      } catch (notificationError) {
+        console.error('failed to create offer notification', notificationError)
+      }
+    }
+
     return NextResponse.json({ ok: true, offer })
   } catch (error) {
     if (error instanceof OfferCreateConflictError) {

--- a/talentify-next-frontend/components/notifications/NotificationItem.tsx
+++ b/talentify-next-frontend/components/notifications/NotificationItem.tsx
@@ -30,6 +30,11 @@ function resolveIcon(type: string) {
   return typeIcon[prefix] || Info
 }
 
+function isResurfacedNotification(createdAt: string | null, updatedAt: string | null): boolean {
+  if (!createdAt || !updatedAt) return false
+  return new Date(updatedAt).getTime() - new Date(createdAt).getTime() > 60_000
+}
+
 export default function NotificationItem({ notification, onRead, className }: Props) {
   const router = useRouter()
   const Icon = resolveIcon(notification.type)
@@ -68,6 +73,9 @@ export default function NotificationItem({ notification, onRead, className }: Pr
           <span>
             {formatDistanceToNow(new Date(notification.created_at), { addSuffix: true, locale: ja })}
           </span>
+          {isResurfacedNotification(notification.created_at, notification.updated_at) && (
+            <span className="text-amber-700">再通知</span>
+          )}
           <span className="ml-auto text-primary">{getActionLabel(notification)}</span>
         </div>
       </div>

--- a/talentify-next-frontend/components/notifications/NotificationsInboxPage.tsx
+++ b/talentify-next-frontend/components/notifications/NotificationsInboxPage.tsx
@@ -21,6 +21,13 @@ const PRIORITY_LABEL: Record<NotificationRow['priority'], string> = {
   high: '高',
 }
 
+
+function isResurfacedNotification(notification: NotificationRow): boolean {
+  const createdAt = new Date(notification.created_at).getTime()
+  const updatedAt = new Date(notification.updated_at).getTime()
+  return Number.isFinite(createdAt) && Number.isFinite(updatedAt) && updatedAt - createdAt > 60_000
+}
+
 export default function NotificationsInboxPage() {
   const [items, setItems] = useState<NotificationRow[]>([])
   const [tab, setTab] = useState<TabType>('all')
@@ -164,6 +171,7 @@ export default function NotificationsInboxPage() {
             <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
               <span>{notification.actor_name || 'Talentify'}</span>
               <span>{formatJaDateTimeWithWeekday(notification.created_at)}</span>
+              {isResurfacedNotification(notification) && <span className="text-amber-700">再通知</span>}
               <span className="ml-auto text-primary">{getActionLabel(notification)}</span>
             </div>
           </div>

--- a/talentify-next-frontend/e2e/notifications.spec.ts
+++ b/talentify-next-frontend/e2e/notifications.spec.ts
@@ -1,0 +1,118 @@
+import { expect, test, type APIRequestContext, type Page } from '@playwright/test'
+
+function uniqueKey(prefix: string) {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+async function ensureLoggedIn(page: Page) {
+  await page.goto('/app/notifications')
+  await expect(page.getByRole('heading', { name: '通知' })).toBeVisible()
+}
+
+async function seedNotification(request: APIRequestContext, opts?: { groupKey?: string; title?: string }) {
+  const response = await request.post('/api/notifications', {
+    headers: {
+      'Content-Type': 'application/json',
+      'Idempotency-Key': uniqueKey('seed'),
+    },
+    data: {
+      type: 'offer_created',
+      title: opts?.title ?? `E2E通知 ${uniqueKey('title')}`,
+      body: 'E2E body',
+      action_url: '/talent/offers/e2e-offer-id',
+      entity_type: 'offer',
+      entity_id: 'e2e-offer-id',
+      group_key: opts?.groupKey ?? null,
+      data: {
+        offer_id: 'e2e-offer-id',
+      },
+    },
+  })
+
+  expect(response.ok()).toBeTruthy()
+  const payload = (await response.json()) as { data: { id: string; title: string } }
+  return payload.data
+}
+
+async function unreadCount(page: Page): Promise<number> {
+  const text = await page.getByTestId('notifications-unread-count').innerText()
+  const match = text.match(/(\d+)/)
+  return match ? Number(match[1]) : 0
+}
+
+test.describe('notifications e2e', () => {
+  test('A. 未読同期: ヘッダーと一覧の未読件数が一致する', async ({ page, request }) => {
+    await ensureLoggedIn(page)
+    await seedNotification(request)
+
+    await page.reload()
+
+    const listCount = await unreadCount(page)
+    await expect(page.getByTestId('header-notification-badge')).toHaveText(String(listCount))
+  })
+
+  test('B. 個別既読: クリックで遷移し未読が減る', async ({ page, request }) => {
+    await ensureLoggedIn(page)
+    const seeded = await seedNotification(request)
+
+    await page.reload()
+    const before = await unreadCount(page)
+
+    await page.getByTestId(`notification-row-${seeded.id}`).click()
+    await expect(page).toHaveURL(/offers\//)
+
+    await page.goto('/app/notifications')
+    const after = await unreadCount(page)
+    expect(after).toBeLessThanOrEqual(before)
+  })
+
+  test('C/E. 一括既読 + 連打耐性: 件数が壊れず0になる', async ({ page, request }) => {
+    await ensureLoggedIn(page)
+    await seedNotification(request)
+    await seedNotification(request)
+
+    await page.reload()
+
+    const markAll = page.getByTestId('notifications-mark-all-read')
+    await Promise.all([markAll.click(), markAll.click(), markAll.click()])
+
+    await expect(page.getByTestId('notifications-unread-count')).toContainText('未読 0 件')
+    await expect(page.getByText('未読', { exact: true })).toHaveCount(0)
+  })
+
+  test('D. 2ページ同期: 片方で既読後、もう片方の再取得で反映される', async ({ browser, request }) => {
+    const context1 = await browser.newContext()
+    const context2 = await browser.newContext()
+    const page1 = await context1.newPage()
+    const page2 = await context2.newPage()
+
+    const seeded = await seedNotification(request)
+
+    await ensureLoggedIn(page1)
+    await ensureLoggedIn(page2)
+
+    await page1.reload()
+    await page2.reload()
+
+    await page1.getByTestId(`notification-row-${seeded.id}`).click()
+    await expect(page1).toHaveURL(/offers\//)
+
+    await page2.goto('/app/notifications')
+    await expect(page2.getByTestId('notifications-unread-count')).toContainText('未読')
+
+    await context1.close()
+    await context2.close()
+  })
+
+  test('F. offer通知遷移: role別の正しいURLに遷移する', async ({ page, request }) => {
+    await ensureLoggedIn(page)
+    const seeded = await seedNotification(request, {
+      title: `Offer role test ${uniqueKey('offer')}`,
+      groupKey: uniqueKey('group'),
+    })
+
+    await page.reload()
+    await page.getByTestId(`notification-row-${seeded.id}`).click()
+    await expect(page).toHaveURL(/\/offers\//)
+  })
+})

--- a/talentify-next-frontend/jest.config.js
+++ b/talentify-next-frontend/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
     '^@utils/(.*)$': '<rootDir>/utils/$1',
     '^@types/(.*)$': '<rootDir>/types/$1'
   },
+  testPathIgnorePatterns: ['<rootDir>/e2e/'],
   globals: {
     'ts-jest': {
       tsconfig: {

--- a/talentify-next-frontend/lib/notification-idempotency.ts
+++ b/talentify-next-frontend/lib/notification-idempotency.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { findIdempotentResponse, saveIdempotentResponse } from '@/lib/repositories/notification-idempotency'
+
+export function getIdempotencyContext(req: NextRequest, userId: string) {
+  const key = req.headers.get('idempotency-key')?.trim()
+  if (!key) {
+    return null
+  }
+
+  return {
+    key,
+    endpoint: `${req.method}:${req.nextUrl.pathname}`,
+    userId,
+  }
+}
+
+export async function getIdempotentResponse(req: NextRequest, userId: string): Promise<NextResponse | null> {
+  const ctx = getIdempotencyContext(req, userId)
+  if (!ctx) {
+    return null
+  }
+
+  const snapshot = await findIdempotentResponse(ctx)
+  if (!snapshot) {
+    return null
+  }
+
+  return NextResponse.json(snapshot.body, { status: snapshot.status })
+}
+
+export async function persistIdempotentResponse(req: NextRequest, userId: string, res: NextResponse) {
+  const ctx = getIdempotencyContext(req, userId)
+  if (!ctx) {
+    return
+  }
+
+  const cloned = res.clone()
+  let body: unknown
+
+  try {
+    body = await cloned.json()
+  } catch {
+    body = null
+  }
+
+  await saveIdempotentResponse({
+    ...ctx,
+    snapshot: {
+      status: res.status,
+      body,
+    },
+  })
+}

--- a/talentify-next-frontend/lib/notifications/emit.ts
+++ b/talentify-next-frontend/lib/notifications/emit.ts
@@ -1,0 +1,20 @@
+import type { NotificationEvent } from '@/lib/notifications/config'
+import type { RecipientRole } from '@/lib/notifications/payload'
+
+export type EmitNotificationInput = {
+  recipientUserId: string
+  event: NotificationEvent
+  recipientRole?: RecipientRole
+}
+
+/**
+ * Centralized notification emit entrypoint.
+ *
+ * Policy:
+ * - offer_created emits only on initial offer creation.
+ * - offer status changes emit offer_updated / offer_accepted, never offer_created.
+ */
+export async function emitNotification({ recipientUserId, event, recipientRole }: EmitNotificationInput) {
+  const { createActionableNotification } = await import('@/lib/notifications/service')
+  return createActionableNotification(recipientUserId, event, recipientRole)
+}

--- a/talentify-next-frontend/lib/repositories/notification-idempotency.ts
+++ b/talentify-next-frontend/lib/repositories/notification-idempotency.ts
@@ -1,0 +1,88 @@
+import { Prisma } from '@prisma/client'
+import { getPrismaClient } from '@/lib/prisma'
+
+const DEFAULT_TTL_MINUTES = 10
+
+type IdempotentSnapshot = {
+  status: number
+  body: unknown
+}
+
+type FindInput = {
+  key: string
+  userId: string
+  endpoint: string
+}
+
+type SaveInput = FindInput & {
+  snapshot: IdempotentSnapshot
+  ttlMinutes?: number
+}
+
+type IdempotencyRow = {
+  response_snapshot: Prisma.JsonValue
+}
+
+export async function findIdempotentResponse({ key, userId, endpoint }: FindInput): Promise<IdempotentSnapshot | null> {
+  const prisma = getPrismaClient()
+
+  const rows = await prisma.$queryRaw<IdempotencyRow[]>`
+    SELECT response_snapshot
+    FROM public.notification_idempotency_keys
+    WHERE key = ${key}
+      AND user_id = ${userId}::uuid
+      AND endpoint = ${endpoint}
+      AND expires_at > NOW()
+    LIMIT 1
+  `
+
+  const snapshot = rows[0]?.response_snapshot
+  if (!snapshot || typeof snapshot !== 'object' || Array.isArray(snapshot)) {
+    return null
+  }
+
+  const status = (snapshot as Record<string, unknown>).status
+  const body = (snapshot as Record<string, unknown>).body
+  if (typeof status !== 'number') {
+    return null
+  }
+
+  return {
+    status,
+    body,
+  }
+}
+
+export async function saveIdempotentResponse({
+  key,
+  userId,
+  endpoint,
+  snapshot,
+  ttlMinutes = DEFAULT_TTL_MINUTES,
+}: SaveInput): Promise<void> {
+  const prisma = getPrismaClient()
+
+  await prisma.$executeRaw`
+    INSERT INTO public.notification_idempotency_keys (
+      key,
+      user_id,
+      endpoint,
+      response_snapshot,
+      created_at,
+      expires_at
+    )
+    VALUES (
+      ${key},
+      ${userId}::uuid,
+      ${endpoint},
+      ${JSON.stringify(snapshot)}::jsonb,
+      NOW(),
+      NOW() + (${ttlMinutes} * INTERVAL '1 minute')
+    )
+    ON CONFLICT (key, user_id, endpoint)
+    DO UPDATE SET
+      response_snapshot = EXCLUDED.response_snapshot,
+      created_at = NOW(),
+      expires_at = EXCLUDED.expires_at
+  `
+}

--- a/talentify-next-frontend/package-lock.json
+++ b/talentify-next-frontend/package-lock.json
@@ -42,6 +42,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@playwright/test": "^1.54.2",
         "@tailwindcss/postcss": "^4.1.11",
         "@types/jest": "^30.0.0",
         "@types/node": "24.0.10",
@@ -1714,6 +1715,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -10083,6 +10100,53 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/talentify-next-frontend/package.json
+++ b/talentify-next-frontend/package.json
@@ -7,7 +7,9 @@
     "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest"
+    "test": "jest",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
@@ -55,7 +57,8 @@
     "jest": "^30.0.4",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",
-    "ts-jest": "^29.4.0"
+    "ts-jest": "^29.4.0",
+    "@playwright/test": "^1.54.2"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.9",

--- a/talentify-next-frontend/playwright.config.ts
+++ b/talentify-next-frontend/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:3000'
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 60_000,
+  expect: {
+    timeout: 10_000,
+  },
+  fullyParallel: false,
+  retries: process.env.CI ? 1 : 0,
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+})

--- a/talentify-next-frontend/prisma/schema.prisma
+++ b/talentify-next-frontend/prisma/schema.prisma
@@ -309,6 +309,21 @@ model notifications {
 
 /// This table contains check constraints and requires additional setup for migrations. Visit https://pris.ly/d/check-constraints for more info.
 /// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+
+
+model notification_idempotency_keys {
+  key               String   @db.VarChar(255)
+  user_id           String   @db.Uuid
+  endpoint          String   @db.VarChar(255)
+  response_snapshot Json
+  created_at        DateTime @default(now()) @db.Timestamptz(6)
+  expires_at        DateTime @db.Timestamptz(6)
+
+  @@id([key, user_id, endpoint])
+  @@index([user_id, expires_at], map: "idx_notification_idempo_user_expires")
+  @@schema("public")
+}
+
 model offer_messages {
   id            String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   offer_id      String?  @db.Uuid


### PR DESCRIPTION
### Motivation
- Ensure notification correctness in real browsers by adding Playwright E2E coverage for user-facing flows.
- Prevent duplicate or hard-to-trace notifications by centralizing emit logic and unifying the `offer_created` policy (emit only on initial create).
- Make notification-related endpoints robust to retries by adding API-level idempotency keys and a small TTL-backed storage.
- Finalize updated_at UX so surfaced/resurfaced items are ordered by `updated_at` while showing `created_at` with a “再通知” label.

### Description
- Added Playwright configuration (`playwright.config.ts`), an E2E suite (`e2e/notifications.spec.ts`), and `package.json` scripts (`test:e2e`, `test:e2e:ui`) to drive browser tests for unread sync, single-read, mark-all, two-context sync, rapid-click resilience, and offer navigation.
- Introduced a centralized emit entrypoint `lib/notifications/emit.ts` and switched API callsites to use `emitNotification`, clarifying that `offer_created` is emitted only from the offer create path while status changes emit `offer_updated`/`offer_accepted`.
- Implemented API-level idempotency: new Prisma model and Supabase migration `notification_idempotency_keys`, repo helpers `lib/repositories/notification-idempotency.ts`, route helper `lib/notification-idempotency.ts`, and wiring into `POST /api/notifications`, `PATCH /api/notifications/[id]/read`, and `PATCH /api/notifications/read-all` with default TTL (10 minutes).
- Updated UI logic to keep sorting by `updated_at` while displaying `created_at` and show a `再通知` badge when `updated_at - created_at > 60s`, and adjusted Jest config/tests to mock/idempotency-aware behavior and to exclude `e2e/` from Jest runs.

### Testing
- Ran the full Jest suite with `npm test -- --runInBand`, and the final run completed successfully with all Jest suites passing (`24` test suites, `79` tests passed). 
- Verified targeted API unit suites with `npx jest __tests__/offers-post-api.test.ts __tests__/offers-get-api.test.ts __tests__/offers-id-api.test.ts --runInBand`, which passed.
- Confirmed Playwright tests are discoverable via `npm run test:e2e -- --list`, which listed the 5 notifications scenarios (Playwright execution environment and authenticated browser state are prepared separately in CI).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddfc6515288332a9412d76afe5902a)