### PR TITLE
Improve debug logging for notifications APIs

### DIFF
--- a/talentify-next-frontend/app/api/notifications/bell/route.ts
+++ b/talentify-next-frontend/app/api/notifications/bell/route.ts
@@ -14,22 +14,6 @@ const bellFilter = {
 
 type BellFailureStage = 'getCurrentUser' | 'fetchUnreadCount' | 'fetchNotificationsList'
 
-function toErrorDetails(error: unknown) {
-  if (error instanceof Error) {
-    return {
-      message: error.message,
-      stack: error.stack,
-      name: error.name,
-    }
-  }
-
-  return {
-    message: String(error),
-    stack: undefined,
-    name: undefined,
-  }
-}
-
 function logBellFailure({
   stage,
   error,
@@ -44,7 +28,9 @@ function logBellFailure({
     userId,
     bellFilter,
     limit: BELL_LIMIT,
-    error: toErrorDetails(error),
+    error,
+    message: error instanceof Error ? error.message : null,
+    stack: error instanceof Error ? error.stack : null,
   })
 }
 
@@ -53,7 +39,9 @@ export async function GET() {
 
   try {
     const currentUserResult = await getCurrentUser()
-    console.info('[notifications][api][bell] getCurrentUser result', currentUserResult)
+    console.info('[auth][debug]', {
+      user: currentUserResult.user,
+    })
     user = currentUserResult.user
   } catch (error) {
     logBellFailure({
@@ -75,6 +63,9 @@ export async function GET() {
 
   let count = 0
   try {
+    console.info('[notifications][count][before]', {
+      userId: user.id,
+    })
     count = await countUnreadNotificationsByUser({ userId: user.id, ...bellFilter })
   } catch (error) {
     logBellFailure({
@@ -87,6 +78,10 @@ export async function GET() {
 
   let items: Awaited<ReturnType<typeof findNotificationsByUser>> = []
   try {
+    console.info('[notifications][list][before]', {
+      userId: user.id,
+      limit: BELL_LIMIT,
+    })
     items = await findNotificationsByUser({ userId: user.id, limit: BELL_LIMIT, ...bellFilter })
   } catch (error) {
     logBellFailure({

--- a/talentify-next-frontend/app/api/notifications/route.ts
+++ b/talentify-next-frontend/app/api/notifications/route.ts
@@ -39,7 +39,11 @@ function isPriority(value: unknown): value is 'low' | 'medium' | 'high' {
 
 export async function GET(req: NextRequest) {
   try {
-    const { user } = await getCurrentUser()
+    const currentUserResult = await getCurrentUser()
+    console.info('[auth][debug]', {
+      user: currentUserResult.user,
+    })
+    const { user } = currentUserResult
 
     if (!user) {
       return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
@@ -51,6 +55,9 @@ export async function GET(req: NextRequest) {
     })
 
     if (countFilter.unreadCountOnly) {
+      console.info('[notifications][count][before]', {
+        userId: user.id,
+      })
       const count = await countUnreadNotificationsByUser({
         userId: user.id,
         actionableOnly: countFilter.actionableOnly,
@@ -85,6 +92,11 @@ export async function GET(req: NextRequest) {
       })
     }
 
+    console.info('[notifications][list][before]', {
+      userId: user.id,
+      limit: limit ?? null,
+    })
+
     const data = await findNotificationsByUser({
       userId: user.id,
       limit,
@@ -97,14 +109,22 @@ export async function GET(req: NextRequest) {
 
     return NextResponse.json({ data })
   } catch (error) {
-    console.error('failed to fetch notifications', error)
+    console.error('failed to fetch notifications', {
+      error,
+      message: error instanceof Error ? error.message : null,
+      stack: error instanceof Error ? error.stack : null,
+    })
     return NextResponse.json({ error: 'failed to fetch notifications' }, { status: 500 })
   }
 }
 
 export async function POST(req: NextRequest) {
   try {
-    const { user } = await getCurrentUser()
+    const currentUserResult = await getCurrentUser()
+    console.info('[auth][debug]', {
+      user: currentUserResult.user,
+    })
+    const { user } = currentUserResult
 
     if (!user) {
       return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
@@ -166,11 +186,21 @@ export async function POST(req: NextRequest) {
       return response
     } catch (error) {
       const message = error instanceof Error ? error.message : 'failed to insert notification'
-      console.error('failed to insert notification', { user_id: user.id, type, error })
+      console.error('failed to insert notification', {
+        user_id: user.id,
+        type,
+        error,
+        message: error instanceof Error ? error.message : null,
+        stack: error instanceof Error ? error.stack : null,
+      })
       return NextResponse.json({ error: message }, { status: 400 })
     }
   } catch (error) {
-    console.error('failed to insert notification', error)
+    console.error('failed to insert notification', {
+      error,
+      message: error instanceof Error ? error.message : null,
+      stack: error instanceof Error ? error.stack : null,
+    })
     return NextResponse.json({ error: 'invalid request' }, { status: 400 })
   }
 }


### PR DESCRIPTION
### Motivation

- Pinpoint where `/api/notifications` and `/api/notifications/bell` are failing by adding deterministic logs around auth and DB calls.  
- Ensure `error.message` and `error.stack` are always captured in catch blocks for root-cause analysis.  

### Description

- Add `[auth][debug]` logging immediately after `getCurrentUser()` in both `app/api/notifications/route.ts` and `app/api/notifications/bell/route.ts` to record the resolved `user`.  
- Add pre-query logs `[notifications][count][before]` and `[notifications][list][before]` to record `userId` and `limit` before calling `countUnreadNotificationsByUser` and `findNotificationsByUser`.  
- Strengthen all `catch` logs to always include the `error` object plus `message` and `stack` when available, and update the bell route failure logger to emit these fields.  
- Files modified: `talentify-next-frontend/app/api/notifications/route.ts` and `talentify-next-frontend/app/api/notifications/bell/route.ts`.

### Testing

- Ran lint on the modified files with `pnpm -s exec eslint app/api/notifications/route.ts app/api/notifications/bell/route.ts` and it succeeded.  
- Ran type-check with `pnpm -s exec tsc --noEmit`, which failed due to pre-existing repository-wide type errors unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df3c09e0b88332a4346ee795e0059c)