### PR TITLE
Server-side signup + app-user upsert; move RegisterForm to API-backed flow

### DIFF
--- a/talentify-next-frontend/app/api/auth/signup/route.ts
+++ b/talentify-next-frontend/app/api/auth/signup/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { getRedirectUrl } from '@/lib/getRedirectUrl'
+import {
+  mapSupabaseSignUpError,
+  signUpSchema,
+  type SignupErrorCode,
+} from '@/lib/auth/signup'
+
+type ErrorResponse = {
+  ok: false
+  error: {
+    code: SignupErrorCode
+    message: string
+  }
+}
+
+function errorResponse(
+  status: number,
+  code: SignupErrorCode,
+  message: string
+) {
+  return NextResponse.json<ErrorResponse>(
+    {
+      ok: false,
+      error: { code, message },
+    },
+    { status }
+  )
+}
+
+export async function POST(req: NextRequest) {
+  let body: unknown
+
+  try {
+    body = await req.json()
+  } catch {
+    return errorResponse(400, 'INVALID_INPUT', 'リクエスト形式が正しくありません')
+  }
+
+  const parsed = signUpSchema.safeParse(body)
+  if (!parsed.success) {
+    return errorResponse(400, 'INVALID_INPUT', '入力内容を確認してください')
+  }
+
+  const { email, password, role } = parsed.data
+
+  const supabase = createClient()
+
+  const { error } = await supabase.auth.signUp({
+    email,
+    password,
+    options: {
+      emailRedirectTo: getRedirectUrl(role),
+      data: {
+        role,
+      },
+    },
+  })
+
+  if (error) {
+    const code = mapSupabaseSignUpError(error)
+
+    if (code === 'RATE_LIMITED') {
+      return errorResponse(429, code, '確認メールの送信回数が上限に達しています')
+    }
+
+    if (code === 'EMAIL_ALREADY_EXISTS') {
+      return errorResponse(409, code, 'このメールアドレスは既に登録されています')
+    }
+
+    if (code === 'INVALID_EMAIL') {
+      return errorResponse(400, code, 'メールアドレスの形式が正しくありません')
+    }
+
+    return errorResponse(400, code, '登録に失敗しました')
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: {
+        next: 'check_email',
+      },
+    },
+    { status: 200 }
+  )
+}

--- a/talentify-next-frontend/app/auth/callback/route.ts
+++ b/talentify-next-frontend/app/auth/callback/route.ts
@@ -1,10 +1,22 @@
 import { NextResponse, type NextRequest } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { upsertAppUser } from '@/lib/auth/app-user'
+import { SIGNUP_ROLES, type SignupRole } from '@/lib/auth/signup'
+
+function toSignupRole(value: string | undefined): SignupRole | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  return SIGNUP_ROLES.includes(value as SignupRole)
+    ? (value as SignupRole)
+    : undefined
+}
 
 export async function GET(req: NextRequest) {
   const url = new URL(req.url)
   const code = url.searchParams.get('code')
-  const role = url.searchParams.get('role') ?? undefined
+  const roleParam = url.searchParams.get('role') ?? undefined
 
   if (!code) {
     return NextResponse.redirect(new URL('/auth/error', url))
@@ -18,11 +30,33 @@ export async function GET(req: NextRequest) {
     return NextResponse.redirect(new URL('/auth/error', url))
   }
 
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  const roleFromMetadata = toSignupRole((user?.user_metadata as { role?: string } | undefined)?.role)
+  const role = toSignupRole(roleParam) ?? roleFromMetadata
+
+  if (user?.id && user?.email && role) {
+    try {
+      await upsertAppUser({
+        authUserId: user.id,
+        email: user.email,
+        role,
+        status: 'onboarding',
+      })
+    } catch (appUserError) {
+      console.error('failed to upsert app user on callback', appUserError)
+    }
+  }
+
   const redirect =
     role === 'store'
       ? '/store/edit'
       : role === 'talent'
       ? '/talent/edit'
+      : role === 'company'
+      ? '/company/edit'
       : '/dashboard'
 
   return NextResponse.redirect(new URL(redirect, url))

--- a/talentify-next-frontend/components/RegisterForm.tsx
+++ b/talentify-next-frontend/components/RegisterForm.tsx
@@ -3,12 +3,8 @@
 import { FormEvent, useState } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import Link from 'next/link'
-import { createClient } from '@/utils/supabase/client'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
-import { getRedirectUrl } from '@/lib/getRedirectUrl'
-
-const supabase = createClient()
 
 export default function RegisterForm() {
   const router = useRouter()
@@ -29,26 +25,19 @@ export default function RegisterForm() {
   const [confirmError, setConfirmError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
-  const getSignUpErrorMessage = (code?: string, message?: string) => {
-    const normalizedCode = code?.toLowerCase() ?? ''
-    const normalizedMessage = message?.toLowerCase() ?? ''
-
-    if (
-      normalizedCode.includes('over_email_send_rate_limit') ||
-      normalizedMessage.includes('rate limit')
-    ) {
-      return '確認メールの送信回数が上限に達しました。しばらく時間をおいてから再度お試しください。'
+  const getSignUpErrorMessage = (code?: string) => {
+    switch (code) {
+      case 'RATE_LIMITED':
+        return '確認メールの送信回数が上限に達しました。しばらく時間をおいてから再度お試しください。'
+      case 'EMAIL_ALREADY_EXISTS':
+        return 'このメールアドレスは既に登録されています'
+      case 'INVALID_EMAIL':
+        return 'メールアドレスの形式が正しくありません'
+      case 'INVALID_INPUT':
+        return '入力内容を確認してください'
+      default:
+        return '登録に失敗しました。時間をおいて再度お試しください。'
     }
-
-    if (normalizedMessage.includes('already')) {
-      return 'このメールアドレスは既に登録されています'
-    }
-
-    if (normalizedMessage.includes('invalid')) {
-      return 'メールアドレスの形式が正しくありません'
-    }
-
-    return '登録に失敗しました。時間をおいて再度お試しください。'
   }
 
   const handleRegister = async (e: FormEvent<HTMLFormElement>) => {
@@ -97,21 +86,22 @@ export default function RegisterForm() {
         return
       }
 
-      const { error: signUpError } = await supabase.auth.signUp({
-        email,
-        password,
-        options: {
-          // The role is passed via query parameter so the callback can
-          // create the appropriate profile on the server.
-          emailRedirectTo: getRedirectUrl(role),
+      const response = await fetch('/api/auth/signup', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
         },
+        body: JSON.stringify({
+          email,
+          password,
+          role,
+        }),
       })
 
-      if (signUpError) {
-        console.error('signUp error:', signUpError)
-        setGlobalError(
-          getSignUpErrorMessage(signUpError.code, signUpError.message)
-        )
+      const payload = await response.json().catch(() => null)
+
+      if (!response.ok || !payload?.ok) {
+        setGlobalError(getSignUpErrorMessage(payload?.error?.code))
         return
       }
 

--- a/talentify-next-frontend/lib/auth/app-user.ts
+++ b/talentify-next-frontend/lib/auth/app-user.ts
@@ -48,11 +48,13 @@ export async function upsertAppUser(params: UpsertAppUserParams) {
     throw selectError
   }
 
-  if (existing?.id) {
+  const existingId = (existing as { id?: string } | null)?.id
+
+  if (existingId) {
     const { error: updateError } = await service
       .from('users' as any)
       .update(record)
-      .eq('id', existing.id)
+      .eq('id', existingId)
 
     if (updateError) {
       throw updateError

--- a/talentify-next-frontend/lib/auth/app-user.ts
+++ b/talentify-next-frontend/lib/auth/app-user.ts
@@ -1,0 +1,71 @@
+import { createServiceClient } from '@/lib/supabase/service'
+import type { SignupRole } from '@/lib/auth/signup'
+
+export type AppUserStatus =
+  | 'pending_email_verification'
+  | 'onboarding'
+  | 'active'
+  | 'suspended'
+
+type UpsertAppUserParams = {
+  authUserId: string
+  email: string
+  role: SignupRole
+  status: AppUserStatus
+}
+
+export async function upsertAppUser(params: UpsertAppUserParams) {
+  const service = createServiceClient()
+
+  const record = {
+    auth_user_id: params.authUserId,
+    email: params.email,
+    role: params.role,
+    status: params.status,
+  }
+
+  const upsertResult = await service
+    .from('users' as any)
+    .upsert(record, { onConflict: 'auth_user_id' })
+
+  if (!upsertResult.error) {
+    return
+  }
+
+  const { error } = upsertResult
+
+  if (error.code !== '42P10') {
+    throw error
+  }
+
+  const { data: existing, error: selectError } = await service
+    .from('users' as any)
+    .select('id')
+    .eq('auth_user_id', params.authUserId)
+    .maybeSingle()
+
+  if (selectError && selectError.code !== 'PGRST116') {
+    throw selectError
+  }
+
+  if (existing?.id) {
+    const { error: updateError } = await service
+      .from('users' as any)
+      .update(record)
+      .eq('id', existing.id)
+
+    if (updateError) {
+      throw updateError
+    }
+
+    return
+  }
+
+  const { error: insertError } = await service
+    .from('users' as any)
+    .insert(record)
+
+  if (insertError) {
+    throw insertError
+  }
+}

--- a/talentify-next-frontend/lib/auth/signup.ts
+++ b/talentify-next-frontend/lib/auth/signup.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod'
+
+export const SIGNUP_ROLES = ['talent', 'store', 'company'] as const
+export const signUpSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+  role: z.enum(SIGNUP_ROLES),
+})
+
+export type SignupRole = (typeof SIGNUP_ROLES)[number]
+
+export type SignupErrorCode =
+  | 'INVALID_INPUT'
+  | 'RATE_LIMITED'
+  | 'EMAIL_ALREADY_EXISTS'
+  | 'INVALID_EMAIL'
+  | 'SIGNUP_FAILED'
+
+export function mapSupabaseSignUpError(
+  error: { code?: string; message?: string } | null
+): SignupErrorCode {
+  const code = error?.code?.toLowerCase() ?? ''
+  const message = error?.message?.toLowerCase() ?? ''
+
+  if (code.includes('over_email_send_rate_limit') || message.includes('rate limit')) {
+    return 'RATE_LIMITED'
+  }
+
+  if (message.includes('already') || message.includes('registered')) {
+    return 'EMAIL_ALREADY_EXISTS'
+  }
+
+  if (message.includes('invalid') && message.includes('email')) {
+    return 'INVALID_EMAIL'
+  }
+
+  return 'SIGNUP_FAILED'
+}

--- a/talentify-next-frontend/prisma/migrations/20260415000000_add_app_users_auth_columns/migration.sql
+++ b/talentify-next-frontend/prisma/migrations/20260415000000_add_app_users_auth_columns/migration.sql
@@ -1,0 +1,43 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type t
+    JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE t.typname = 'user_status' AND n.nspname = 'public'
+  ) THEN
+    CREATE TYPE public.user_status AS ENUM (
+      'pending_email_verification',
+      'onboarding',
+      'active',
+      'suspended'
+    );
+  END IF;
+END
+$$;
+
+ALTER TABLE IF EXISTS public.users
+  ADD COLUMN IF NOT EXISTS auth_user_id uuid,
+  ADD COLUMN IF NOT EXISTS email text,
+  ADD COLUMN IF NOT EXISTS role text,
+  ADD COLUMN IF NOT EXISTS status public.user_status NOT NULL DEFAULT 'pending_email_verification',
+  ADD COLUMN IF NOT EXISTS created_at timestamptz NOT NULL DEFAULT now(),
+  ADD COLUMN IF NOT EXISTS updated_at timestamptz NOT NULL DEFAULT now();
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relname = 'users' AND n.nspname = 'public') THEN
+    BEGIN
+      ALTER TABLE public.users ADD CONSTRAINT users_auth_user_id_key UNIQUE (auth_user_id);
+    EXCEPTION
+      WHEN duplicate_table THEN
+        NULL;
+      WHEN duplicate_object THEN
+        NULL;
+    END;
+  END IF;
+END
+$$;
+
+CREATE INDEX IF NOT EXISTS idx_users_email ON public.users (email);
+CREATE INDEX IF NOT EXISTS idx_users_role ON public.users (role);
+CREATE INDEX IF NOT EXISTS idx_users_status ON public.users (status);

--- a/talentify-next-frontend/prisma/schema.prisma
+++ b/talentify-next-frontend/prisma/schema.prisma
@@ -486,6 +486,22 @@ model stores {
 }
 
 /// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model users {
+  id           String      @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  auth_user_id String?     @unique(map: "users_auth_user_id_key") @db.Uuid
+  email        String?
+  role         String?
+  status       user_status @default(pending_email_verification)
+  created_at   DateTime?   @default(now()) @db.Timestamptz(6)
+  updated_at   DateTime?   @default(now()) @db.Timestamptz(6)
+
+  @@index([email], map: "idx_users_email")
+  @@index([role], map: "idx_users_role")
+  @@index([status], map: "idx_users_status")
+  @@schema("public")
+}
+
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
 model talent_availability_dates {
   id         String              @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   user_id    String              @db.Uuid
@@ -770,6 +786,16 @@ enum your_enum_type {
   value1
   value2
   value3
+
+  @@schema("public")
+}
+
+
+enum user_status {
+  pending_email_verification
+  onboarding
+  active
+  suspended
 
   @@schema("public")
 }

--- a/talentify-next-frontend/types/supabase.ts
+++ b/talentify-next-frontend/types/supabase.ts
@@ -11,6 +11,37 @@ export type Json =
 export type Database = {
   public: {
     Tables: {
+
+      users: {
+        Row: {
+          id: string
+          auth_user_id: string | null
+          email: string | null
+          role: string | null
+          status: 'pending_email_verification' | 'onboarding' | 'active' | 'suspended'
+          created_at: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          id?: string
+          auth_user_id?: string | null
+          email?: string | null
+          role?: string | null
+          status?: 'pending_email_verification' | 'onboarding' | 'active' | 'suspended'
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          id?: string
+          auth_user_id?: string | null
+          email?: string | null
+          role?: string | null
+          status?: 'pending_email_verification' | 'onboarding' | 'active' | 'suspended'
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
       stores: {
         Row: {
           avatar_url: string | null


### PR DESCRIPTION
### Motivation

- Move signup responsibilities off the client-only `supabase.auth.signUp()` call to a server API so the app can enforce validation, rate limits and normalized errors. 
- Create a stable place to manage app-level user state (role, onboarding/status) so the product can support invite/review/resend flows and auditability. 
- Keep current UX (email confirmation / callback redirect) while making future features (resend control, gating, admin review) easy to add. 

### Description

- Added a server signup endpoint at `POST /api/auth/signup` that validates `email`, `password`, `role` (`talent | store | company`) with `zod`, calls `supabase.auth.signUp()` and returns UI-friendly error codes (`INVALID_INPUT`, `RATE_LIMITED`, `EMAIL_ALREADY_EXISTS`, `INVALID_EMAIL`, `SIGNUP_FAILED`). (`app/api/auth/signup/route.ts`, `lib/auth/signup.ts`).
- Refactored the client `RegisterForm` to call `/api/auth/signup` instead of directly calling `supabase.auth.signUp()` and to render messages based on the normalized error codes. (`components/RegisterForm.tsx`).
- Implemented app-user persistence and upsert helper using the Supabase service role client to keep `auth user` ↔ `app user` in sync (`lib/auth/app-user.ts`), and updated the `/auth/callback` flow to resolve role from query or `user_metadata.role` and upsert the app user (preserving existing redirect behavior and adding `company` onboarding redirect). (`app/auth/callback/route.ts`).
- Added DB + schema foundations: appended a `public.users` model and a `user_status` enum to the Prisma schema, created a SQL migration that adds `auth_user_id`, `email`, `role`, `status`, timestamps, unique constraint and indexes, and updated `types/supabase.ts` to include `public.users` for typed Supabase access. (`prisma/schema.prisma`, `prisma/migrations/20260415000000_add_app_users_auth_columns/migration.sql`, `types/supabase.ts`).

### Testing

- Ran `npm run lint` in the frontend repository which completed without errors (only pre-existing `no-img-element` warnings remained). 
- No unit tests were added in this change set; manual code paths tested: client signup flow now calls `/api/auth/signup` and the callback path performs a safe `upsertAppUser` (errors are logged and do not change redirect behavior).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df06b412108332b47af2aac6e3c24f)