### PR TITLE
Unify notification bell count/list logic, add bell API, and improve error handling/UI

### DIFF
--- a/talentify-next-frontend/__tests__/notifications-inbox-filters.test.ts
+++ b/talentify-next-frontend/__tests__/notifications-inbox-filters.test.ts
@@ -9,6 +9,9 @@ describe('notifications inbox shared filters', () => {
     expect(buildNotificationCountFilter({ unreadCountOnly: true })).toEqual({
       unreadCountOnly: true,
       unreadOnly: true,
+      actionableOnly: false,
+      includeExpired: false,
+      category: undefined,
     })
   })
 

--- a/talentify-next-frontend/__tests__/notifications.test.ts
+++ b/talentify-next-frontend/__tests__/notifications.test.ts
@@ -135,6 +135,52 @@ test('getUnreadNotificationCount returns unread count from API', async () => {
   expect(count).toBe(3)
 })
 
+test('getBellNotifications returns count and items from API', async () => {
+  const mockData: NotificationRow[] = [
+    {
+      id: '1',
+      user_id: 'user1',
+      type: 'offer_created',
+      title: 'offer',
+      body: 'body',
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+      is_read: false,
+      data: null,
+      read_at: null,
+      priority: 'medium',
+      action_url: null,
+      action_label: null,
+      entity_type: null,
+      entity_id: null,
+      actor_name: null,
+      expires_at: null,
+      group_key: null,
+    },
+  ]
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ count: 1, items: mockData }),
+  } as Response)
+
+  const { getBellNotifications } = await import('@/utils/notifications')
+  const payload = await getBellNotifications()
+
+  expect(global.fetch).toHaveBeenCalledWith('/api/notifications/bell')
+  expect(payload).toEqual({ count: 1, items: mockData })
+})
+
+test('getNotifications throws on HTTP error', async () => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: false,
+    status: 500,
+    text: async () => 'boom',
+  } as Response)
+
+  const { getNotifications, NotificationsFetchError } = await import('@/utils/notifications')
+  await expect(getNotifications()).rejects.toBeInstanceOf(NotificationsFetchError)
+})
+
 test('formatUnreadCount formats values', async () => {
   const { formatUnreadCount } = await import('@/utils/notifications')
   expect(formatUnreadCount(0)).toBeNull()

--- a/talentify-next-frontend/app/api/notifications/bell/route.ts
+++ b/talentify-next-frontend/app/api/notifications/bell/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server'
+import { getCurrentUser } from '@/lib/auth/getCurrentUser'
+import { countUnreadNotificationsByUser, findNotificationsByUser } from '@/lib/repositories/notifications'
+
+export const runtime = 'nodejs'
+
+const BELL_LIMIT = 8
+
+const bellFilter = {
+  unreadOnly: true,
+  actionableOnly: false,
+  includeExpired: false,
+  category: undefined,
+} as const
+
+export async function GET() {
+  try {
+    const { user } = await getCurrentUser()
+
+    if (!user) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+    }
+
+    const [count, items] = await Promise.all([
+      countUnreadNotificationsByUser({ userId: user.id, ...bellFilter }),
+      findNotificationsByUser({ userId: user.id, limit: BELL_LIMIT, ...bellFilter }),
+    ])
+
+    if (process.env.NOTIFICATIONS_DEBUG_LOG === 'true') {
+      console.info('[notifications][api][bell]', {
+        userId: user.id,
+        bellFilter,
+        count,
+        itemCount: items.length,
+      })
+    }
+
+    return NextResponse.json({ count, items })
+  } catch (error) {
+    console.error('failed to fetch bell notifications', error)
+    return NextResponse.json({ error: 'failed to fetch bell notifications' }, { status: 500 })
+  }
+}

--- a/talentify-next-frontend/app/api/notifications/route.ts
+++ b/talentify-next-frontend/app/api/notifications/route.ts
@@ -51,7 +51,12 @@ export async function GET(req: NextRequest) {
     })
 
     if (countFilter.unreadCountOnly) {
-      const count = await countUnreadNotificationsByUser({ userId: user.id })
+      const count = await countUnreadNotificationsByUser({
+        userId: user.id,
+        actionableOnly: countFilter.actionableOnly,
+        category: countFilter.category,
+        includeExpired: countFilter.includeExpired,
+      })
       if (process.env.NOTIFICATIONS_DEBUG_LOG === 'true') {
         console.info('[notifications][api][count]', { userId: user.id, countFilter, count })
       }

--- a/talentify-next-frontend/components/notifications/NotificationBell.tsx
+++ b/talentify-next-frontend/components/notifications/NotificationBell.tsx
@@ -7,11 +7,11 @@ import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent } from '@/compon
 import NotificationItem from './NotificationItem'
 import type { NotificationRow } from '@/utils/notifications'
 import {
-  getNotifications,
-  getUnreadNotificationCount,
+  getBellNotifications,
   markAllNotificationsRead,
   formatUnreadCount,
   NOTIFICATIONS_CHANGED_EVENT,
+  NotificationsFetchError,
 } from '@/utils/notifications'
 import { createClient } from '@/utils/supabase/client'
 import { Button } from '@/components/ui/button'
@@ -23,45 +23,52 @@ export default function NotificationBell() {
   const { role } = useUserRole()
   const [count, setCount] = useState(0)
   const [items, setItems] = useState<NotificationRow[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
 
-  const refreshCount = async () => {
-    const c = await getUnreadNotificationCount()
-    setCount(c)
-  }
-
-  const refreshItems = async () => {
-    const list = await getNotifications({ limit: 8 })
-    setItems(list)
+  const refreshBell = async (options?: { silent?: boolean }) => {
+    if (!options?.silent) {
+      setIsLoading(true)
+    }
+    setLoadError(null)
+    try {
+      const payload = await getBellNotifications()
+      setCount(payload.count)
+      setItems(payload.items)
+    } catch (error) {
+      if (!(error instanceof NotificationsFetchError)) {
+        console.error('failed to refresh bell notifications', error)
+      }
+      setLoadError('通知の取得に失敗しました')
+    } finally {
+      setIsLoading(false)
+    }
   }
 
   useEffect(() => {
-    refreshCount()
-    refreshItems()
+    refreshBell()
     const channel = supabase
       .channel('notifications-bell')
       .on(
         'postgres_changes',
         { event: '*', schema: 'public', table: 'notifications' },
         () => {
-          refreshCount()
-          refreshItems()
+          refreshBell({ silent: true })
         }
       )
       .subscribe()
     const onLocalNotificationsChanged = () => {
-      refreshCount()
-      refreshItems()
+      refreshBell({ silent: true })
     }
     window.addEventListener(NOTIFICATIONS_CHANGED_EVENT, onLocalNotificationsChanged)
     const onVisible = () => {
       if (document.visibilityState === 'visible') {
-        refreshCount()
-        refreshItems()
+        refreshBell({ silent: true })
       }
     }
     document.addEventListener('visibilitychange', onVisible)
 
-    const interval = setInterval(refreshCount, 60000)
+    const interval = setInterval(() => refreshBell({ silent: true }), 60000)
     return () => {
       supabase.removeChannel(channel)
       window.removeEventListener(NOTIFICATIONS_CHANGED_EVENT, onLocalNotificationsChanged)
@@ -71,20 +78,19 @@ export default function NotificationBell() {
   }, [])
 
   const handleOpenChange = (open: boolean) => {
-    if (open) refreshItems()
+    if (open) refreshBell({ silent: true })
   }
 
   const handleItemRead = (id: string) => {
     setItems((prev) => prev.map((n) => (n.id === id ? { ...n, is_read: true } : n)))
-    refreshCount()
-    refreshItems()
+    refreshBell({ silent: true })
   }
 
   const handleReadAll = async () => {
     const unreadIds = items.filter((n) => !n.is_read).map((n) => n.id)
     if (unreadIds.length === 0) return
     await markAllNotificationsRead(unreadIds)
-    await Promise.all([refreshCount(), refreshItems()])
+    await refreshBell({ silent: true })
   }
 
   const notificationsPath = role ? `/${role}/notifications` : '/notifications'
@@ -117,12 +123,23 @@ export default function NotificationBell() {
           </Button>
         </div>
         <div className="max-h-96 overflow-y-auto p-2 space-y-2">
-          {items.length === 0 && (
+          {isLoading && <p className="text-sm text-muted-foreground px-2 py-4">読み込み中...</p>}
+          {!isLoading && loadError && (
+            <div className="px-2 py-4 space-y-2">
+              <p className="text-sm text-destructive">{loadError}</p>
+              <Button variant="outline" size="sm" onClick={() => refreshBell()}>
+                再読み込み
+              </Button>
+            </div>
+          )}
+          {!isLoading && !loadError && items.length === 0 && (
             <p className="text-sm text-muted-foreground px-2 py-4">通知はありません</p>
           )}
-          {items.map((n) => (
+          {!isLoading &&
+            !loadError &&
+            items.map((n) => (
             <NotificationItem key={n.id} notification={n} onRead={handleItemRead} />
-          ))}
+            ))}
         </div>
         <div className="border-t">
           <Link

--- a/talentify-next-frontend/lib/notifications/inbox-filters.ts
+++ b/talentify-next-frontend/lib/notifications/inbox-filters.ts
@@ -29,5 +29,8 @@ export function buildNotificationCountFilter(input: { unreadCountOnly?: boolean 
   return {
     unreadCountOnly: input.unreadCountOnly === true,
     unreadOnly: true as const,
+    actionableOnly: false as const,
+    includeExpired: false as const,
+    category: undefined as NotificationCategoryFilter | undefined,
   }
 }

--- a/talentify-next-frontend/lib/repositories/notifications.ts
+++ b/talentify-next-frontend/lib/repositories/notifications.ts
@@ -10,6 +10,9 @@ type NotificationInsert = Database['public']['Tables']['notifications']['Insert'
 type CountUnreadNotificationsParams = {
   userId: string
   type?: NotificationType
+  actionableOnly?: boolean
+  category?: 'announcement' | 'notification'
+  includeExpired?: boolean
 }
 
 type FindNotificationsByUserParams = {
@@ -18,6 +21,7 @@ type FindNotificationsByUserParams = {
   unreadOnly?: boolean
   actionableOnly?: boolean
   category?: 'announcement' | 'notification'
+  includeExpired?: boolean
 }
 
 type MarkNotificationReadParams = {
@@ -42,57 +46,19 @@ const ACTION_REQUIRED_TYPES: NotificationType[] = [
   'invoice_submitted',
 ]
 
-
-export async function findNotificationOwner({
-  id,
-  userId,
-}: {
-  id: string
-  userId: string
-}): Promise<boolean> {
-  const prisma = getPrismaClient()
-  const row = await prisma.notifications.findFirst({
-    where: {
-      id,
-      user_id: userId,
-    },
-    select: { id: true },
-  })
-
-  return Boolean(row)
+type NotificationQueryFilter = {
+  unreadOnly?: boolean
+  actionableOnly?: boolean
+  category?: 'announcement' | 'notification'
+  includeExpired?: boolean
 }
 
-export async function countUnreadNotificationsByUser({
-  userId,
-  type,
-}: CountUnreadNotificationsParams): Promise<number> {
-  const prisma = getPrismaClient()
-
-  const count = await prisma.notifications.count({
-    where: {
-      user_id: userId,
-      is_read: false,
-      ...(type ? { type } : {}),
-    },
-  })
-
-  return count
-}
-
-export async function findNotificationsByUser({
-  userId,
-  limit,
+function buildNotificationQueryClauses({
   unreadOnly,
   actionableOnly,
   category,
-}: FindNotificationsByUserParams): Promise<NotificationRow[]> {
-  const prisma = getPrismaClient()
-
-  const limitClause =
-    typeof limit === 'number' && Number.isFinite(limit) && limit > 0
-      ? Prisma.sql`LIMIT ${Math.floor(limit)}`
-      : Prisma.empty
-
+  includeExpired,
+}: NotificationQueryFilter) {
   const unreadClause = unreadOnly ? Prisma.sql`AND is_read = false` : Prisma.empty
 
   const actionableClause = actionableOnly
@@ -121,6 +87,100 @@ export async function findNotificationsByUser({
           )`
         : Prisma.empty
 
+  const expiresClause =
+    includeExpired === false ? Prisma.sql`AND (expires_at IS NULL OR expires_at > NOW())` : Prisma.empty
+
+  return { unreadClause, actionableClause, categoryClause, expiresClause }
+}
+
+
+export async function findNotificationOwner({
+  id,
+  userId,
+}: {
+  id: string
+  userId: string
+}): Promise<boolean> {
+  const prisma = getPrismaClient()
+  const row = await prisma.notifications.findFirst({
+    where: {
+      id,
+      user_id: userId,
+    },
+    select: { id: true },
+  })
+
+  return Boolean(row)
+}
+
+export async function countUnreadNotificationsByUser({
+  userId,
+  type,
+  actionableOnly,
+  category,
+  includeExpired,
+}: CountUnreadNotificationsParams): Promise<number> {
+  const prisma = getPrismaClient()
+  const { unreadClause, actionableClause, categoryClause, expiresClause } = buildNotificationQueryClauses({
+    unreadOnly: true,
+    actionableOnly,
+    category,
+    includeExpired,
+  })
+  const typeClause = type ? Prisma.sql`AND type = ${type}::public.notification_type` : Prisma.empty
+
+  const rows = await prisma.$queryRaw<Array<{ count: bigint | number }>>`
+    SELECT COUNT(*)::bigint AS count
+    FROM public.notifications
+    WHERE user_id = ${userId}
+    ${unreadClause}
+    ${actionableClause}
+    ${categoryClause}
+    ${expiresClause}
+    ${typeClause}
+  `
+  const rawCount = rows[0]?.count
+  const count = typeof rawCount === 'bigint' ? Number(rawCount) : Number(rawCount ?? 0)
+
+  if (process.env.NOTIFICATIONS_DEBUG_LOG === 'true') {
+    console.info('[notifications][repository][countUnread]', {
+      userId,
+      filter: {
+        type: type ?? null,
+        unreadOnly: true,
+        actionableOnly: Boolean(actionableOnly),
+        category: category ?? null,
+        includeExpired: includeExpired !== false,
+      },
+      count,
+    })
+  }
+
+  return count
+}
+
+export async function findNotificationsByUser({
+  userId,
+  limit,
+  unreadOnly,
+  actionableOnly,
+  category,
+  includeExpired,
+}: FindNotificationsByUserParams): Promise<NotificationRow[]> {
+  const prisma = getPrismaClient()
+
+  const limitClause =
+    typeof limit === 'number' && Number.isFinite(limit) && limit > 0
+      ? Prisma.sql`LIMIT ${Math.floor(limit)}`
+      : Prisma.empty
+
+  const { unreadClause, actionableClause, categoryClause, expiresClause } = buildNotificationQueryClauses({
+    unreadOnly,
+    actionableOnly,
+    category,
+    includeExpired,
+  })
+
   const rows = await prisma.$queryRaw<NotificationQueryRow[]>`
     SELECT
       id,
@@ -146,6 +206,7 @@ export async function findNotificationsByUser({
     ${unreadClause}
     ${actionableClause}
     ${categoryClause}
+    ${expiresClause}
     ORDER BY updated_at DESC, created_at DESC
     ${limitClause}
   `
@@ -153,7 +214,12 @@ export async function findNotificationsByUser({
   if (process.env.NOTIFICATIONS_DEBUG_LOG === 'true') {
     console.info('[notifications][repository][find]', {
       userId,
-      filter: { unreadOnly: Boolean(unreadOnly), actionableOnly: Boolean(actionableOnly), category: category ?? null },
+      filter: {
+        unreadOnly: Boolean(unreadOnly),
+        actionableOnly: Boolean(actionableOnly),
+        category: category ?? null,
+        includeExpired: includeExpired !== false,
+      },
       resultCount: rows.length,
     })
   }

--- a/talentify-next-frontend/utils/notifications.ts
+++ b/talentify-next-frontend/utils/notifications.ts
@@ -28,11 +28,23 @@ type GetUnreadCountResponse = {
   count?: number
 }
 
+type GetBellNotificationsResponse = {
+  count?: number
+  items?: NotificationRow[]
+}
+
+export class NotificationsFetchError extends Error {}
+
 export type GetNotificationsOptions = {
   limit?: number
   unreadOnly?: boolean
   actionableOnly?: boolean
   category?: 'announcement' | 'notification'
+}
+
+export type NotificationBellPayload = {
+  count: number
+  items: NotificationRow[]
 }
 
 export const NOTIFICATIONS_CHANGED_EVENT = 'talentify:notifications-changed'
@@ -73,40 +85,36 @@ async function patchNotificationReadState(id: string, isRead: boolean): Promise<
 }
 
 export async function getNotifications(options?: number | GetNotificationsOptions): Promise<NotificationRow[]> {
-  try {
-    const searchParams = new URLSearchParams()
-    const normalized = typeof options === 'number' ? { limit: options } : options
+  const searchParams = new URLSearchParams()
+  const normalized = typeof options === 'number' ? { limit: options } : options
 
-    if (typeof normalized?.limit === 'number' && Number.isFinite(normalized.limit) && normalized.limit > 0) {
-      searchParams.set('limit', String(Math.floor(normalized.limit)))
-    }
-
-    if (normalized?.unreadOnly) searchParams.set('unread_only', 'true')
-    if (normalized?.actionableOnly) searchParams.set('actionable_only', 'true')
-    if (normalized?.category) searchParams.set('category', normalized.category)
-
-    const suffix = searchParams.toString()
-    if (process.env.NEXT_PUBLIC_NOTIFICATIONS_DEBUG_LOG === 'true') {
-      console.info('[notifications][client][query]', {
-        options: normalized ?? null,
-        queryString: suffix,
-      })
-    }
-    const res = await fetch(`${API_BASE}/api/notifications${suffix ? `?${suffix}` : ''}`)
-
-    if (!res.ok) {
-      if (res.status !== 401) {
-        console.error('failed to fetch notifications', await res.text())
-      }
-      return []
-    }
-
-    const payload = (await res.json()) as GetNotificationsResponse
-    return Array.isArray(payload.data) ? payload.data : []
-  } catch (error) {
-    console.error('failed to fetch notifications', error)
-    return []
+  if (typeof normalized?.limit === 'number' && Number.isFinite(normalized.limit) && normalized.limit > 0) {
+    searchParams.set('limit', String(Math.floor(normalized.limit)))
   }
+
+  if (normalized?.unreadOnly) searchParams.set('unread_only', 'true')
+  if (normalized?.actionableOnly) searchParams.set('actionable_only', 'true')
+  if (normalized?.category) searchParams.set('category', normalized.category)
+
+  const suffix = searchParams.toString()
+  if (process.env.NEXT_PUBLIC_NOTIFICATIONS_DEBUG_LOG === 'true') {
+    console.info('[notifications][client][query]', {
+      options: normalized ?? null,
+      queryString: suffix,
+    })
+  }
+  const res = await fetch(`${API_BASE}/api/notifications${suffix ? `?${suffix}` : ''}`)
+
+  if (!res.ok) {
+    if (res.status !== 401) {
+      const body = await res.text()
+      console.error('failed to fetch notifications', body)
+    }
+    throw new NotificationsFetchError('failed to fetch notifications')
+  }
+
+  const payload = (await res.json()) as GetNotificationsResponse
+  return Array.isArray(payload.data) ? payload.data : []
 }
 
 export async function getUnreadNotificationCount(): Promise<number> {
@@ -124,6 +132,23 @@ export async function getUnreadNotificationCount(): Promise<number> {
   } catch (error) {
     console.error('failed to fetch unread notifications count', error)
     return 0
+  }
+}
+
+export async function getBellNotifications(): Promise<NotificationBellPayload> {
+  const res = await fetch(`${API_BASE}/api/notifications/bell`)
+  if (!res.ok) {
+    if (res.status !== 401) {
+      const body = await res.text()
+      console.error('failed to fetch bell notifications', body)
+    }
+    throw new NotificationsFetchError('failed to fetch bell notifications')
+  }
+
+  const payload = (await res.json()) as GetBellNotificationsResponse
+  return {
+    count: typeof payload.count === 'number' ? payload.count : 0,
+    items: Array.isArray(payload.items) ? payload.items : [],
   }
 }
 


### PR DESCRIPTION
### Motivation

- The header bell showed an unread badge while the dropdown could be empty because count and list were fetched by separate code paths with different filters and the list API masked failures as `[]`.
- We need deterministic bell behavior where the badge count matches the dropdown contents and failures are visible to users for recovery.

### Description

- Added a dedicated bell endpoint `GET /api/notifications/bell` that returns `count` and `items` together for the bell (latest N unread items) and logs debug info when `NOTIFICATIONS_DEBUG_LOG=true`.
- Unified repository filtering via `buildNotificationQueryClauses` and applied the same clauses to `countUnreadNotificationsByUser` and `findNotificationsByUser` (including `is_read`, `actionable`, `category`, and `expires_at` handling) and added repository-level debug logging.
- Updated `GET /api/notifications` to forward the unified count filter to the count path and changed `lib/notifications/inbox-filters.ts` to define sensible bell defaults (`unreadOnly=true`, `actionableOnly=false`, `includeExpired=false`).
- Client changes: `getNotifications()` now throws `NotificationsFetchError` on HTTP failure, added `getBellNotifications()` to call the new bell API, and updated `NotificationBell` to use `getBellNotifications()` and expose `isLoading`/`loadError` UI states with a retry button and explicit messages for loading, fetch failure, and empty list.

### Testing

- Ran `cd talentify-next-frontend && npm test -- --runTestsByPath __tests__/notifications.test.ts __tests__/notifications-inbox-filters.test.ts` and the test suites passed. 
- Test result summary: 2 test suites, 14 tests — all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df256d435083328430d4a6605c764e)