### PR TITLE
Fix unread notifications tab filter mismatch

### DIFF
--- a/talentify-next-frontend/__tests__/notification-filters.test.ts
+++ b/talentify-next-frontend/__tests__/notification-filters.test.ts
@@ -1,0 +1,19 @@
+import { buildNotificationFilter } from '@/components/notifications/notification-filters'
+
+describe('buildNotificationFilter', () => {
+  test('未読タブは is_read=false のみで絞り込む', () => {
+    expect(buildNotificationFilter('unread')).toEqual({ unreadOnly: true })
+  })
+
+  test('要対応タブは actionable のみで絞り込む', () => {
+    expect(buildNotificationFilter('action_required')).toEqual({ actionableOnly: true })
+  })
+
+  test('お知らせタブは category=announcement で絞り込む', () => {
+    expect(buildNotificationFilter('announcement')).toEqual({ category: 'announcement' })
+  })
+
+  test('すべてタブは追加条件なし', () => {
+    expect(buildNotificationFilter('all')).toEqual({})
+  })
+})

--- a/talentify-next-frontend/__tests__/notifications-e2e.test.ts
+++ b/talentify-next-frontend/__tests__/notifications-e2e.test.ts
@@ -142,7 +142,7 @@ describe('notifications quality e2e', () => {
 
     await getNotificationsRoute(new NextRequest('http://localhost/api/notifications?unread_only=true'))
     expect(findNotificationsByUser).toHaveBeenLastCalledWith(
-      expect.objectContaining({ unreadOnly: true, actionableOnly: false }),
+      expect.objectContaining({ unreadOnly: true, actionableOnly: false, category: undefined }),
     )
 
     await getNotificationsRoute(new NextRequest('http://localhost/api/notifications?actionable_only=true'))

--- a/talentify-next-frontend/__tests__/notifications.test.ts
+++ b/talentify-next-frontend/__tests__/notifications.test.ts
@@ -54,6 +54,74 @@ test('getNotifications fetches notifications from API', async () => {
   expect(global.fetch).toHaveBeenCalledWith('/api/notifications?limit=5')
 })
 
+test('getNotifications builds unread-only query without actionable/category constraints', async () => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ data: [] }),
+  } as Response)
+
+  const { getNotifications } = await import('@/utils/notifications')
+  await getNotifications({ unreadOnly: true })
+
+  expect(global.fetch).toHaveBeenCalledWith('/api/notifications?unread_only=true')
+})
+
+test('getNotifications returns unread offer_created/payment_created even when not actionable', async () => {
+  const mockData: NotificationRow[] = [
+    {
+      id: 'offer-1',
+      user_id: 'user1',
+      type: 'offer_created',
+      title: 'offer',
+      body: null,
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+      is_read: false,
+      data: { is_actionable: false },
+      read_at: null,
+      priority: 'medium',
+      action_url: null,
+      action_label: null,
+      entity_type: 'offer',
+      entity_id: 'offer-1',
+      actor_name: null,
+      expires_at: null,
+      group_key: null,
+    },
+    {
+      id: 'payment-1',
+      user_id: 'user1',
+      type: 'payment_created',
+      title: 'payment',
+      body: null,
+      created_at: '2026-01-02T00:00:00.000Z',
+      updated_at: '2026-01-02T00:00:00.000Z',
+      is_read: false,
+      data: { is_actionable: false },
+      read_at: null,
+      priority: 'medium',
+      action_url: null,
+      action_label: null,
+      entity_type: 'payment',
+      entity_id: 'payment-1',
+      actor_name: null,
+      expires_at: null,
+      group_key: null,
+    },
+  ]
+
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ data: mockData }),
+  } as Response)
+
+  const { getNotifications } = await import('@/utils/notifications')
+  const data = await getNotifications({ unreadOnly: true })
+
+  expect(data.map((item) => item.type)).toEqual(['offer_created', 'payment_created'])
+  expect(global.fetch).toHaveBeenCalledWith('/api/notifications?unread_only=true')
+})
+
 test('getUnreadNotificationCount returns unread count from API', async () => {
   global.fetch = jest.fn().mockResolvedValue({
     ok: true,

--- a/talentify-next-frontend/components/notifications/NotificationsInboxPage.tsx
+++ b/talentify-next-frontend/components/notifications/NotificationsInboxPage.tsx
@@ -12,8 +12,7 @@ import {
 } from '@/utils/notifications'
 import { formatJaDateTimeWithWeekday } from '@/utils/formatJaDateTimeWithWeekday'
 import { getActionLabel, getNotificationLink, isActionRequired } from './notification-meta'
-
-type TabType = 'all' | 'unread' | 'action_required' | 'announcement'
+import { buildNotificationFilter, type NotificationInboxTab } from './notification-filters'
 
 const PRIORITY_LABEL: Record<NotificationRow['priority'], string> = {
   low: '低',
@@ -30,16 +29,12 @@ function isResurfacedNotification(notification: NotificationRow): boolean {
 
 export default function NotificationsInboxPage() {
   const [items, setItems] = useState<NotificationRow[]>([])
-  const [tab, setTab] = useState<TabType>('all')
+  const [tab, setTab] = useState<NotificationInboxTab>('all')
   const [unreadCount, setUnreadCount] = useState(0)
   const [isMutating, setIsMutating] = useState(false)
 
-  const loadNotifications = async (currentTab: TabType) => {
-    const data = await getNotifications({
-      unreadOnly: currentTab === 'unread',
-      actionableOnly: currentTab === 'action_required',
-      category: currentTab === 'announcement' ? 'announcement' : currentTab === 'all' ? undefined : 'notification',
-    })
+  const loadNotifications = async (currentTab: NotificationInboxTab) => {
+    const data = await getNotifications(buildNotificationFilter(currentTab))
     setItems(data)
   }
 
@@ -139,7 +134,7 @@ export default function NotificationsInboxPage() {
             key={option.key}
             variant={tab === option.key ? 'default' : 'outline'}
             size="sm"
-            onClick={() => setTab(option.key as TabType)}
+            onClick={() => setTab(option.key as NotificationInboxTab)}
             data-testid={`notifications-tab-${option.key}`}
           >
             {option.label}

--- a/talentify-next-frontend/components/notifications/notification-filters.ts
+++ b/talentify-next-frontend/components/notifications/notification-filters.ts
@@ -1,0 +1,17 @@
+import type { GetNotificationsOptions } from '@/utils/notifications'
+
+export type NotificationInboxTab = 'all' | 'unread' | 'action_required' | 'announcement'
+
+export function buildNotificationFilter(tab: NotificationInboxTab): GetNotificationsOptions {
+  switch (tab) {
+    case 'unread':
+      return { unreadOnly: true }
+    case 'action_required':
+      return { actionableOnly: true }
+    case 'announcement':
+      return { category: 'announcement' }
+    case 'all':
+    default:
+      return {}
+  }
+}

--- a/talentify-next-frontend/utils/notifications.ts
+++ b/talentify-next-frontend/utils/notifications.ts
@@ -28,7 +28,7 @@ type GetUnreadCountResponse = {
   count?: number
 }
 
-type GetNotificationsOptions = {
+export type GetNotificationsOptions = {
   limit?: number
   unreadOnly?: boolean
   actionableOnly?: boolean


### PR DESCRIPTION
### Motivation

- The unread tab was more restrictive than the header unread count because additional filters (actionable/category) were being applied, causing unread notifications (e.g. `offer_created` / `payment_created`) to be excluded from the unread list.

### Description

- Introduced a shared `buildNotificationFilter` (`components/notifications/notification-filters.ts`) to map inbox tabs to API query options and keep tab semantics explicit.
- Refactored `NotificationsInboxPage` to use the shared filter builder so the `unread` tab now requests only `unread_only=true` and does not implicitly add `actionable` or category constraints.
- Exported `GetNotificationsOptions` from `utils/notifications.ts` for typed reuse and updated client fetch behavior accordingly.
- Added/updated tests: `__tests__/notification-filters.test.ts` (new), extended `__tests__/notifications.test.ts` with unread-query and offer/payment cases, and tightened `__tests__/notifications-e2e.test.ts` assertions to verify consistent repository mapping.

### Testing

- Ran `npm test -- --runInBand __tests__/notification-filters.test.ts __tests__/notifications.test.ts __tests__/notifications-e2e.test.ts` and all test suites passed. 
- Test summary: 3 test suites, 20 tests, all passed. 
- Note: `npm` emitted an unrelated `Unknown env config "http-proxy"` warning during test startup but it did not affect test results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dee13bd8948332a530e9e23011c4fe)