### PR TITLE
Add /auth/error page and UI for expired/invalid confirmation links

### DIFF
--- a/talentify-next-frontend/app/auth/error/AuthErrorCard.tsx
+++ b/talentify-next-frontend/app/auth/error/AuthErrorCard.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { AlertCircle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+type AuthErrorCardProps = {
+  initialErrorCode?: string
+  initialError?: string
+}
+
+function parseHashParams(hashValue: string) {
+  const hash = hashValue.startsWith('#') ? hashValue.slice(1) : hashValue
+  return new URLSearchParams(hash)
+}
+
+export default function AuthErrorCard({ initialErrorCode, initialError }: AuthErrorCardProps) {
+  const [hashErrorCode, setHashErrorCode] = useState<string | null>(null)
+  const [hashError, setHashError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const params = parseHashParams(window.location.hash)
+    setHashErrorCode(params.get('error_code'))
+    setHashError(params.get('error'))
+  }, [])
+
+  const effectiveErrorCode = hashErrorCode ?? initialErrorCode ?? undefined
+  const effectiveError = hashError ?? initialError ?? undefined
+
+  const detailMessage = useMemo(() => {
+    if (effectiveErrorCode === 'otp_expired') {
+      return '確認メールのリンクは有効期限切れです。新しい確認メールを再送して、最新のリンクからお試しください。'
+    }
+
+    if (effectiveError === 'access_denied') {
+      return '認証が拒否されました。リンクが古いか、すでに使用済みの可能性があります。'
+    }
+
+    return '時間をおいて再度お試しいただくか、確認メールを再送して最新のリンクからアクセスしてください。'
+  }, [effectiveError, effectiveErrorCode])
+
+  return (
+    <div className="mx-auto flex min-h-[calc(100vh-64px)] w-full max-w-3xl items-center justify-center px-4 py-12">
+      <Card className="w-full max-w-xl">
+        <CardHeader className="space-y-3">
+          <div className="flex items-center gap-2 text-red-600">
+            <AlertCircle className="h-5 w-5" aria-hidden="true" />
+            <p className="text-sm font-medium">認証エラー</p>
+          </div>
+          <CardTitle className="text-2xl">確認メールのリンクが無効か、有効期限が切れています</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <p className="text-sm leading-relaxed text-muted-foreground">{detailMessage}</p>
+
+          <div className="grid gap-3 sm:grid-cols-3">
+            <Button asChild>
+              <Link href="/login">ログインへ</Link>
+            </Button>
+            <Button asChild variant="secondary">
+              <Link href="/register">新規登録へ</Link>
+            </Button>
+            <Button asChild variant="outline">
+              <Link href="/check-email">確認メール再送の案内へ</Link>
+            </Button>
+          </div>
+
+          <p className="text-xs text-muted-foreground">
+            確認メールを再送してください。再送後は、最新のメールに記載されたリンクをご利用ください。
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/talentify-next-frontend/app/auth/error/page.tsx
+++ b/talentify-next-frontend/app/auth/error/page.tsx
@@ -1,0 +1,17 @@
+import AuthErrorCard from './AuthErrorCard'
+
+type AuthErrorPageProps = {
+  searchParams?: {
+    error?: string
+    error_code?: string
+  }
+}
+
+export default function AuthErrorPage({ searchParams }: AuthErrorPageProps) {
+  return (
+    <AuthErrorCard
+      initialError={searchParams?.error}
+      initialErrorCode={searchParams?.error_code}
+    />
+  )
+}


### PR DESCRIPTION
### Motivation

- Supabase auth redirects to `/auth/error` on missing `code` or failed `exchangeCodeForSession`, but the app had no `/auth/error` page so those requests returned 404. 
- Users clicking expired or invalid confirmation links therefore saw a generic 404 instead of actionable guidance.

### Description

- Added a new route `app/auth/error/page.tsx` which accepts optional `searchParams` (`error`, `error_code`) and renders a client UI so the route no longer 404s. 
- Implemented `app/auth/error/AuthErrorCard.tsx` as a client component that reads `window.location.hash` and falls back to query params, and shows localized messages for `otp_expired`, `access_denied`, and generic auth errors. 
- The UI displays the required copy "確認メールのリンクが無効か、有効期限が切れています" and provides recovery buttons linking to ` /login`, ` /register`, and ` /check-email` (the latter is a guidance path for resending confirmation emails). 
- The `AuthErrorCard` is structured so a future resend API (for example ` /auth/resend`) can be wired into the third button or replaced with a modal without changing routing.

### Testing

- Ran `npm run lint` in `talentify-next-frontend` and no new lint errors were introduced; unrelated `no-img-element` warnings remain from other files. 
- Verified the new files `app/auth/error/page.tsx` and `app/auth/error/AuthErrorCard.tsx` are present and import correctly (build-time/type checks implied by lint step).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df157d21308332b13d860b7bbf799d)