### PR TITLE
Harden auth callback idempotency and clarify app user status transitions

### DIFF
--- a/talentify-next-frontend/__tests__/app-user-state.test.ts
+++ b/talentify-next-frontend/__tests__/app-user-state.test.ts
@@ -1,0 +1,21 @@
+import { resolveNextAppUserStatus } from '@/lib/auth/user-state'
+
+describe('resolveNextAppUserStatus', () => {
+  it('allows pending_email_verification to onboarding', () => {
+    expect(resolveNextAppUserStatus('pending_email_verification', 'onboarding')).toBe(
+      'onboarding'
+    )
+  })
+
+  it('does not roll active back to onboarding', () => {
+    expect(resolveNextAppUserStatus('active', 'onboarding')).toBe('active')
+  })
+
+  it('keeps suspended even if callback asks onboarding', () => {
+    expect(resolveNextAppUserStatus('suspended', 'onboarding')).toBe('suspended')
+  })
+
+  it('always allows transition to suspended', () => {
+    expect(resolveNextAppUserStatus('onboarding', 'suspended')).toBe('suspended')
+  })
+})

--- a/talentify-next-frontend/app/api/auth/signup/route.ts
+++ b/talentify-next-frontend/app/api/auth/signup/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { getRedirectUrl } from '@/lib/getRedirectUrl'
+import { upsertAppUser } from '@/lib/auth/app-user'
 import {
   mapSupabaseSignUpError,
   signUpSchema,
@@ -47,7 +48,7 @@ export async function POST(req: NextRequest) {
 
   const supabase = createClient()
 
-  const { error } = await supabase.auth.signUp({
+  const { data, error } = await supabase.auth.signUp({
     email,
     password,
     options: {
@@ -74,6 +75,21 @@ export async function POST(req: NextRequest) {
     }
 
     return errorResponse(400, code, '登録に失敗しました')
+  }
+
+  // signup 時点で app users を pending に合わせておく。
+  // callback が複数回呼ばれても status の巻き戻りは upsert 側で吸収する。
+  if (data.user?.id && data.user.email) {
+    try {
+      await upsertAppUser({
+        authUserId: data.user.id,
+        email: data.user.email,
+        role,
+        status: 'pending_email_verification',
+      })
+    } catch (appUserError) {
+      console.error('failed to upsert app user on signup', appUserError)
+    }
   }
 
   return NextResponse.json(

--- a/talentify-next-frontend/app/auth/callback/route.ts
+++ b/talentify-next-frontend/app/auth/callback/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
-import { upsertAppUser } from '@/lib/auth/app-user'
+import { getAppUserByAuthUserId, upsertAppUser } from '@/lib/auth/app-user'
 import { SIGNUP_ROLES, type SignupRole } from '@/lib/auth/signup'
 
 function toSignupRole(value: string | undefined): SignupRole | undefined {
@@ -34,10 +34,19 @@ export async function GET(req: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser()
 
-  const roleFromMetadata = toSignupRole((user?.user_metadata as { role?: string } | undefined)?.role)
-  const role = toSignupRole(roleParam) ?? roleFromMetadata
+  const existingAppUser = user?.id
+    ? await getAppUserByAuthUserId(user.id).catch((fetchError) => {
+        console.error('failed to fetch app user on callback', fetchError)
+        return null
+      })
+    : null
 
-  if (user?.id && user?.email && role) {
+  const roleFromMetadata = toSignupRole((user?.user_metadata as { role?: string } | undefined)?.role)
+  const roleFromExisting = toSignupRole(existingAppUser?.role)
+  const roleFromQuery = toSignupRole(roleParam)
+  const role = roleFromMetadata ?? roleFromExisting ?? roleFromQuery
+
+  if (user?.id && user?.email) {
     try {
       await upsertAppUser({
         authUserId: user.id,

--- a/talentify-next-frontend/components/RegisterForm.tsx
+++ b/talentify-next-frontend/components/RegisterForm.tsx
@@ -15,11 +15,12 @@ export default function RegisterForm() {
       ? roleParam
       : null
 
-  const [role] = useState(initialRole)
+  const role = initialRole
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [confirm, setConfirm] = useState('')
   const [globalError, setGlobalError] = useState<string | null>(null)
+  const [rateLimitError, setRateLimitError] = useState<string | null>(null)
   const [emailError, setEmailError] = useState<string | null>(null)
   const [passwordError, setPasswordError] = useState<string | null>(null)
   const [confirmError, setConfirmError] = useState<string | null>(null)
@@ -49,6 +50,7 @@ export default function RegisterForm() {
 
     setIsSubmitting(true)
     setGlobalError(null)
+    setRateLimitError(null)
     setEmailError(null)
     setPasswordError(null)
     setConfirmError(null)
@@ -101,14 +103,20 @@ export default function RegisterForm() {
       const payload = await response.json().catch(() => null)
 
       if (!response.ok || !payload?.ok) {
-        setGlobalError(getSignUpErrorMessage(payload?.error?.code))
+        const message = getSignUpErrorMessage(payload?.error?.code)
+
+        if (payload?.error?.code === 'RATE_LIMITED' || response.status === 429) {
+          setRateLimitError(message)
+        } else {
+          setGlobalError(message)
+        }
+
         return
       }
 
       // ✅ メール送信成功 → check-email に遷移
       router.push('/check-email')
-    } catch (e) {
-      console.error('signUp failed:', e)
+    } catch {
       setGlobalError('通信に失敗しました。インターネット接続をご確認ください')
     } finally {
       setIsSubmitting(false)
@@ -120,6 +128,11 @@ export default function RegisterForm() {
       <h1 className="text-2xl font-bold">新規登録</h1>
 
       {globalError && <p className="text-red-600">{globalError}</p>}
+      {rateLimitError && (
+        <p className="text-amber-700" role="alert" aria-live="polite">
+          {rateLimitError}
+        </p>
+      )}
 
       <form onSubmit={handleRegister} className="space-y-6">
         <div>

--- a/talentify-next-frontend/lib/auth/app-user.ts
+++ b/talentify-next-frontend/lib/auth/app-user.ts
@@ -77,7 +77,7 @@ export async function upsertAppUser(params: UpsertAppUserParams) {
     throw error
   }
 
-  const { data: existing, error: selectError } = await service
+  const { data: existingRecord, error: selectError } = await service
     .from('users' as any)
     .select('id')
     .eq('auth_user_id', params.authUserId)
@@ -87,7 +87,7 @@ export async function upsertAppUser(params: UpsertAppUserParams) {
     throw selectError
   }
 
-  const existingId = (existing as { id?: string } | null)?.id
+  const existingId = (existingRecord as { id?: string } | null)?.id
 
   if (existingId) {
     const { error: updateError } = await service

--- a/talentify-next-frontend/lib/auth/app-user.ts
+++ b/talentify-next-frontend/lib/auth/app-user.ts
@@ -1,27 +1,66 @@
 import { createServiceClient } from '@/lib/supabase/service'
-import type { SignupRole } from '@/lib/auth/signup'
-
-export type AppUserStatus =
-  | 'pending_email_verification'
-  | 'onboarding'
-  | 'active'
-  | 'suspended'
+import { SIGNUP_ROLES, type SignupRole } from '@/lib/auth/signup'
+import {
+  resolveNextAppUserStatus,
+  type AppUserStatus,
+} from '@/lib/auth/user-state'
 
 type UpsertAppUserParams = {
   authUserId: string
   email: string
-  role: SignupRole
+  role?: SignupRole
   status: AppUserStatus
+}
+
+type AppUserRow = {
+  id?: string
+  auth_user_id?: string
+  email?: string | null
+  role?: string | null
+  status?: AppUserStatus | null
+} | null
+
+function toSignupRole(value: string | null | undefined): SignupRole | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  return SIGNUP_ROLES.includes(value as SignupRole)
+    ? (value as SignupRole)
+    : undefined
+}
+
+async function findByAuthUserId(authUserId: string): Promise<AppUserRow> {
+  const service = createServiceClient()
+  const { data, error } = await service
+    .from('users' as any)
+    .select('id, auth_user_id, email, role, status')
+    .eq('auth_user_id', authUserId)
+    .maybeSingle()
+
+  if (error && error.code !== 'PGRST116') {
+    throw error
+  }
+
+  return (data as AppUserRow) ?? null
+}
+
+export async function getAppUserByAuthUserId(authUserId: string): Promise<AppUserRow> {
+  return findByAuthUserId(authUserId)
 }
 
 export async function upsertAppUser(params: UpsertAppUserParams) {
   const service = createServiceClient()
+  const existing = await findByAuthUserId(params.authUserId)
+
+  const resolvedRole = params.role ?? toSignupRole(existing?.role)
+  const resolvedStatus = resolveNextAppUserStatus(existing?.status, params.status)
 
   const record = {
     auth_user_id: params.authUserId,
     email: params.email,
-    role: params.role,
-    status: params.status,
+    role: resolvedRole ?? existing?.role ?? null,
+    status: resolvedStatus,
   }
 
   const upsertResult = await service

--- a/talentify-next-frontend/lib/auth/user-state.ts
+++ b/talentify-next-frontend/lib/auth/user-state.ts
@@ -1,0 +1,38 @@
+export type AppUserStatus =
+  | 'pending_email_verification'
+  | 'onboarding'
+  | 'active'
+  | 'suspended'
+
+/**
+ * Route guard / middleware guidance:
+ * - pending_email_verification: show verification check / resend mail flow
+ * - onboarding: lock to onboarding pages
+ * - active: allow full product access
+ * - suspended: lock to suspended/support page
+ */
+export const APP_USER_STATUS_TRANSITIONS: Record<AppUserStatus, AppUserStatus[]> = {
+  pending_email_verification: ['onboarding', 'suspended'],
+  onboarding: ['active', 'suspended'],
+  active: ['suspended'],
+  suspended: [],
+}
+
+export function resolveNextAppUserStatus(
+  current: AppUserStatus | null | undefined,
+  next: AppUserStatus
+): AppUserStatus {
+  if (!current) {
+    return next
+  }
+
+  if (current === next) {
+    return current
+  }
+
+  if (current === 'suspended' || next === 'suspended') {
+    return 'suspended'
+  }
+
+  return APP_USER_STATUS_TRANSITIONS[current].includes(next) ? next : current
+}

--- a/talentify-next-frontend/middleware.ts
+++ b/talentify-next-frontend/middleware.ts
@@ -3,6 +3,16 @@ import { createMiddlewareClient } from '@/lib/supabase/server'
 import { getUserRoleInfo } from '@/lib/getUserRole'
 
 export async function middleware(req: NextRequest) {
+  /**
+   * Next step (status-based route guard):
+   * - pending_email_verification: keep only verification / resend surfaces
+   * - onboarding: force /{role}/edit flows
+   * - active: allow dashboards/features
+   * - suspended: force suspended page
+   *
+   * Auth callback currently promotes pending_email_verification -> onboarding,
+   * while active/suspended are intentionally not rolled back by callback re-entry.
+   */
   if (req.nextUrl.pathname.startsWith('/auth/callback')) {
     return NextResponse.next()
   }


### PR DESCRIPTION
### Motivation

- 認証コールバックや再送・二重送信が発生してもユーザーデータが壊れないようにし、`role` の正本と `users.status` の遷移を明確化するため。 

### Description

- `auth/callback` の役割解決順を `user_metadata.role` → 既存 `users.role` → クエリの順にして `user_metadata` を正本に変更し、フォールバックを残しました (`app/auth/callback/route.ts`).
- `upsertAppUser` を強化して既存レコードを先に取得してから `upsert`/`update` するようにし、`auth_user_id` ごとに一意の行へ収束するように責務を拡張しました (`lib/auth/app-user.ts`).
- `users.status` の遷移ロジックを `lib/auth/user-state.ts` に切り出して明文化し、`pending_email_verification` → `onboarding` → `active`、`suspended` は優先扱いなどのルールを実装しました。
- signup の成功時に初期 `users.status` を `pending_email_verification` として `upsertAppUser` するようにし、callback 前後で状態整合が取れるようにしました (`app/api/auth/signup/route.ts`).
- `RegisterForm` の UX を改善し `isSubmitting` による二重送信防止は維持しつつ、`429 / RATE_LIMITED` 用の専用文言表示を追加してエラーメッセージを分離しました (`components/RegisterForm.tsx`).
- middleware に次段での status ベースのルートガード方針コメントを追加して、`pending_email_verification` / `onboarding` / `active` / `suspended` をどのように扱うかを示しました (`middleware.ts`).
- 状態遷移ロジックのユニットテストを追加して遷移ルール（例: `active` を `onboarding` に戻さない等）を固定化しました (`__tests__/app-user-state.test.ts`).

### Testing

- 実行した lint: `cd talentify-next-frontend && npm run lint` — コマンドは終了し主要な ESLint 警告のみ報告されました（終了コード 0）。
- 実行したユニットテスト: `cd talentify-next-frontend && npm run test -- --runInBand __tests__/app-user-state.test.ts` — テストスイートは `PASS` で全テストが成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df116ec6608332b06bd28971b8078f)