### PR TITLE
Improve registration flow resiliency for Supabase rate limits

### DIFF
--- a/talentify-next-frontend/components/RegisterForm.tsx
+++ b/talentify-next-frontend/components/RegisterForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { FormEvent, useState } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { createClient } from '@/utils/supabase/client'
@@ -27,9 +27,38 @@ export default function RegisterForm() {
   const [emailError, setEmailError] = useState<string | null>(null)
   const [passwordError, setPasswordError] = useState<string | null>(null)
   const [confirmError, setConfirmError] = useState<string | null>(null)
-  const [success, setSuccess] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
-  const handleRegister = async () => {
+  const getSignUpErrorMessage = (code?: string, message?: string) => {
+    const normalizedCode = code?.toLowerCase() ?? ''
+    const normalizedMessage = message?.toLowerCase() ?? ''
+
+    if (
+      normalizedCode.includes('over_email_send_rate_limit') ||
+      normalizedMessage.includes('rate limit')
+    ) {
+      return '確認メールの送信回数が上限に達しました。しばらく時間をおいてから再度お試しください。'
+    }
+
+    if (normalizedMessage.includes('already')) {
+      return 'このメールアドレスは既に登録されています'
+    }
+
+    if (normalizedMessage.includes('invalid')) {
+      return 'メールアドレスの形式が正しくありません'
+    }
+
+    return '登録に失敗しました。時間をおいて再度お試しください。'
+  }
+
+  const handleRegister = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+
+    if (isSubmitting) {
+      return
+    }
+
+    setIsSubmitting(true)
     setGlobalError(null)
     setEmailError(null)
     setPasswordError(null)
@@ -58,15 +87,17 @@ export default function RegisterForm() {
       hasError = true
     }
 
-    if (!role) {
-      setGlobalError('登録種別が不明です')
-      return
-    }
-
-    if (hasError) return
-
     try {
-      const { data, error: signUpError } = await supabase.auth.signUp({
+      if (!role) {
+        setGlobalError('登録種別が不明です')
+        return
+      }
+
+      if (hasError) {
+        return
+      }
+
+      const { error: signUpError } = await supabase.auth.signUp({
         email,
         password,
         options: {
@@ -76,20 +107,11 @@ export default function RegisterForm() {
         },
       })
 
-      console.log('✅ signUp後のdata:', data)
-      console.log('➡️ data.user:', data.user)
-      console.log('➡️ data.session:', data.session)
-
       if (signUpError) {
         console.error('signUp error:', signUpError)
-        const msg = signUpError.message
-        if (msg.toLowerCase().includes('already')) {
-          setGlobalError('このメールアドレスは既に登録されています')
-        } else if (msg.toLowerCase().includes('invalid')) {
-          setGlobalError('メールアドレスの形式が正しくありません')
-        } else {
-          setGlobalError('登録に失敗しました')
-        }
+        setGlobalError(
+          getSignUpErrorMessage(signUpError.code, signUpError.message)
+        )
         return
       }
 
@@ -98,6 +120,8 @@ export default function RegisterForm() {
     } catch (e) {
       console.error('signUp failed:', e)
       setGlobalError('通信に失敗しました。インターネット接続をご確認ください')
+    } finally {
+      setIsSubmitting(false)
     }
   }
 
@@ -107,57 +131,52 @@ export default function RegisterForm() {
 
       {globalError && <p className="text-red-600">{globalError}</p>}
 
-      {success ? (
-        <p className="text-green-600">
-          確認メールを送信しました。メールを確認してください。
-        </p>
-      ) : (
-        <>
-          <div>
-            <label className="block font-medium">メールアドレス</label>
-            <Input
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              aria-invalid={!!emailError}
-              required
-            />
-            {emailError && (
-              <p className="text-red-600 text-sm mt-1">{emailError}</p>
-            )}
-          </div>
+      <form onSubmit={handleRegister} className="space-y-6">
+        <div>
+          <label className="block font-medium">メールアドレス</label>
+          <Input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            aria-invalid={!!emailError}
+            disabled={isSubmitting}
+            required
+          />
+          {emailError && <p className="text-red-600 text-sm mt-1">{emailError}</p>}
+        </div>
 
-          <div>
-            <label className="block font-medium">パスワード</label>
-            <Input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              aria-invalid={!!passwordError}
-              required
-            />
-            {passwordError && (
-              <p className="text-red-600 text-sm mt-1">{passwordError}</p>
-            )}
-          </div>
+        <div>
+          <label className="block font-medium">パスワード</label>
+          <Input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            aria-invalid={!!passwordError}
+            disabled={isSubmitting}
+            required
+          />
+          {passwordError && (
+            <p className="text-red-600 text-sm mt-1">{passwordError}</p>
+          )}
+        </div>
 
-          <div>
-            <label className="block font-medium">パスワード（確認）</label>
-            <Input
-              type="password"
-              value={confirm}
-              onChange={(e) => setConfirm(e.target.value)}
-              aria-invalid={!!confirmError}
-              required
-            />
-            {confirmError && (
-              <p className="text-red-600 text-sm mt-1">{confirmError}</p>
-            )}
-          </div>
+        <div>
+          <label className="block font-medium">パスワード（確認）</label>
+          <Input
+            type="password"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            aria-invalid={!!confirmError}
+            disabled={isSubmitting}
+            required
+          />
+          {confirmError && <p className="text-red-600 text-sm mt-1">{confirmError}</p>}
+        </div>
 
-          <Button onClick={handleRegister}>登録</Button>
-        </>
-      )}
+        <Button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? '送信中...' : '登録'}
+        </Button>
+      </form>
 
       <p className="text-sm text-center">
         すでにアカウントをお持ちの方は{' '}

--- a/talentify-next-frontend/lib/getRedirectUrl.ts
+++ b/talentify-next-frontend/lib/getRedirectUrl.ts
@@ -3,9 +3,10 @@ export function getRedirectUrl(role: string) {
     process.env.NODE_ENV === 'development'
       ? 'http://localhost:3000'
       : process.env.NEXT_PUBLIC_SITE_URL || 'https://talentify-xi.vercel.app'
+  const normalizedBaseUrl = baseUrl.replace(/\/+$/, '')
 
   // Always redirect to the auth callback so that Supabase session tokens
   // contained in the confirmation link can be exchanged properly. Pass the
   // desired role via query parameters instead of using localStorage.
-  return `${baseUrl}/auth/callback?role=${encodeURIComponent(role)}`
+  return `${normalizedBaseUrl}/auth/callback?role=${encodeURIComponent(role)}`
 }


### PR DESCRIPTION
### Motivation
- 登録フォームから直接 `supabase.auth.signUp` を呼んでいる現在の実装では、Enter 送信や連打で二重送信が発生しやすく、Supabase のメール送信レート制限（429 / `over_email_send_rate_limit`）発生時に適切な UX を提供できていません。 
- コールバック URL が環境変数の末尾スラッシュにより `//auth/callback` になってしまう問題を防ぎ、認証フローの安定性を高める必要があります.

### Description
- `RegisterForm` を `form` + `onSubmit` ベースに変更して Enter キーの送信に対応し、`handleRegister` は `FormEvent` を受け取るようにしました. 
- `isSubmitting` 状態を導入して送信中は入力欄とボタンを `disabled` にし、重複送信を回避し、ボタン文言を送信中のみ `送信中...` に変更しました. 
- Supabase の `signUp` エラーを `code` と `message` の両方で判定する `getSignUpErrorMessage` を追加し、以下の文言に分岐するようにしました: 既存メール、無効なメール形式、`over_email_send_rate_limit` / `rate limit`（メール送信回数上限）および汎用フォールバック。 
- 未使用の `success` state と不要な `console.log` を削除し、`router.push('/check-email')` は維持しました。 
- `getRedirectUrl` で `baseUrl.replace(/\/+$, '')` により末尾スラッシュを除去して `normalizedBaseUrl` を使うようにし、`NEXT_PUBLIC_SITE_URL` に末尾スラッシュがあっても `//auth/callback` が発生しないようにしました. 

### Testing
- 実行: `npm run test -- --runTestsByPath __tests__/getRedirectUrl.test.ts` — テストは全件成功しました（4 通過）。
- 実行: `npm run lint -- --file components/RegisterForm.tsx --file lib/getRedirectUrl.ts` — ESLint/Next lint は警告・エラーなく成功しました.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69def93b70208332a821af302bf1a800)