### PR TITLE
Add granular diagnostics to bell notifications API

### DIFF
--- a/talentify-next-frontend/app/api/notifications/bell/route.ts
+++ b/talentify-next-frontend/app/api/notifications/bell/route.ts
@@ -14,30 +14,71 @@ const bellFilter = {
 } as const
 
 export async function GET() {
+  let user: { id?: string } | null = null
+
   try {
-    const { user } = await getCurrentUser()
-
-    if (!user) {
-      return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
-    }
-
-    const [count, items] = await Promise.all([
-      countUnreadNotificationsByUser({ userId: user.id, ...bellFilter }),
-      findNotificationsByUser({ userId: user.id, limit: BELL_LIMIT, ...bellFilter }),
-    ])
-
-    if (process.env.NOTIFICATIONS_DEBUG_LOG === 'true') {
-      console.info('[notifications][api][bell]', {
-        userId: user.id,
-        bellFilter,
-        count,
-        itemCount: items.length,
-      })
-    }
-
-    return NextResponse.json({ count, items })
+    const currentUserResult = await getCurrentUser()
+    console.info('[notifications][api][bell] getCurrentUser result', currentUserResult)
+    user = currentUserResult.user
   } catch (error) {
-    console.error('failed to fetch bell notifications', error)
+    console.error('[notifications][api][bell] failed to get current user', { error })
+    console.error('failed to fetch bell notifications', {
+      error,
+      userId: user?.id,
+    })
     return NextResponse.json({ error: 'failed to fetch bell notifications' }, { status: 500 })
   }
+
+  if (!user) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  if (!user.id) {
+    console.error('[notifications][api][bell] user.id is undefined', { user })
+    return NextResponse.json({ error: 'failed to fetch bell notifications' }, { status: 500 })
+  }
+
+  let count = 0
+  try {
+    count = await countUnreadNotificationsByUser({ userId: user.id, ...bellFilter })
+  } catch (error) {
+    console.error('[notifications][api][bell] failed to fetch unread count', {
+      error,
+      userId: user.id,
+      bellFilter,
+    })
+    console.error('failed to fetch bell notifications', {
+      error,
+      userId: user?.id,
+    })
+    return NextResponse.json({ error: 'failed to fetch bell notifications' }, { status: 500 })
+  }
+
+  let items: Awaited<ReturnType<typeof findNotificationsByUser>> = []
+  try {
+    items = await findNotificationsByUser({ userId: user.id, limit: BELL_LIMIT, ...bellFilter })
+  } catch (error) {
+    console.error('[notifications][api][bell] failed to fetch notifications list', {
+      error,
+      userId: user.id,
+      bellFilter,
+      limit: BELL_LIMIT,
+    })
+    console.error('failed to fetch bell notifications', {
+      error,
+      userId: user?.id,
+    })
+    return NextResponse.json({ error: 'failed to fetch bell notifications' }, { status: 500 })
+  }
+
+  if (process.env.NOTIFICATIONS_DEBUG_LOG === 'true') {
+    console.info('[notifications][api][bell]', {
+      userId: user.id,
+      bellFilter,
+      count,
+      itemCount: items.length,
+    })
+  }
+
+  return NextResponse.json({ count, items })
 }


### PR DESCRIPTION
### Motivation

- Improve observability and make it easy to identify which step is failing when the bell API returns `failed to fetch bell notifications`.
- Capture `getCurrentUser()` output and include `userId` and the original `error` in logs for faster debugging without exposing details to the frontend.

### Description

- Split the single `try-catch` in `app/api/notifications/bell/route.ts` into per-step `try-catch` blocks for `getCurrentUser()`, `countUnreadNotificationsByUser()`, and `findNotificationsByUser()` to isolate failures.
- Log the full `getCurrentUser()` result via `console.info('[notifications][api][bell] getCurrentUser result', currentUserResult)`.
- Change error logs to include structured context using `console.error('failed to fetch bell notifications', { error, userId: user?.id })` and add specific error messages for each failed step.
- Add an explicit guard and log for missing `user.id` while keeping the frontend-facing error payload unchanged.

### Testing

- Ran `npm test -- --runInBand __tests__/notifications-e2e.test.ts`, and the test suite passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df286098148332a5638c967cbf93c8)