### PR TITLE
Resolve message target IDs and harden notification mapping to avoid dropouts

### DIFF
--- a/talentify-next-frontend/__tests__/notifications-e2e.test.ts
+++ b/talentify-next-frontend/__tests__/notifications-e2e.test.ts
@@ -249,4 +249,17 @@ describe('notifications quality e2e', () => {
       expect.objectContaining({ unreadOnly: true, actionableOnly: false }),
     )
   })
+
+  it('I. link/action fallback stays safe when action_url and entity references are missing', () => {
+    const broken = buildNotification({
+      type: 'offer_created',
+      action_url: 'https://unsafe.example.com/x',
+      data: { recipient_role: 'talent', actor_name: '' },
+      entity_id: null,
+      actor_name: null,
+    })
+
+    expect(getNotificationLink(broken)).toBe('/talent/notifications')
+    expect(isActionRequired(broken)).toBe(true)
+  })
 })

--- a/talentify-next-frontend/__tests__/notifications-repository-mapper.test.ts
+++ b/talentify-next-frontend/__tests__/notifications-repository-mapper.test.ts
@@ -1,0 +1,31 @@
+import { mapNotificationQueryRowToRow } from '@/lib/notifications/notification-row-mapper'
+
+describe('mapNotificationQueryRowToRow', () => {
+  it('keeps notification visible even when created_at / updated_at are null', () => {
+    const row = {
+      id: 'n1',
+      user_id: 'u1',
+      type: 'offer_created',
+      data: { actor_name: '店舗A' },
+      title: 'title',
+      body: 'body',
+      is_read: false,
+      created_at: null,
+      updated_at: null,
+      read_at: new Date('2026-01-02T03:04:05.000Z'),
+      priority: 'medium',
+      action_url: null,
+      action_label: null,
+      entity_type: null,
+      entity_id: null,
+      actor_name: null,
+      expires_at: null,
+      group_key: null,
+    }
+
+    const mapped = mapNotificationQueryRowToRow(row)
+    expect(mapped.created_at).toBe('2026-01-02T03:04:05.000Z')
+    expect(mapped.updated_at).toBe('2026-01-02T03:04:05.000Z')
+    expect(mapped.actor_name).toBe('店舗A')
+  })
+})

--- a/talentify-next-frontend/__tests__/resolve-message-target.test.ts
+++ b/talentify-next-frontend/__tests__/resolve-message-target.test.ts
@@ -1,0 +1,42 @@
+jest.mock('@/lib/prisma', () => ({
+  getPrismaClient: jest.fn(),
+}))
+
+const { getPrismaClient } = jest.requireMock('@/lib/prisma') as {
+  getPrismaClient: jest.Mock
+}
+
+describe('resolveMessageTargetUserId', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns null for non-uuid values', async () => {
+    const { resolveMessageTargetUserId } = await import('@/lib/resolve-message-target')
+    await expect(resolveMessageTargetUserId('not-a-uuid')).resolves.toBeNull()
+    expect(getPrismaClient).not.toHaveBeenCalled()
+  })
+
+  it('resolves talents.id to user_id', async () => {
+    getPrismaClient.mockReturnValue({
+      talents: { findFirst: jest.fn().mockResolvedValue({ user_id: 'user-1' }) },
+      stores: { findFirst: jest.fn().mockResolvedValue(null) },
+      companies: { findFirst: jest.fn().mockResolvedValue(null) },
+    })
+
+    const { resolveMessageTargetUserId } = await import('@/lib/resolve-message-target')
+    await expect(resolveMessageTargetUserId('2e3bd187-1c86-4916-b2cf-2f7cb2e583d1')).resolves.toBe('user-1')
+  })
+
+  it('falls back to raw uuid when mapping rows are missing', async () => {
+    getPrismaClient.mockReturnValue({
+      talents: { findFirst: jest.fn().mockResolvedValue(null) },
+      stores: { findFirst: jest.fn().mockResolvedValue(null) },
+      companies: { findFirst: jest.fn().mockResolvedValue(null) },
+    })
+
+    const { resolveMessageTargetUserId } = await import('@/lib/resolve-message-target')
+    const raw = '2e3bd187-1c86-4916-b2cf-2f7cb2e583d1'
+    await expect(resolveMessageTargetUserId(raw)).resolves.toBe(raw)
+  })
+})

--- a/talentify-next-frontend/__tests__/store-message-target-route.test.ts
+++ b/talentify-next-frontend/__tests__/store-message-target-route.test.ts
@@ -1,0 +1,37 @@
+jest.mock('next/navigation', () => ({
+  redirect: jest.fn(),
+}))
+
+jest.mock('@/lib/resolve-message-target', () => ({
+  resolveMessageTargetUserId: jest.fn(),
+}))
+
+const { redirect } = jest.requireMock('next/navigation') as { redirect: jest.Mock }
+const { resolveMessageTargetUserId } = jest.requireMock('@/lib/resolve-message-target') as {
+  resolveMessageTargetUserId: jest.Mock
+}
+
+describe('/store/messages/[id] route', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('redirects to conversation when user id resolves', async () => {
+    resolveMessageTargetUserId.mockResolvedValue('2e3bd187-1c86-4916-b2cf-2f7cb2e583d1')
+    const mod = await import('@/app/store/messages/[id]/page')
+
+    await mod.default({ params: Promise.resolve({ id: 'talent-id' }) })
+
+    expect(resolveMessageTargetUserId).toHaveBeenCalledWith('talent-id')
+    expect(redirect).toHaveBeenCalledWith('/messages/2e3bd187-1c86-4916-b2cf-2f7cb2e583d1')
+  })
+
+  it('falls back to direct tab when id cannot be resolved', async () => {
+    resolveMessageTargetUserId.mockResolvedValue(null)
+    const mod = await import('@/app/store/messages/[id]/page')
+
+    await mod.default({ params: Promise.resolve({ id: 'invalid' }) })
+
+    expect(redirect).toHaveBeenCalledWith('/store/messages?tab=direct')
+  })
+})

--- a/talentify-next-frontend/app/api/messages/send/route.ts
+++ b/talentify-next-frontend/app/api/messages/send/route.ts
@@ -5,7 +5,9 @@ import { emitNotification } from '@/lib/notifications/emit'
 export const runtime = 'nodejs'
 
 export async function POST(req: NextRequest) {
-  const { receiverUserId, body, offerId, senderUserId = 'u1', senderName } = await req.json()
+  const payload = await req.json()
+  const receiverUserId = payload.receiverUserId ?? payload.receiverUser
+  const { body, offerId, senderUserId = 'u1', senderName } = payload
 
   if (!receiverUserId || !body) {
     return NextResponse.json(

--- a/talentify-next-frontend/app/store/messages/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/messages/[id]/page.tsx
@@ -1,0 +1,17 @@
+import { redirect } from 'next/navigation'
+import { resolveMessageTargetUserId } from '@/lib/resolve-message-target'
+
+type Props = {
+  params: Promise<{ id: string }>
+}
+
+export default async function StoreMessageTargetPage({ params }: Props) {
+  const { id } = await params
+  const targetUserId = await resolveMessageTargetUserId(id)
+
+  if (!targetUserId) {
+    redirect('/store/messages?tab=direct')
+  }
+
+  redirect(`/messages/${targetUserId}`)
+}

--- a/talentify-next-frontend/app/talent/messages/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/messages/[id]/page.tsx
@@ -1,0 +1,17 @@
+import { redirect } from 'next/navigation'
+import { resolveMessageTargetUserId } from '@/lib/resolve-message-target'
+
+type Props = {
+  params: Promise<{ id: string }>
+}
+
+export default async function TalentMessageTargetPage({ params }: Props) {
+  const { id } = await params
+  const targetUserId = await resolveMessageTargetUserId(id)
+
+  if (!targetUserId) {
+    redirect('/talent/messages?tab=direct')
+  }
+
+  redirect(`/messages/${targetUserId}`)
+}

--- a/talentify-next-frontend/components/messages/MessagesPage.tsx
+++ b/talentify-next-frontend/components/messages/MessagesPage.tsx
@@ -193,7 +193,7 @@ export default function MessagesPage({ role, type }: { role: UserRole; type: 'di
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          receiverUser: activeThread.partnerId,
+          receiverUserId: activeThread.partnerId,
           body: newMsg.body,
           ...(type === 'offer' ? { offerId: activeThread.id } : {}),
         }),

--- a/talentify-next-frontend/lib/messages.ts
+++ b/talentify-next-frontend/lib/messages.ts
@@ -18,7 +18,7 @@ export async function sendMessage(conversationId: string, body: string) {
   const res = await fetch('/api/messages/send', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ receiverUser: conversationId, body })
+    body: JSON.stringify({ receiverUserId: conversationId, receiverUser: conversationId, body })
   })
   if (!res.ok) {
     throw new Error('failed to send message')

--- a/talentify-next-frontend/lib/notifications/notification-row-mapper.ts
+++ b/talentify-next-frontend/lib/notifications/notification-row-mapper.ts
@@ -1,0 +1,60 @@
+import type { Database, Json } from '@/types/supabase'
+
+type NotificationRow = Database['public']['Tables']['notifications']['Row']
+
+export type NotificationQueryRow = {
+  id: string
+  user_id: string
+  type: NotificationRow['type']
+  data: Json | null
+  title: string
+  body: string | null
+  is_read: boolean
+  created_at: Date | null
+  updated_at: Date | null
+  read_at: Date | null
+  priority: 'low' | 'medium' | 'high'
+  action_url: string | null
+  action_label: string | null
+  entity_type: string | null
+  entity_id: string | null
+  actor_name: string | null
+  expires_at: Date | null
+  group_key: string | null
+}
+
+function resolvePriority(value: string | null): NotificationRow['priority'] {
+  return value === 'low' || value === 'high' ? value : 'medium'
+}
+
+function toIsoString(value: Date | null | undefined): string | null {
+  if (!value) return null
+  return value.toISOString()
+}
+
+export function mapNotificationQueryRowToRow(row: NotificationQueryRow): NotificationRow {
+  const rawData = row.data && typeof row.data === 'object' && !Array.isArray(row.data) ? row.data : null
+  const createdAt = row.created_at ?? row.updated_at ?? row.read_at ?? new Date(0)
+  const updatedAt = row.updated_at ?? row.created_at ?? createdAt
+
+  return {
+    id: row.id,
+    user_id: row.user_id,
+    type: row.type,
+    data: row.data,
+    title: row.title,
+    body: row.body,
+    is_read: row.is_read,
+    created_at: createdAt.toISOString(),
+    updated_at: updatedAt.toISOString(),
+    read_at: toIsoString(row.read_at),
+    priority: resolvePriority(row.priority ?? (typeof rawData?.priority === 'string' ? rawData.priority : null)),
+    action_url: row.action_url ?? (typeof rawData?.url === 'string' ? rawData.url : null),
+    action_label: row.action_label ?? (typeof rawData?.action_label === 'string' ? rawData.action_label : null),
+    entity_type: row.entity_type ?? (typeof rawData?.entity_type === 'string' ? rawData.entity_type : null),
+    entity_id: row.entity_id ?? (typeof rawData?.entity_id === 'string' ? rawData.entity_id : null),
+    actor_name: row.actor_name ?? (typeof rawData?.actor_name === 'string' ? rawData.actor_name : null),
+    expires_at: toIsoString(row.expires_at),
+    group_key: row.group_key,
+  }
+}

--- a/talentify-next-frontend/lib/repositories/notifications.ts
+++ b/talentify-next-frontend/lib/repositories/notifications.ts
@@ -1,7 +1,8 @@
 import { Prisma } from '@prisma/client'
 import { getPrismaClient } from '@/lib/prisma'
-import type { Database, Json } from '@/types/supabase'
+import type { Database } from '@/types/supabase'
 import type { NotificationType } from '@/types/notifications'
+import { mapNotificationQueryRowToRow, type NotificationQueryRow } from '@/lib/notifications/notification-row-mapper'
 
 type NotificationRow = Database['public']['Tables']['notifications']['Row']
 type NotificationInsert = Database['public']['Tables']['notifications']['Insert']
@@ -41,26 +42,6 @@ const ACTION_REQUIRED_TYPES: NotificationType[] = [
   'invoice_submitted',
 ]
 
-type NotificationQueryRow = {
-  id: string
-  user_id: string
-  type: NotificationRow['type']
-  data: Json | null
-  title: string
-  body: string | null
-  is_read: boolean
-  created_at: Date
-  updated_at: Date
-  read_at: Date | null
-  priority: 'low' | 'medium' | 'high'
-  action_url: string | null
-  action_label: string | null
-  entity_type: string | null
-  entity_id: string | null
-  actor_name: string | null
-  expires_at: Date | null
-  group_key: string | null
-}
 
 export async function findNotificationOwner({
   id,
@@ -79,35 +60,6 @@ export async function findNotificationOwner({
   })
 
   return Boolean(row)
-}
-
-function resolvePriority(value: string | null): NotificationRow['priority'] {
-  return value === 'low' || value === 'high' ? value : 'medium'
-}
-
-function toNotificationRow(row: NotificationQueryRow): NotificationRow {
-  const rawData = row.data && typeof row.data === 'object' && !Array.isArray(row.data) ? row.data : null
-
-  return {
-    id: row.id,
-    user_id: row.user_id,
-    type: row.type,
-    data: row.data,
-    title: row.title,
-    body: row.body,
-    is_read: row.is_read,
-    created_at: row.created_at.toISOString(),
-    updated_at: row.updated_at.toISOString(),
-    read_at: row.read_at?.toISOString() ?? null,
-    priority: resolvePriority(row.priority ?? (typeof rawData?.priority === 'string' ? rawData.priority : null)),
-    action_url: row.action_url ?? (typeof rawData?.url === 'string' ? rawData.url : null),
-    action_label: row.action_label ?? (typeof rawData?.action_label === 'string' ? rawData.action_label : null),
-    entity_type: row.entity_type ?? (typeof rawData?.entity_type === 'string' ? rawData.entity_type : null),
-    entity_id: row.entity_id ?? (typeof rawData?.entity_id === 'string' ? rawData.entity_id : null),
-    actor_name: row.actor_name ?? (typeof rawData?.actor_name === 'string' ? rawData.actor_name : null),
-    expires_at: row.expires_at?.toISOString() ?? null,
-    group_key: row.group_key,
-  }
 }
 
 export async function countUnreadNotificationsByUser({
@@ -206,7 +158,7 @@ export async function findNotificationsByUser({
     })
   }
 
-  return rows.map(toNotificationRow)
+  return rows.map(mapNotificationQueryRowToRow)
 }
 
 export async function createNotification({
@@ -281,7 +233,7 @@ export async function createNotification({
     `
 
     if (mergedRows.length > 0) {
-      return toNotificationRow(mergedRows[0])
+      return mapNotificationQueryRowToRow(mergedRows[0])
     }
   }
 
@@ -345,7 +297,7 @@ export async function createNotification({
     throw new Error('failed to insert notification')
   }
 
-  return toNotificationRow(rows[0])
+  return mapNotificationQueryRowToRow(rows[0])
 }
 
 export async function markNotificationRead({

--- a/talentify-next-frontend/lib/resolve-message-target.ts
+++ b/talentify-next-frontend/lib/resolve-message-target.ts
@@ -1,0 +1,49 @@
+import { getPrismaClient } from '@/lib/prisma'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+function isUuid(value: string): boolean {
+  return UUID_RE.test(value)
+}
+
+async function resolveFromRoleTables(id: string): Promise<string | null> {
+  const prisma = getPrismaClient()
+
+  const [talent, store, company] = await Promise.all([
+    prisma.talents.findFirst({
+      where: {
+        OR: [{ id }, { user_id: id }],
+      },
+      select: { user_id: true },
+    }),
+    prisma.stores.findFirst({
+      where: {
+        OR: [{ id }, { user_id: id }],
+      },
+      select: { user_id: true },
+    }),
+    prisma.companies.findFirst({
+      where: {
+        OR: [{ id }, { user_id: id }],
+      },
+      select: { user_id: true },
+    }),
+  ])
+
+  return talent?.user_id ?? store?.user_id ?? company?.user_id ?? null
+}
+
+/**
+ * Resolves a message target id into canonical auth user id.
+ * Accepts user_id directly, or profile ids such as talents.id/stores.id/companies.id.
+ */
+export async function resolveMessageTargetUserId(rawId: string): Promise<string | null> {
+  const id = rawId.trim()
+  if (!isUuid(id)) return null
+
+  const resolvedByRole = await resolveFromRoleTables(id)
+  if (resolvedByRole) return resolvedByRole
+
+  // Fallback: treat UUID as user_id directly so legacy links continue to work.
+  return id
+}


### PR DESCRIPTION
### Motivation

- Users experienced 404 when following the “この演者にメッセージを送る” link and notifications showing a non-zero unread count while the notifications list was empty.  
- Root cause looked like ID-type mismatches (auth `user_id` vs profile IDs like `talents.id`) and fragile notification row mapping that dropped rows when related fields (e.g. timestamps) were missing.  
- The intent is to make message links resolve robustly and ensure notifications remain visible even when some related metadata is partial or missing.

### Description

- Added a canonical resolver `lib/resolve-message-target.ts` that accepts a route `id` (UUID) and resolves it to an auth `user_id` by checking `talents/stores/companies` and falling back to the UUID as `user_id` for legacy links.  
- Implemented redirect pages `app/store/messages/[id]/page.tsx` and `app/talent/messages/[id]/page.tsx` that use the resolver and redirect to the canonical conversation at `/messages/[user_id]`.  
- Fixed message sending contract: API `app/api/messages/send/route.ts` now accepts `receiverUserId` (preferred) while remaining compatible with legacy `receiverUser`, and client call sites (`lib/messages.ts`, `components/messages/MessagesPage.tsx`) were updated to send `receiverUserId`.  
- Hardened notifications repository by extracting a row mapper `lib/notifications/notification-row-mapper.ts` and switching `lib/repositories/notifications.ts` to use it so null/missing `created_at`/`updated_at`/other fields do not cause notifications to be dropped, and added/updated tests covering these cases.

### Testing

- Ran unit/integration tests with `npm test -- --runInBand __tests__/resolve-message-target.test.ts __tests__/notifications-repository-mapper.test.ts __tests__/store-message-target-route.test.ts __tests__/notifications-e2e.test.ts` and all suites passed (4 test suites, 15 tests).  
- Ran the notifications e2e only with `npm test -- --runInBand __tests__/notifications-e2e.test.ts` and it passed (9 tests in that suite).  
- Added tests: `__tests__/resolve-message-target.test.ts`, `__tests__/store-message-target-route.test.ts`, `__tests__/notifications-repository-mapper.test.ts`, and extended `__tests__/notifications-e2e.test.ts`; all new/updated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69def2d4b6408332900696d334036266)