### PR TITLE
受信オファー詳細に「オファー内容」カードを追加

### DIFF
--- a/talentify-next-frontend/app/talent/offers/[id]/SubmittedOfferContentCard.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/SubmittedOfferContentCard.tsx
@@ -1,0 +1,120 @@
+'use client'
+
+import { useMemo } from 'react'
+import { format } from 'date-fns'
+import { ja } from 'date-fns/locale'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+type SubmittedOfferContentCardProps = {
+  submittedOffer: {
+    preferredDate: string | null
+    preferredTimeRange: string | null
+    reward: number | null
+    transportationFee: number | null
+    message: string | null
+  }
+}
+
+type SubmittedOfferFieldKey = 'preferredDate' | 'preferredTimeRange' | 'reward' | 'transportationFee' | 'message'
+
+type SubmittedOfferField = {
+  key: SubmittedOfferFieldKey
+  label: string
+  value: string
+  multiline?: boolean
+}
+
+const EMPTY_LABEL = '未入力'
+
+function normalizeText(value: string | null | undefined) {
+  if (typeof value !== 'string') return EMPTY_LABEL
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : EMPTY_LABEL
+}
+
+function formatPreferredDate(value: string | null) {
+  if (!value) return EMPTY_LABEL
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return EMPTY_LABEL
+
+  return format(date, 'yyyy/MM/dd (EEE)', { locale: ja })
+}
+
+function formatCurrency(value: number | null) {
+  if (value == null || Number.isNaN(value)) return EMPTY_LABEL
+  return `${value.toLocaleString('ja-JP')}円`
+}
+
+function formatPreferredTimeRange(value: string | null) {
+  const normalized = normalizeText(value)
+  if (normalized === EMPTY_LABEL) return EMPTY_LABEL
+
+  const normalizedDelimiter = normalized.replace(/~/g, '〜').replace(/\s*〜\s*/g, '〜')
+  const [start, end] = normalizedDelimiter.split('〜')
+
+  if (!start || !end) {
+    return normalizedDelimiter
+  }
+
+  return `${start}〜${end}`
+}
+
+export default function SubmittedOfferContentCard({ submittedOffer }: SubmittedOfferContentCardProps) {
+  const fields = useMemo<SubmittedOfferField[]>(() => {
+    return [
+      {
+        key: 'preferredDate',
+        label: '希望日',
+        value: formatPreferredDate(submittedOffer.preferredDate),
+      },
+      {
+        key: 'preferredTimeRange',
+        label: '希望時間帯',
+        value: formatPreferredTimeRange(submittedOffer.preferredTimeRange),
+      },
+      {
+        key: 'reward',
+        label: '提示金額',
+        value: formatCurrency(submittedOffer.reward),
+      },
+      {
+        key: 'transportationFee',
+        label: '交通費',
+        value: formatCurrency(submittedOffer.transportationFee),
+      },
+      {
+        key: 'message',
+        label: 'メッセージ',
+        value: normalizeText(submittedOffer.message),
+        multiline: true,
+      },
+    ]
+  }, [
+    submittedOffer.preferredDate,
+    submittedOffer.preferredTimeRange,
+    submittedOffer.reward,
+    submittedOffer.transportationFee,
+    submittedOffer.message,
+  ])
+
+  return (
+    <Card className="rounded-xl border border-slate-200 bg-white shadow-sm">
+      <CardHeader className="space-y-1 px-4 pt-4 sm:px-5 sm:pt-5">
+        <CardTitle className="text-base font-semibold text-slate-900 sm:text-lg">オファー内容</CardTitle>
+      </CardHeader>
+      <CardContent className="px-4 pb-4 pt-1 sm:px-5 sm:pb-5">
+        <dl className="space-y-3 text-sm">
+          {fields.map(field => (
+            <div key={field.key} className="grid gap-1 sm:grid-cols-[160px_1fr] sm:items-start sm:gap-3">
+              <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{field.label}</dt>
+              <dd className={field.multiline ? 'whitespace-pre-wrap text-sm font-medium text-slate-900' : 'text-sm font-semibold text-slate-900'}>
+                {field.value}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </CardContent>
+    </Card>
+  )
+}

--- a/talentify-next-frontend/app/talent/offers/[id]/TalentOfferProgressPanel.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/TalentOfferProgressPanel.tsx
@@ -6,6 +6,7 @@ import { ja } from 'date-fns/locale'
 import type { OfferProgressStep, OfferProgressStatus, OfferStepKey } from '@/utils/offerProgress'
 import ProgressCard from './ProgressCard'
 import StepDetailCard from './StepDetailCard'
+import SubmittedOfferContentCard from './SubmittedOfferContentCard'
 
 type TalentOfferProgressPanelProps = {
   steps: OfferProgressStep[]
@@ -14,6 +15,8 @@ type TalentOfferProgressPanelProps = {
     id: string
     status: string
     date: string | null
+    timeRange: string | null
+    reward: number | null
     updatedAt: string
     submittedAt: string | null
     paid: boolean
@@ -22,6 +25,7 @@ type TalentOfferProgressPanelProps = {
     invoiceStatusLabel: string
     paymentStatusLabel: string
     reviewCompleted: boolean
+    message: string | null
   }
   invoiceId: string | null
   paymentLink?: string
@@ -102,6 +106,15 @@ export default function TalentOfferProgressPanel({
   return (
     <div className="space-y-4">
       <ProgressCard steps={progressSteps} activeStep={activeStep} onStepChange={setActiveStep} />
+      <SubmittedOfferContentCard
+        submittedOffer={{
+          preferredDate: offer.date,
+          preferredTimeRange: offer.timeRange,
+          reward: offer.reward,
+          transportationFee: null,
+          message: offer.message,
+        }}
+      />
       <StepDetailCard
         activeStep={activeStep}
         activeStatus={activeStatus}

--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -184,6 +184,7 @@ export default function TalentOfferPage() {
               invoiceStatusLabel: offer.invoiceStatusLabel,
               paymentStatusLabel: offer.paymentStatusLabel,
               reviewCompleted: offer.reviewCompleted,
+              message: offer.message,
             }}
             invoiceId={invoiceId}
             paymentLink={paymentLink}

--- a/talentify-next-frontend/app/talent/offers/[id]/page.tsx
+++ b/talentify-next-frontend/app/talent/offers/[id]/page.tsx
@@ -32,7 +32,7 @@ export default function TalentOfferPage() {
       .from('offers')
       .select(
         `
-        id,status,date,updated_at,created_at,message,talent_id,user_id,paid,paid_at,
+        id,status,date,time_range,reward,updated_at,created_at,message,talent_id,user_id,paid,paid_at,
         reviews(id),
         talents(stage_name,avatar_url,user_id),
         store:stores!offers_store_id_fkey(id, store_name, user_id)
@@ -56,6 +56,8 @@ export default function TalentOfferPage() {
         id: data.id,
         status: data.status,
         date: data.date,
+        timeRange: data.time_range,
+        reward: data.reward,
         message: data.message,
         performerName: data.talents?.stage_name || '',
         performerAvatarUrl: data.talents?.avatar_url || null,
@@ -172,6 +174,8 @@ export default function TalentOfferPage() {
               id: offer.id,
               status: offer.status,
               date: offer.date,
+              timeRange: offer.timeRange,
+              reward: offer.reward,
               updatedAt: offer.updatedAt,
               submittedAt: offer.submittedAt,
               paid: offer.paid,


### PR DESCRIPTION
### Motivation
- 承認前にユーザーが送信時点のオファー内容（条件・金額・メッセージ等）を一目で確認できるようにするため、進捗状況カードの直下にオファー内容カードを表示する。 

### Description
- 受信オファー取得クエリに `time_range` と `reward` を追加し、ページから進捗パネルに渡すようにした (`app/talent/offers/[id]/page.tsx`)。 
- タレント向け進捗パネルに新規コンポーネント `SubmittedOfferContentCard` を導入し、`ProgressCard` の直下かつ承認/辞退操作より前に配置した (`app/talent/offers/[id]/TalentOfferProgressPanel.tsx`)。 
- 新規ファイル `app/talent/offers/[id]/SubmittedOfferContentCard.tsx` を追加し、白カードでラベル＋値形式の表示（希望日、希望時間帯、提示金額、交通費、メッセージ）を実装し、未入力は `未入力` を表示するようにした。 
- 交通費は現行データモデルに保持項目がないため `null` を渡し `未入力` を表示する扱いにしている。 

### Testing
- フロントエンド静的解析を実行するために `cd talentify-next-frontend && npm run lint` を実行し、今回追加箇所に関するエラーはなく実行は成功した（既存コード由来の `no-img-element` 警告のみ）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df25be28148332a8a3f132c6ea3b60)