### PR TITLE
Add confirmation email resend recovery flow

### DIFF
--- a/talentify-next-frontend/__tests__/auth-resend-confirmation-api.test.ts
+++ b/talentify-next-frontend/__tests__/auth-resend-confirmation-api.test.ts
@@ -1,0 +1,119 @@
+import { NextRequest } from 'next/server'
+import { POST } from '@/app/api/auth/resend-confirmation/route'
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(),
+}))
+
+jest.mock('@/lib/supabase/service', () => ({
+  createServiceClient: jest.fn(),
+}))
+
+const { createClient } = jest.requireMock('@/lib/supabase/server') as {
+  createClient: jest.Mock
+}
+
+const { createServiceClient } = jest.requireMock('@/lib/supabase/service') as {
+  createServiceClient: jest.Mock
+}
+
+describe('POST /api/auth/resend-confirmation', () => {
+  const resend = jest.fn()
+  const maybeSingle = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    createClient.mockReturnValue({
+      auth: {
+        resend,
+      },
+    })
+
+    createServiceClient.mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          ilike: jest.fn().mockReturnValue({
+            maybeSingle,
+          }),
+        }),
+      }),
+    })
+
+    maybeSingle.mockResolvedValue({ data: null, error: null })
+    resend.mockResolvedValue({ error: null })
+  })
+
+  it('returns INVALID_INPUT when email is missing', async () => {
+    const req = new NextRequest('http://localhost/api/auth/resend-confirmation', {
+      method: 'POST',
+      body: JSON.stringify({}),
+    })
+
+    const res = await POST(req)
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toMatchObject({
+      ok: false,
+      code: 'INVALID_INPUT',
+    })
+  })
+
+  it('returns RATE_LIMITED when Supabase hits sending limit', async () => {
+    resend.mockResolvedValue({
+      error: { code: 'over_email_send_rate_limit', message: 'rate limit' },
+    })
+
+    const req = new NextRequest('http://localhost/api/auth/resend-confirmation', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'pending@example.com' }),
+    })
+
+    const res = await POST(req)
+
+    expect(res.status).toBe(429)
+    await expect(res.json()).resolves.toMatchObject({
+      ok: false,
+      code: 'RATE_LIMITED',
+    })
+  })
+
+  it('returns NOT_FOUND_OR_ALREADY_VERIFIED when status is active', async () => {
+    maybeSingle.mockResolvedValue({ data: { status: 'active', role: 'talent' }, error: null })
+
+    const req = new NextRequest('http://localhost/api/auth/resend-confirmation', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'active@example.com' }),
+    })
+
+    const res = await POST(req)
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toMatchObject({
+      ok: true,
+      code: 'NOT_FOUND_OR_ALREADY_VERIFIED',
+    })
+    expect(resend).not.toHaveBeenCalled()
+  })
+
+  it('returns OK for pending users', async () => {
+    maybeSingle.mockResolvedValue({
+      data: { status: 'pending_email_verification', role: 'company' },
+      error: null,
+    })
+
+    const req = new NextRequest('http://localhost/api/auth/resend-confirmation', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'pending@example.com' }),
+    })
+
+    const res = await POST(req)
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toMatchObject({
+      ok: true,
+      code: 'OK',
+    })
+    expect(resend).toHaveBeenCalled()
+  })
+})

--- a/talentify-next-frontend/app/api/auth/resend-confirmation/route.ts
+++ b/talentify-next-frontend/app/api/auth/resend-confirmation/route.ts
@@ -1,0 +1,136 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { createServiceClient } from '@/lib/supabase/service'
+import {
+  mapSupabaseResendError,
+  resendConfirmationSchema,
+  toSignupRole,
+  type ResendConfirmationCode,
+} from '@/lib/auth/resend-confirmation'
+import { getRedirectUrl } from '@/lib/getRedirectUrl'
+
+type ResendResponse = {
+  ok: boolean
+  code: ResendConfirmationCode
+  message: string
+}
+
+function jsonResponse(status: number, body: ResendResponse) {
+  return NextResponse.json(body, { status })
+}
+
+function resolveEmailRedirect(role?: string) {
+  if (role) {
+    return getRedirectUrl(role)
+  }
+
+  const baseUrl =
+    process.env.NODE_ENV === 'development'
+      ? 'http://localhost:3000'
+      : process.env.NEXT_PUBLIC_SITE_URL || 'https://talentify-xi.vercel.app'
+
+  return `${baseUrl.replace(/\/+$/, '')}/auth/callback`
+}
+
+export async function POST(req: NextRequest) {
+  let body: unknown
+
+  try {
+    body = await req.json()
+  } catch {
+    return jsonResponse(400, {
+      ok: false,
+      code: 'INVALID_INPUT',
+      message: '入力内容を確認してください',
+    })
+  }
+
+  const parsed = resendConfirmationSchema.safeParse(body)
+  if (!parsed.success) {
+    return jsonResponse(400, {
+      ok: false,
+      code: 'INVALID_INPUT',
+      message: '入力内容を確認してください',
+    })
+  }
+
+  const email = parsed.data.email.toLowerCase()
+  const requestedRole = parsed.data.role
+
+  const service = createServiceClient()
+  const { data: appUser, error: appUserError } = await service
+    .from('users' as any)
+    .select('status, role')
+    .ilike('email', email)
+    .maybeSingle()
+
+  if (appUserError && appUserError.code !== 'PGRST116') {
+    console.error('resend confirmation app user lookup failed', appUserError)
+    return jsonResponse(500, {
+      ok: false,
+      code: 'RESEND_FAILED',
+      message: '確認メールの再送に失敗しました',
+    })
+  }
+
+  const appUserRole = toSignupRole(appUser?.role)
+  const role = requestedRole ?? appUserRole
+
+  if (requestedRole && appUserRole && requestedRole !== appUserRole) {
+    return jsonResponse(200, {
+      ok: true,
+      code: 'NOT_FOUND_OR_ALREADY_VERIFIED',
+      message: '該当する未確認ユーザーが見つからないか、すでに確認済みです',
+    })
+  }
+
+  if (appUser?.status && appUser.status !== 'pending_email_verification') {
+    return jsonResponse(200, {
+      ok: true,
+      code: 'NOT_FOUND_OR_ALREADY_VERIFIED',
+      message: '該当する未確認ユーザーが見つからないか、すでに確認済みです',
+    })
+  }
+
+  const supabase = createClient()
+  const { error } = await supabase.auth.resend({
+    type: 'signup',
+    email,
+    options: {
+      emailRedirectTo: resolveEmailRedirect(role),
+    },
+  })
+
+  if (error) {
+    const code = mapSupabaseResendError(error)
+
+    if (code === 'RATE_LIMITED') {
+      return jsonResponse(429, {
+        ok: false,
+        code,
+        message: '送信回数が上限に達しました。時間をおいてお試しください',
+      })
+    }
+
+    if (code === 'NOT_FOUND_OR_ALREADY_VERIFIED') {
+      return jsonResponse(200, {
+        ok: true,
+        code,
+        message: '該当する未確認ユーザーが見つからないか、すでに確認済みです',
+      })
+    }
+
+    console.error('resend confirmation failed', error)
+    return jsonResponse(500, {
+      ok: false,
+      code,
+      message: '確認メールの再送に失敗しました',
+    })
+  }
+
+  return jsonResponse(200, {
+    ok: true,
+    code: 'OK',
+    message: '確認メールを再送しました',
+  })
+}

--- a/talentify-next-frontend/app/api/auth/resend-confirmation/route.ts
+++ b/talentify-next-frontend/app/api/auth/resend-confirmation/route.ts
@@ -19,6 +19,25 @@ function jsonResponse(status: number, body: ResendResponse) {
   return NextResponse.json(body, { status })
 }
 
+
+type AppUserLookupRow = {
+  status?: string | null
+  role?: string | null
+} | null
+
+function toAppUserLookupRow(value: unknown): AppUserLookupRow {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+
+  const candidate = value as { status?: unknown; role?: unknown }
+
+  return {
+    status: typeof candidate.status === 'string' ? candidate.status : null,
+    role: typeof candidate.role === 'string' ? candidate.role : null,
+  }
+}
+
 function resolveEmailRedirect(role?: string) {
   if (role) {
     return getRedirectUrl(role)
@@ -58,7 +77,7 @@ export async function POST(req: NextRequest) {
   const requestedRole = parsed.data.role
 
   const service = createServiceClient()
-  const { data: appUser, error: appUserError } = await service
+  const { data: appUserData, error: appUserError } = await service
     .from('users' as any)
     .select('status, role')
     .ilike('email', email)
@@ -72,6 +91,8 @@ export async function POST(req: NextRequest) {
       message: '確認メールの再送に失敗しました',
     })
   }
+
+  const appUser = toAppUserLookupRow(appUserData)
 
   const appUserRole = toSignupRole(appUser?.role)
   const role = requestedRole ?? appUserRole

--- a/talentify-next-frontend/app/auth/error/AuthErrorCard.tsx
+++ b/talentify-next-frontend/app/auth/error/AuthErrorCard.tsx
@@ -19,11 +19,15 @@ function parseHashParams(hashValue: string) {
 export default function AuthErrorCard({ initialErrorCode, initialError }: AuthErrorCardProps) {
   const [hashErrorCode, setHashErrorCode] = useState<string | null>(null)
   const [hashError, setHashError] = useState<string | null>(null)
+  const [emailFromQuery, setEmailFromQuery] = useState<string | null>(null)
 
   useEffect(() => {
     const params = parseHashParams(window.location.hash)
     setHashErrorCode(params.get('error_code'))
     setHashError(params.get('error'))
+
+    const queryParams = new URLSearchParams(window.location.search)
+    setEmailFromQuery(queryParams.get('email'))
   }, [])
 
   const effectiveErrorCode = hashErrorCode ?? initialErrorCode ?? undefined
@@ -40,6 +44,10 @@ export default function AuthErrorCard({ initialErrorCode, initialError }: AuthEr
 
     return '時間をおいて再度お試しいただくか、確認メールを再送して最新のリンクからアクセスしてください。'
   }, [effectiveError, effectiveErrorCode])
+
+  const resendHref = emailFromQuery
+    ? `/check-email?email=${encodeURIComponent(emailFromQuery)}&from=auth-error`
+    : '/check-email?from=auth-error'
 
   return (
     <div className="mx-auto flex min-h-[calc(100vh-64px)] w-full max-w-3xl items-center justify-center px-4 py-12">
@@ -62,7 +70,7 @@ export default function AuthErrorCard({ initialErrorCode, initialError }: AuthEr
               <Link href="/register">新規登録へ</Link>
             </Button>
             <Button asChild variant="outline">
-              <Link href="/check-email">確認メール再送の案内へ</Link>
+              <Link href={resendHref}>確認メール再送の案内へ</Link>
             </Button>
           </div>
 

--- a/talentify-next-frontend/app/check-email/ResendConfirmationCard.tsx
+++ b/talentify-next-frontend/app/check-email/ResendConfirmationCard.tsx
@@ -1,0 +1,145 @@
+'use client'
+
+import { FormEvent, useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { RESEND_CONFIRMATION_COOLDOWN_SECONDS } from '@/lib/auth/resend-confirmation'
+
+function isValidEmail(value: string) {
+  return /^\S+@\S+\.\S+$/.test(value)
+}
+
+export default function ResendConfirmationCard() {
+  const searchParams = useSearchParams()
+  const initialEmail = searchParams.get('email') ?? ''
+  const role = searchParams.get('role')
+  const [email, setEmail] = useState(initialEmail)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [message, setMessage] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [cooldown, setCooldown] = useState(0)
+
+  useEffect(() => {
+    if (cooldown <= 0) {
+      return
+    }
+
+    const timer = window.setInterval(() => {
+      setCooldown((prev) => (prev > 0 ? prev - 1 : 0))
+    }, 1000)
+
+    return () => window.clearInterval(timer)
+  }, [cooldown])
+
+  const canSubmit = useMemo(() => {
+    return !isSubmitting && cooldown === 0 && isValidEmail(email)
+  }, [cooldown, email, isSubmitting])
+
+  const onResend = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    if (!canSubmit) {
+      return
+    }
+
+    setIsSubmitting(true)
+    setMessage(null)
+    setError(null)
+
+    try {
+      const response = await fetch('/api/auth/resend-confirmation', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email,
+          ...(role ? { role } : {}),
+          // 将来的に captcha を追加する場合はここで token を付与する。
+          // captchaToken,
+        }),
+      })
+
+      const payload = (await response.json().catch(() => null)) as
+        | { code?: string; message?: string }
+        | null
+
+      if (payload?.code === 'RATE_LIMITED' || response.status === 429) {
+        setError('送信回数が上限に達しました。しばらく時間をおいてから再度お試しください。')
+        setCooldown(RESEND_CONFIRMATION_COOLDOWN_SECONDS)
+        return
+      }
+
+      if (payload?.code === 'NOT_FOUND_OR_ALREADY_VERIFIED') {
+        setMessage(
+          '該当する未確認アカウントが見つからないか、すでに確認済みです。最新のメールをご確認ください。'
+        )
+        setCooldown(RESEND_CONFIRMATION_COOLDOWN_SECONDS)
+        return
+      }
+
+      if (!response.ok || payload?.code === 'RESEND_FAILED' || payload?.code === 'INVALID_INPUT') {
+        setError('確認メールの再送に失敗しました。時間をおいて再度お試しください。')
+        return
+      }
+
+      setMessage('確認メールを再送しました。受信トレイをご確認ください。')
+      setCooldown(RESEND_CONFIRMATION_COOLDOWN_SECONDS)
+    } catch {
+      setError('通信に失敗しました。インターネット接続をご確認ください。')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="mt-8 w-full max-w-md rounded-lg border border-slate-200 p-5">
+      <h2 className="text-base font-semibold">確認メールの再送</h2>
+      <p className="mt-2 text-sm text-gray-600">
+        リンクの有効期限が切れた場合は、こちらから確認メールを再送できます。
+      </p>
+
+      <form className="mt-4 space-y-3" onSubmit={onResend}>
+        <label className="block text-sm font-medium text-gray-700">メールアドレス</label>
+        <Input
+          type="email"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+          placeholder="you@example.com"
+          disabled={isSubmitting}
+          required
+        />
+
+        {error && (
+          <p className="text-sm text-red-600" role="alert" aria-live="polite">
+            {error}
+          </p>
+        )}
+
+        {message && (
+          <p className="text-sm text-emerald-700" role="status" aria-live="polite">
+            {message}
+          </p>
+        )}
+
+        {cooldown > 0 && (
+          <p className="text-xs text-amber-700">再送は {cooldown} 秒後に可能です。</p>
+        )}
+
+        <Button type="submit" disabled={!canSubmit}>
+          {isSubmitting ? '再送中...' : '確認メールを再送する'}
+        </Button>
+      </form>
+
+      <p className="mt-3 text-xs text-gray-500">
+        セキュリティ保護のため、アカウントの存在有無に関わらず同様の案内を表示する場合があります。
+      </p>
+
+      <Link href="/" className="mt-4 inline-block text-sm text-blue-600 underline">
+        トップページに戻る
+      </Link>
+    </div>
+  )
+}

--- a/talentify-next-frontend/app/check-email/page.tsx
+++ b/talentify-next-frontend/app/check-email/page.tsx
@@ -1,21 +1,22 @@
-// app/check-email/page.tsx
-import { Button } from "@/components/ui/button";
-import Link from "next/link";
+import { Suspense } from 'react'
+import ResendConfirmationCard from './ResendConfirmationCard'
 
 export default function CheckEmailPage() {
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-white px-4">
-      <h1 className="text-2xl font-bold text-gray-800 mb-4">仮登録が完了しました</h1>
-      <p className="text-center text-gray-600 mb-6">
-        ご入力いただいたメールアドレス宛に確認メールをお送りしました。<br />
+      <h1 className="mb-4 text-2xl font-bold text-gray-800">仮登録が完了しました</h1>
+      <p className="mb-6 text-center text-gray-600">
+        ご入力いただいたメールアドレス宛に確認メールをお送りしました。
+        <br />
         メールに記載されたURLをクリックして、本登録を完了してください。
       </p>
-      <p className="text-sm text-gray-500 mb-8">
+      <p className="text-sm text-gray-500">
         ※メールが届かない場合は、迷惑メールフォルダをご確認ください。
       </p>
-      <Link href="/">
-        <Button>トップページに戻る</Button>
-      </Link>
+
+      <Suspense fallback={null}>
+        <ResendConfirmationCard />
+      </Suspense>
     </div>
-  );
+  )
 }

--- a/talentify-next-frontend/components/RegisterForm.tsx
+++ b/talentify-next-frontend/components/RegisterForm.tsx
@@ -115,7 +115,8 @@ export default function RegisterForm() {
       }
 
       // ✅ メール送信成功 → check-email に遷移
-      router.push('/check-email')
+      const nextParams = new URLSearchParams({ email, role })
+      router.push(`/check-email?${nextParams.toString()}`)
     } catch {
       setGlobalError('通信に失敗しました。インターネット接続をご確認ください')
     } finally {

--- a/talentify-next-frontend/lib/auth/resend-confirmation.ts
+++ b/talentify-next-frontend/lib/auth/resend-confirmation.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod'
+import { SIGNUP_ROLES, type SignupRole } from '@/lib/auth/signup'
+
+export const RESEND_CONFIRMATION_COOLDOWN_SECONDS = 60
+
+export const resendConfirmationSchema = z.object({
+  email: z.string().trim().email(),
+  role: z.enum(SIGNUP_ROLES).optional(),
+  captchaToken: z.string().min(1).optional(),
+})
+
+export type ResendConfirmationCode =
+  | 'INVALID_INPUT'
+  | 'RATE_LIMITED'
+  | 'NOT_FOUND_OR_ALREADY_VERIFIED'
+  | 'RESEND_FAILED'
+  | 'OK'
+
+export function mapSupabaseResendError(
+  error: { code?: string; message?: string } | null
+): Exclude<ResendConfirmationCode, 'INVALID_INPUT' | 'OK'> {
+  const code = error?.code?.toLowerCase() ?? ''
+  const message = error?.message?.toLowerCase() ?? ''
+
+  if (code.includes('over_email_send_rate_limit') || message.includes('rate limit')) {
+    return 'RATE_LIMITED'
+  }
+
+  if (
+    message.includes('not found') ||
+    message.includes('user not found') ||
+    message.includes('already verified')
+  ) {
+    return 'NOT_FOUND_OR_ALREADY_VERIFIED'
+  }
+
+  return 'RESEND_FAILED'
+}
+
+export function toSignupRole(value: string | null | undefined): SignupRole | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  return SIGNUP_ROLES.includes(value as SignupRole)
+    ? (value as SignupRole)
+    : undefined
+}


### PR DESCRIPTION
### Motivation
- Allow users to recover when a signup confirmation link has expired without re-registering by providing an in-app resend flow.
- Make the resend path reachable from both `/check-email` and `/auth/error` and keep the callback behavior unchanged.
- Structure the flow so rate limiting, cooldown and future captcha protections can be added incrementally.

### Description
- Add a server API at `POST /api/auth/resend-confirmation` that validates input, consults the `users` table and calls Supabase `auth.resend`, and returns UI-facing codes: `INVALID_INPUT`, `RATE_LIMITED`, `NOT_FOUND_OR_ALREADY_VERIFIED`, `RESEND_FAILED`, and `OK` (`talentify-next-frontend/app/api/auth/resend-confirmation/route.ts`).
- Introduce reusable helpers and schema in `lib/auth/resend-confirmation.ts` including `resendConfirmationSchema`, `mapSupabaseResendError`, `toSignupRole`, and `RESEND_CONFIRMATION_COOLDOWN_SECONDS` (60s).
- Add a client UI card `app/check-email/ResendConfirmationCard.tsx` and embed it in `app/check-email/page.tsx` which supports email prefill from query, submit disabled state, success/error messages, and a 60s cooldown to avoid double sends.
- Wire `app/auth/error/AuthErrorCard.tsx` to route users into the resend flow (preserving an optional `email` query param), and update the register flow to pass `email` and `role` to `/check-email` for easier retries (`components/RegisterForm.tsx`).
- Add unit tests for the resend API covering invalid input, rate limiting, active-user neutral response, and pending-user success (`__tests__/auth-resend-confirmation-api.test.ts`).

### Testing
- Ran the new API unit tests with `npm test -- --runInBand __tests__/auth-resend-confirmation-api.test.ts` and all tests passed (4/4).
- Ran linting for the touched files with `npm run lint -- --file app/api/auth/resend-confirmation/route.ts --file app/check-email/page.tsx --file app/check-email/ResendConfirmationCard.tsx --file app/auth/error/AuthErrorCard.tsx --file components/RegisterForm.tsx --file lib/auth/resend-confirmation.ts` and there were no ESLint warnings or errors.
- The resend flow is implemented so server-side rate-limits coming from Supabase are mapped to `RATE_LIMITED` (returned as HTTP 429) and the UI applies a client-side `60s` cooldown; tests exercise the mapped error cases successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df1a9e61ec8332a621e26748efccbe)