### PR TITLE
Harden bell API logging and add unread-count fallback

### DIFF
--- a/talentify-next-frontend/app/api/notifications/bell/route.ts
+++ b/talentify-next-frontend/app/api/notifications/bell/route.ts
@@ -9,9 +9,44 @@ const BELL_LIMIT = 8
 const bellFilter = {
   unreadOnly: true,
   actionableOnly: false,
-  includeExpired: false,
   category: undefined,
 } as const
+
+type BellFailureStage = 'getCurrentUser' | 'fetchUnreadCount' | 'fetchNotificationsList'
+
+function toErrorDetails(error: unknown) {
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      stack: error.stack,
+      name: error.name,
+    }
+  }
+
+  return {
+    message: String(error),
+    stack: undefined,
+    name: undefined,
+  }
+}
+
+function logBellFailure({
+  stage,
+  error,
+  userId,
+}: {
+  stage: BellFailureStage
+  error: unknown
+  userId?: string
+}) {
+  console.error('[notifications][api][bell] failed', {
+    stage,
+    userId,
+    bellFilter,
+    limit: BELL_LIMIT,
+    error: toErrorDetails(error),
+  })
+}
 
 export async function GET() {
   let user: { id?: string } | null = null
@@ -21,8 +56,8 @@ export async function GET() {
     console.info('[notifications][api][bell] getCurrentUser result', currentUserResult)
     user = currentUserResult.user
   } catch (error) {
-    console.error('[notifications][api][bell] failed to get current user', { error })
-    console.error('failed to fetch bell notifications', {
+    logBellFailure({
+      stage: 'getCurrentUser',
       error,
       userId: user?.id,
     })
@@ -42,14 +77,10 @@ export async function GET() {
   try {
     count = await countUnreadNotificationsByUser({ userId: user.id, ...bellFilter })
   } catch (error) {
-    console.error('[notifications][api][bell] failed to fetch unread count', {
+    logBellFailure({
+      stage: 'fetchUnreadCount',
       error,
       userId: user.id,
-      bellFilter,
-    })
-    console.error('failed to fetch bell notifications', {
-      error,
-      userId: user?.id,
     })
     return NextResponse.json({ error: 'failed to fetch bell notifications' }, { status: 500 })
   }
@@ -58,15 +89,10 @@ export async function GET() {
   try {
     items = await findNotificationsByUser({ userId: user.id, limit: BELL_LIMIT, ...bellFilter })
   } catch (error) {
-    console.error('[notifications][api][bell] failed to fetch notifications list', {
+    logBellFailure({
+      stage: 'fetchNotificationsList',
       error,
       userId: user.id,
-      bellFilter,
-      limit: BELL_LIMIT,
-    })
-    console.error('failed to fetch bell notifications', {
-      error,
-      userId: user?.id,
     })
     return NextResponse.json({ error: 'failed to fetch bell notifications' }, { status: 500 })
   }

--- a/talentify-next-frontend/components/notifications/NotificationBell.tsx
+++ b/talentify-next-frontend/components/notifications/NotificationBell.tsx
@@ -8,6 +8,7 @@ import NotificationItem from './NotificationItem'
 import type { NotificationRow } from '@/utils/notifications'
 import {
   getBellNotifications,
+  getUnreadNotificationCount,
   markAllNotificationsRead,
   formatUnreadCount,
   NOTIFICATIONS_CHANGED_EVENT,
@@ -39,6 +40,8 @@ export default function NotificationBell() {
       if (!(error instanceof NotificationsFetchError)) {
         console.error('failed to refresh bell notifications', error)
       }
+      const fallbackCount = await getUnreadNotificationCount()
+      setCount(fallbackCount)
       setLoadError('通知の取得に失敗しました')
     } finally {
       setIsLoading(false)


### PR DESCRIPTION
### Motivation

- The bell API was returning a generic `failed to fetch bell notifications` and taking down both `count` and `items`, causing the unread badge to disappear; we need better diagnostics and a safe fallback for the count.
- Avoid passing unsupported or extra properties from the route to repository by aligning the route filter payload to a minimal, supported shape.

### Description

- Removed `includeExpired` from the route `bellFilter` to avoid sending unsupported/extra properties to the repository.
- Added structured failure logging in `app/api/notifications/bell/route.ts` via `BellFailureStage`, `toErrorDetails()` and `logBellFailure()` so failures emit `stage`, `userId`, `bellFilter`, `limit` and detailed `error` (`message`, `stack`, `name`).
- Replaced the previous `console.error` calls in the three bell-route catch blocks with calls to `logBellFailure()` for `getCurrentUser`, `fetchUnreadCount`, and `fetchNotificationsList` stages.
- Added a client-side unread-count fallback in `components/notifications/NotificationBell.tsx` that calls `getUnreadNotificationCount()` and sets the badge `count` when `/api/notifications/bell` fails while keeping `items` in the error state.

### Testing

- Ran the notifications unit tests with `npm test -- --runInBand __tests__/notifications.test.ts`, and the suite passed: 1 test suite, 11 tests passed.
- No integration/vercel logs were collected from this environment (network restrictions prevented `vercel` CLI access), so production runtime log verification remains to be done separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df2be890ac83328de96b2416fd07f2)