### PR TITLE
Fix unread notifications list/count drift and add end-to-end filter diagnostics

### DIFF
--- a/talentify-next-frontend/__tests__/notifications-e2e.test.ts
+++ b/talentify-next-frontend/__tests__/notifications-e2e.test.ts
@@ -137,17 +137,17 @@ describe('notifications quality e2e', () => {
 
     await getNotificationsRoute(new NextRequest('http://localhost/api/notifications'))
     expect(findNotificationsByUser).toHaveBeenLastCalledWith(
-      expect.objectContaining({ unreadOnly: false, actionableOnly: false, category: undefined }),
+      expect.objectContaining({ unreadOnly: false, actionableOnly: false }),
     )
 
     await getNotificationsRoute(new NextRequest('http://localhost/api/notifications?unread_only=true'))
     expect(findNotificationsByUser).toHaveBeenLastCalledWith(
-      expect.objectContaining({ unreadOnly: true, actionableOnly: false, category: undefined }),
+      expect.objectContaining({ unreadOnly: true, actionableOnly: false }),
     )
 
     await getNotificationsRoute(new NextRequest('http://localhost/api/notifications?actionable_only=true'))
     expect(findNotificationsByUser).toHaveBeenLastCalledWith(
-      expect.objectContaining({ unreadOnly: false, actionableOnly: true, category: undefined }),
+      expect.objectContaining({ unreadOnly: false, actionableOnly: true }),
     )
 
     await getNotificationsRoute(new NextRequest('http://localhost/api/notifications?category=announcement'))
@@ -229,5 +229,24 @@ describe('notifications quality e2e', () => {
     const refreshed = await patchNotificationReadRoute(readReq, { params: Promise.resolve({ id: 'n1' }) })
 
     await expect(refreshed.json()).resolves.toMatchObject({ ok: true, updated: 1 })
+  })
+
+  it('H. unread list includes offer_created/payment_created without category/actionable constraints', async () => {
+    findNotificationsByUser.mockResolvedValue([
+      buildNotification({ id: 'offer-1', type: 'offer_created', is_read: false, entity_type: 'offer' }),
+      buildNotification({ id: 'payment-1', type: 'payment_created', is_read: false, entity_type: 'payment' }),
+    ])
+
+    const listReq = new NextRequest('http://localhost/api/notifications?unread_only=true')
+    const listRes = await getNotificationsRoute(listReq)
+    const listBody = await listRes.json()
+
+    expect(listBody.data.map((item: NotificationRow) => item.type)).toEqual([
+      'offer_created',
+      'payment_created',
+    ])
+    expect(findNotificationsByUser).toHaveBeenCalledWith(
+      expect.objectContaining({ unreadOnly: true, actionableOnly: false }),
+    )
   })
 })

--- a/talentify-next-frontend/__tests__/notifications-inbox-filters.test.ts
+++ b/talentify-next-frontend/__tests__/notifications-inbox-filters.test.ts
@@ -1,0 +1,35 @@
+import {
+  buildNotificationCountFilter,
+  buildNotificationListFilter,
+  buildUnreadNotificationFilter,
+} from '@/lib/notifications/inbox-filters'
+
+describe('notifications inbox shared filters', () => {
+  test('未読件数フィルタは常に is_read=false ベースになる', () => {
+    expect(buildNotificationCountFilter({ unreadCountOnly: true })).toEqual({
+      unreadCountOnly: true,
+      unreadOnly: true,
+    })
+  })
+
+  test('未読一覧フィルタは余計な条件を含めない', () => {
+    expect(buildUnreadNotificationFilter()).toEqual({ unreadOnly: true })
+    expect(
+      buildNotificationListFilter({
+        unreadOnly: true,
+        actionableOnly: false,
+        category: null,
+      }),
+    ).toEqual({ unreadOnly: true, actionableOnly: false })
+  })
+
+  test('不正 category は無視し、暗黙の category 注入をしない', () => {
+    expect(
+      buildNotificationListFilter({
+        unreadOnly: true,
+        actionableOnly: false,
+        category: 'unknown',
+      }),
+    ).toEqual({ unreadOnly: true, actionableOnly: false })
+  })
+})

--- a/talentify-next-frontend/__tests__/notifications-pages-wiring.test.tsx
+++ b/talentify-next-frontend/__tests__/notifications-pages-wiring.test.tsx
@@ -1,0 +1,13 @@
+import type { ReactElement } from 'react'
+import DashboardNotificationsPage from '@/app/(dashboard)/notifications/page'
+import StoreNotificationsPage from '@/app/store/notifications/page'
+import TalentNotificationsPage from '@/app/talent/notifications/page'
+import NotificationsInboxPage from '@/components/notifications/NotificationsInboxPage'
+
+describe('notifications page wiring', () => {
+  test('talent/store/dashboard すべて同じ NotificationsInboxPage を使用する', () => {
+    expect((TalentNotificationsPage() as ReactElement).type).toBe(NotificationsInboxPage)
+    expect((StoreNotificationsPage() as ReactElement).type).toBe(NotificationsInboxPage)
+    expect((DashboardNotificationsPage() as ReactElement).type).toBe(NotificationsInboxPage)
+  })
+})

--- a/talentify-next-frontend/app/api/notifications/route.ts
+++ b/talentify-next-frontend/app/api/notifications/route.ts
@@ -8,6 +8,7 @@ import {
 import type { Json } from '@/types/supabase'
 import { isNotificationType } from '@/types/notifications'
 import { getIdempotentResponse, persistIdempotentResponse } from '@/lib/notification-idempotency'
+import { buildNotificationCountFilter, buildNotificationListFilter } from '@/lib/notifications/inbox-filters'
 
 export const runtime = 'nodejs'
 
@@ -45,10 +46,15 @@ export async function GET(req: NextRequest) {
     }
 
     const params = req.nextUrl.searchParams
-    const unreadCountOnly = params.get('unread_count') === 'true'
+    const countFilter = buildNotificationCountFilter({
+      unreadCountOnly: params.get('unread_count') === 'true',
+    })
 
-    if (unreadCountOnly) {
+    if (countFilter.unreadCountOnly) {
       const count = await countUnreadNotificationsByUser({ userId: user.id })
+      if (process.env.NOTIFICATIONS_DEBUG_LOG === 'true') {
+        console.info('[notifications][api][count]', { userId: user.id, countFilter, count })
+      }
       return NextResponse.json({ count })
     }
 
@@ -59,17 +65,30 @@ export async function GET(req: NextRequest) {
         ? Math.floor(parsedLimit)
         : undefined
 
-    const unreadOnly = params.get('unread_only') === 'true'
-    const actionableOnly = params.get('actionable_only') === 'true'
-    const category = params.get('category')
+    const listFilter = buildNotificationListFilter({
+      unreadOnly: params.get('unread_only') === 'true',
+      actionableOnly: params.get('actionable_only') === 'true',
+      category: params.get('category'),
+    })
+
+    if (process.env.NOTIFICATIONS_DEBUG_LOG === 'true') {
+      console.info('[notifications][api][request]', {
+        userId: user.id,
+        searchParams: Object.fromEntries(params.entries()),
+        limit,
+        listFilter,
+      })
+    }
 
     const data = await findNotificationsByUser({
       userId: user.id,
       limit,
-      unreadOnly,
-      actionableOnly,
-      category: category === 'announcement' || category === 'notification' ? category : undefined,
+      ...listFilter,
     })
+
+    if (process.env.NOTIFICATIONS_DEBUG_LOG === 'true') {
+      console.info('[notifications][api][response]', { userId: user.id, resultCount: data.length, listFilter })
+    }
 
     return NextResponse.json({ data })
   } catch (error) {

--- a/talentify-next-frontend/components/notifications/notification-filters.ts
+++ b/talentify-next-frontend/components/notifications/notification-filters.ts
@@ -1,3 +1,4 @@
+import { buildUnreadNotificationFilter } from '@/lib/notifications/inbox-filters'
 import type { GetNotificationsOptions } from '@/utils/notifications'
 
 export type NotificationInboxTab = 'all' | 'unread' | 'action_required' | 'announcement'
@@ -5,7 +6,7 @@ export type NotificationInboxTab = 'all' | 'unread' | 'action_required' | 'annou
 export function buildNotificationFilter(tab: NotificationInboxTab): GetNotificationsOptions {
   switch (tab) {
     case 'unread':
-      return { unreadOnly: true }
+      return buildUnreadNotificationFilter()
     case 'action_required':
       return { actionableOnly: true }
     case 'announcement':

--- a/talentify-next-frontend/e2e/notifications.spec.ts
+++ b/talentify-next-frontend/e2e/notifications.spec.ts
@@ -115,4 +115,35 @@ test.describe('notifications e2e', () => {
     await page.getByTestId(`notification-row-${seeded.id}`).click()
     await expect(page).toHaveURL(/\/offers\//)
   })
+
+  test('G. 未読タブ: 未読件数がある場合は一覧に offer/payment が表示され空状態を出さない', async ({ page, request }) => {
+    await ensureLoggedIn(page)
+    const offerSeeded = await seedNotification(request, {
+      title: `Unread offer ${uniqueKey('offer')}`,
+      groupKey: uniqueKey('offer-group'),
+    })
+    const paymentResponse = await request.post('/api/notifications', {
+      headers: {
+        'Content-Type': 'application/json',
+        'Idempotency-Key': uniqueKey('seed-payment'),
+      },
+      data: {
+        type: 'payment_created',
+        title: `Unread payment ${uniqueKey('payment')}`,
+        body: 'E2E payment body',
+        entity_type: 'payment',
+        entity_id: uniqueKey('payment-id'),
+        data: { payment_id: uniqueKey('payment-data-id') },
+      },
+    })
+    expect(paymentResponse.ok()).toBeTruthy()
+
+    await page.goto('/talent/notifications')
+    await page.getByTestId('notifications-tab-unread').click()
+
+    const badgeCount = await unreadCount(page)
+    expect(badgeCount).toBeGreaterThan(0)
+    await expect(page.getByTestId(`notification-row-${offerSeeded.id}`)).toBeVisible()
+    await expect(page.getByText('未読通知はありません')).toHaveCount(0)
+  })
 })

--- a/talentify-next-frontend/lib/notifications/inbox-filters.ts
+++ b/talentify-next-frontend/lib/notifications/inbox-filters.ts
@@ -1,0 +1,33 @@
+export type NotificationCategoryFilter = 'announcement' | 'notification'
+
+export type NotificationListFilter = {
+  unreadOnly: boolean
+  actionableOnly: boolean
+  category?: NotificationCategoryFilter
+}
+
+export function buildUnreadNotificationFilter(): Pick<NotificationListFilter, 'unreadOnly'> {
+  return { unreadOnly: true }
+}
+
+export function buildNotificationListFilter(input: {
+  unreadOnly?: boolean
+  actionableOnly?: boolean
+  category?: string | null
+}): NotificationListFilter {
+  const category =
+    input.category === 'announcement' || input.category === 'notification' ? input.category : undefined
+
+  return {
+    unreadOnly: input.unreadOnly === true,
+    actionableOnly: input.actionableOnly === true,
+    ...(category ? { category } : {}),
+  }
+}
+
+export function buildNotificationCountFilter(input: { unreadCountOnly?: boolean }) {
+  return {
+    unreadCountOnly: input.unreadCountOnly === true,
+    unreadOnly: true as const,
+  }
+}

--- a/talentify-next-frontend/lib/repositories/notifications.ts
+++ b/talentify-next-frontend/lib/repositories/notifications.ts
@@ -62,12 +62,6 @@ type NotificationQueryRow = {
   group_key: string | null
 }
 
-type OfferVisibilityQueryRow = {
-  id: string
-  status: string | null
-  accepted_at: Date | null
-}
-
 export async function findNotificationOwner({
   id,
   userId,
@@ -114,12 +108,6 @@ function toNotificationRow(row: NotificationQueryRow): NotificationRow {
     expires_at: row.expires_at?.toISOString() ?? null,
     group_key: row.group_key,
   }
-}
-
-function getOfferId(data: Json | null): string | null {
-  if (!data || Array.isArray(data) || typeof data !== 'object') return null
-  const offerId = data.offer_id
-  return typeof offerId === 'string' ? offerId : null
 }
 
 export async function countUnreadNotificationsByUser({
@@ -210,38 +198,15 @@ export async function findNotificationsByUser({
     ${limitClause}
   `
 
-  if (rows.length === 0) {
-    return []
-  }
-
-  const offerIds = rows
-    .map((row) => getOfferId(row.data))
-    .filter((offerId): offerId is string => typeof offerId === 'string')
-
-  if (offerIds.length === 0) {
-    return rows.map(toNotificationRow)
-  }
-
-  const offers = await prisma.$queryRaw<OfferVisibilityQueryRow[]>`
-    SELECT id, status::text, accepted_at
-    FROM public.offers
-    WHERE id = ANY (${offerIds}::uuid[])
-  `
-
-  const hiddenOfferIds = new Set(
-    offers.filter((offer) => offer.status === 'canceled' && !offer.accepted_at).map((offer) => offer.id)
-  )
-
-  if (hiddenOfferIds.size === 0) {
-    return rows.map(toNotificationRow)
-  }
-
-  return rows
-    .filter((row) => {
-      const offerId = getOfferId(row.data)
-      return !offerId || !hiddenOfferIds.has(offerId)
+  if (process.env.NOTIFICATIONS_DEBUG_LOG === 'true') {
+    console.info('[notifications][repository][find]', {
+      userId,
+      filter: { unreadOnly: Boolean(unreadOnly), actionableOnly: Boolean(actionableOnly), category: category ?? null },
+      resultCount: rows.length,
     })
-    .map(toNotificationRow)
+  }
+
+  return rows.map(toNotificationRow)
 }
 
 export async function createNotification({

--- a/talentify-next-frontend/utils/notifications.ts
+++ b/talentify-next-frontend/utils/notifications.ts
@@ -86,6 +86,12 @@ export async function getNotifications(options?: number | GetNotificationsOption
     if (normalized?.category) searchParams.set('category', normalized.category)
 
     const suffix = searchParams.toString()
+    if (process.env.NEXT_PUBLIC_NOTIFICATIONS_DEBUG_LOG === 'true') {
+      console.info('[notifications][client][query]', {
+        options: normalized ?? null,
+        queryString: suffix,
+      })
+    }
     const res = await fetch(`${API_BASE}/api/notifications${suffix ? `?${suffix}` : ''}`)
 
     if (!res.ok) {


### PR DESCRIPTION
### Motivation

- The unread badge/count and the unread list could diverge because the repository applied additional post-query pruning for offers, letting `countUnreadNotificationsByUser` return `is_read=false` counts while `findNotificationsByUser` removed rows after the query. 
- The client/API/repository path had slightly different ways to interpret search params, which risked implicit category/actionable injection and made debug tracing hard. 
- We need a single-source-of-truth for unread/list/count filters so `未読 = is_read = false` is enforced across headline count and the list. 
- Temporary diagnostic logs are required to observe actual queries in a production-equivalent environment while keeping them gated by env flags. 

### Description

- Added shared filter builders in `lib/notifications/inbox-filters.ts`: `buildUnreadNotificationFilter()`, `buildNotificationListFilter()` and `buildNotificationCountFilter()` and wired the client/API to use them. 
- Updated `components/notifications/notification-filters.ts` to use `buildUnreadNotificationFilter()` so tab -> query is centralized. 
- Updated `app/api/notifications/route.ts` to normalize incoming search params via the shared builders and added conditional debug logs (guarded by `NOTIFICATIONS_DEBUG_LOG=true`) showing received params, normalized filters and result counts. 
- Removed the post-query hidden-offer pruning in `lib/repositories/notifications.ts` so `findNotificationsByUser` returns rows that match `is_read=false` consistently, and added conditional repository debug logging. 
- Added client-side optional query logging in `utils/notifications.ts` (guarded by `NEXT_PUBLIC_NOTIFICATIONS_DEBUG_LOG=true`). 
- Added and adjusted tests: new `__tests__/notifications-inbox-filters.test.ts` and `__tests__/notifications-pages-wiring.test.tsx`, extended `__tests__/notifications-e2e.test.ts` assertions, added a Playwright scenario in `e2e/notifications.spec.ts` that seeds `offer_created`/`payment_created` unread notifications and verifies the `/talent/notifications` unread tab shows them. 

### Testing

- Ran unit/integration tests with Jest: `npm test -- --runInBand __tests__/notification-filters.test.ts __tests__/notifications-inbox-filters.test.ts __tests__/notifications-pages-wiring.test.tsx __tests__/notifications-e2e.test.ts` and all selected suites passed. 
- Verified the earlier failing assertions were fixed by centralizing filters and removing the repository-level pruning (tests updated accordingly). 
- Playwright E2E `e2e/notifications.spec.ts` test scenario was added to reproduce the reported UI case but was not executed here due to environment authentication constraints. 
- All debug logs are opt-in behind `NOTIFICATIONS_DEBUG_LOG` and `NEXT_PUBLIC_NOTIFICATIONS_DEBUG_LOG` so they can be enabled for production-equivalent diagnosis without noisy defaults.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deeb58b98c8332a3349499f04e5fd9)