### PR TITLE
オファー詳細に送信時のオファー内容カードを追加

### DIFF
--- a/talentify-next-frontend/app/store/offers/[id]/StoreOfferProgressPanel.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/StoreOfferProgressPanel.tsx
@@ -6,6 +6,7 @@ import { format } from 'date-fns'
 import { ja } from 'date-fns/locale'
 import ProgressCard from './ProgressCard'
 import StepDetailCard from './StepDetailCard'
+import SubmittedOfferContentCard from './SubmittedOfferContentCard'
 
 interface StoreOfferProgressPanelProps {
   steps: OfferProgressStep[]
@@ -26,6 +27,8 @@ interface StoreOfferProgressPanelProps {
     reward: number | null
     talentId: string | null
     reviewCompleted: boolean
+    timeRange: string | null
+    originalMessage: string | null
   }
   invoice?: {
     id: string
@@ -124,6 +127,14 @@ export default function StoreOfferProgressPanel({
   return (
     <div className="space-y-4">
       <ProgressCard steps={progressSteps} activeStep={activeStep} onStepChange={setActiveStep} />
+      <SubmittedOfferContentCard
+        submittedOffer={{
+          preferredDate: offer.date,
+          preferredTimeRange: offer.timeRange,
+          reward: offer.reward,
+          message: offer.originalMessage,
+        }}
+      />
       <StepDetailCard
         activeStep={activeStep}
         activeStatus={activeStatus}

--- a/talentify-next-frontend/app/store/offers/[id]/SubmittedOfferContentCard.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/SubmittedOfferContentCard.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import { useMemo } from 'react'
+import { format } from 'date-fns'
+import { ja } from 'date-fns/locale'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+type SubmittedOfferContentCardProps = {
+  submittedOffer: {
+    preferredDate: string | null
+    preferredTimeRange: string | null
+    reward: number | null
+    message: string | null
+  }
+}
+
+type SubmittedOfferFieldKey = 'preferredDate' | 'preferredTimeRange' | 'reward' | 'message'
+
+type SubmittedOfferField = {
+  key: SubmittedOfferFieldKey
+  label: string
+  value: string
+  multiline?: boolean
+}
+
+const EMPTY_LABEL = '未入力'
+
+function normalizeText(value: string | null | undefined) {
+  if (typeof value !== 'string') return EMPTY_LABEL
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : EMPTY_LABEL
+}
+
+function formatPreferredDate(value: string | null) {
+  if (!value) return EMPTY_LABEL
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return EMPTY_LABEL
+
+  return format(date, 'yyyy/MM/dd (EEE)', { locale: ja })
+}
+
+function formatReward(value: number | null) {
+  if (value == null || Number.isNaN(value)) return EMPTY_LABEL
+  return `${value.toLocaleString('ja-JP')}円`
+}
+
+function formatPreferredTimeRange(value: string | null) {
+  const normalized = normalizeText(value)
+  if (normalized === EMPTY_LABEL) return EMPTY_LABEL
+
+  const normalizedDelimiter = normalized.replace(/~/g, '〜').replace(/\s*〜\s*/g, '〜')
+  const [start, end] = normalizedDelimiter.split('〜')
+
+  if (!start || !end) {
+    return normalizedDelimiter
+  }
+
+  return `${start}〜${end}`
+}
+
+export default function SubmittedOfferContentCard({ submittedOffer }: SubmittedOfferContentCardProps) {
+  const fields = useMemo<SubmittedOfferField[]>(() => {
+    return [
+      {
+        key: 'preferredDate',
+        label: '希望日',
+        value: formatPreferredDate(submittedOffer.preferredDate),
+      },
+      {
+        key: 'preferredTimeRange',
+        label: '希望時間帯（開始〜終了）',
+        value: formatPreferredTimeRange(submittedOffer.preferredTimeRange),
+      },
+      {
+        key: 'reward',
+        label: '提示金額',
+        value: formatReward(submittedOffer.reward),
+      },
+      {
+        key: 'message',
+        label: 'メッセージ',
+        value: normalizeText(submittedOffer.message),
+        multiline: true,
+      },
+    ]
+  }, [submittedOffer.preferredDate, submittedOffer.preferredTimeRange, submittedOffer.reward, submittedOffer.message])
+
+  return (
+    <Card className="rounded-xl border border-slate-200 bg-white shadow-sm">
+      <CardHeader className="space-y-1 px-4 pt-4 sm:px-5 sm:pt-5">
+        <CardTitle className="text-base font-semibold text-slate-900 sm:text-lg">オファー内容</CardTitle>
+      </CardHeader>
+      <CardContent className="px-4 pb-4 pt-1 sm:px-5 sm:pb-5">
+        <dl className="space-y-3 text-sm">
+          {fields.map(field => (
+            <div key={field.key} className="grid gap-1 sm:grid-cols-[220px_1fr] sm:items-start sm:gap-3">
+              <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{field.label}</dt>
+              <dd className={field.multiline ? 'whitespace-pre-wrap text-sm font-medium text-slate-900' : 'text-sm font-semibold text-slate-900'}>
+                {field.value}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </CardContent>
+    </Card>
+  )
+}

--- a/talentify-next-frontend/app/store/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/store/offers/[id]/page.tsx
@@ -29,7 +29,7 @@ export default async function StoreOfferPage({ params }: PageProps) {
     .from('offers')
     .select(
       `
-      id,status,date,respond_deadline,reward,created_at,updated_at,message,talent_id,user_id,canceled_at,accepted_at,paid,paid_at,
+      id,status,date,time_range,respond_deadline,reward,created_at,updated_at,message,talent_id,user_id,canceled_at,accepted_at,paid,paid_at,
       reviews(id), talents(stage_name,avatar_url,user_id),
       store:stores!offers_store_id_fkey(id, store_name, user_id)
     `
@@ -63,7 +63,7 @@ export default async function StoreOfferPage({ params }: PageProps) {
     date: data.date as string,
     respondDeadline: data.respond_deadline as string | null,
     submittedAt: data.created_at as string | null,
-    message: data.message as string,
+    message: data.message as string | null,
     performerName: data.talents?.stage_name || '',
     performerAvatarUrl: data.talents?.avatar_url || null,
     acceptedAt: data.accepted_at as string | null,
@@ -75,6 +75,7 @@ export default async function StoreOfferPage({ params }: PageProps) {
     invoiceStatusLabel,
     paymentStatusLabel,
     reward: data.reward as number | null,
+    timeRange: data.time_range as string | null,
     talentId: data.talent_id as string | null,
     reviewCompleted,
     talentUserId: data.talents?.user_id as string | null,
@@ -157,6 +158,8 @@ export default async function StoreOfferPage({ params }: PageProps) {
               paymentStatusLabel: offer.paymentStatusLabel,
               storeName: offer.storeName,
               reward: offer.reward,
+              timeRange: offer.timeRange,
+              originalMessage: offer.message,
               talentId: offer.talentId,
               reviewCompleted: offer.reviewCompleted,
             }}


### PR DESCRIPTION
### Motivation
- ユーザーがオファー送信時の内容（希望日・希望時間帯・提示金額・メッセージ）を一目で確認できるように、進捗ステップカード直下に送信時のオファー内容を表示するため。

### Description
- 進捗パネル `StoreOfferProgressPanel` に新しい `SubmittedOfferContentCard` を追加して、`ProgressCard` の直下に表示するようにした。 
- 新規コンポーネント `SubmittedOfferContentCard` を追加し、ラベル＋値形式で `希望日` / `希望時間帯（開始〜終了）` / `提示金額` / `メッセージ` を表示し、空値は `未入力` を出すようにした。 
- オファー取得クエリに `time_range` を追加し、送信時の `message` を `originalMessage` としてパネルに渡すようにした（送信時の値をそのまま表示）。
- 表示ロジックは改行を保持する `whitespace-pre-wrap` と時間帯の `〜` 正規化を含み、将来のPDF化や請求書連携で再利用しやすいフィールド配列構造にした。 

### Testing
- 実行した自動化コマンドは `npm run lint` で、実行は成功しエラーはなく既存の `no-img-element` 警告のみ報告されました。 
- ユニット/統合テストは追加しておらず、本変更は静的チェックとビルド前検査を通過しています。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df22fa3d6883328acc29d81e4815d0)