### PR TITLE
Redesign Talentify common top LP with premium, photo-led layout

### DIFF
--- a/talentify-next-frontend/app/page.tsx
+++ b/talentify-next-frontend/app/page.tsx
@@ -1,155 +1,297 @@
 export const dynamic = 'auto'
 
-import Link from 'next/link';
-import Image from 'next/image';
-import { Button } from '@/components/ui/button';
+import Image from 'next/image'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+
+const branchCards = [
+  {
+    eyebrow: 'For Stores',
+    title: '店舗向けLPへ',
+    description:
+      '出稿計画から当日の運用まで。選定・依頼・履歴管理を、ひとつの流れに。',
+    href: '/register?role=store',
+    cta: '店舗の方はこちら',
+  },
+  {
+    eyebrow: 'For Talents',
+    title: '演者向けLPへ',
+    description:
+      '活動の価値を、正しく伝える。案件機会と実績を積み上げるための舞台へ。',
+    href: '/register?role=talent',
+    cta: '演者の方はこちら',
+  },
+]
+
+const faqItems = [
+  {
+    question: '利用料金はかかりますか？',
+    answer:
+      '基本機能は無料で開始できます。詳細なプランや運用設計は、各LPでご案内しています。',
+  },
+  {
+    question: 'どう始めればよいですか？',
+    answer:
+      'まずは店舗または演者として登録し、プロフィールを整えるだけで準備が始まります。',
+  },
+  {
+    question: 'どんな方が利用できますか？',
+    answer:
+      '店舗の担当者さま、出演活動を行う演者さまの双方にご利用いただけます。',
+  },
+  {
+    question: '店舗・演者の両方で登録できますか？',
+    answer:
+      '可能です。用途に応じてアカウントを分けることで、最適な導線を選択できます。',
+  },
+]
 
 export default function HomePage() {
   return (
-    <div className="flex flex-col items-center text-gray-900 bg-white">
-      {/* Hero Section */}
-      <section
-        className="w-full min-h-screen flex flex-col justify-center items-center bg-cover bg-center text-white text-center px-6"
-        style={{ backgroundImage: "url('/images/hero-bg.png')" }}
-      >
-        <div className="max-w-4xl mt-32 sm:mt-48 md:mt-[300px]">
-          <p className="text-2xl md:text-3xl font-semibold text-white mb-10 drop-shadow-md">
-            パチンコ店と演者をマッチングする、全く新しいサービス。
+    <main className="bg-white text-zinc-900">
+      {/* 想定画像（public/images/lp 配下に追加して差し替え）
+        - hero-main.jpg
+        - concept-scene.jpg
+        - story-scene.jpg
+        - atmosphere-1.jpg
+        - atmosphere-2.jpg
+        - ui-dashboard.jpg
+      */}
+
+      <section className="relative isolate min-h-[92vh] overflow-hidden">
+        <Image
+          src="/images/hero-bg.png"
+          alt="店舗と演者が活躍する現場のイメージ"
+          fill
+          priority
+          className="object-cover"
+        />
+        <div className="absolute inset-0 bg-black/45" />
+        <div className="absolute inset-x-0 top-8 z-10 mx-auto flex w-full max-w-6xl items-center justify-between px-6 text-xs tracking-[0.2em] text-white/80 sm:text-sm">
+          <p>TALENTIFY</p>
+          <p>COMMON TOP LP</p>
+        </div>
+
+        <div className="relative z-10 mx-auto flex min-h-[92vh] w-full max-w-6xl items-end px-6 pb-14 pt-28 sm:pb-20">
+          <div className="max-w-3xl text-white">
+            <p className="mb-4 text-xs uppercase tracking-[0.28em] text-white/75 sm:text-sm">Editorial Platform for Real Performances</p>
+            <h1 className="text-4xl font-semibold leading-tight sm:text-6xl sm:leading-[1.1]">
+              才能が、
+              <br />
+              価値として届く。
+            </h1>
+            <p className="mt-5 max-w-2xl text-sm leading-relaxed text-white/85 sm:text-lg">
+              Talentifyは、店舗と演者を結び、依頼から実績までをなめらかにつなぐマッチング基盤です。
+            </p>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+              <Link href="/register?role=store">
+                <Button className="h-12 rounded-full border border-white/30 bg-white px-8 text-sm text-zinc-900 hover:bg-white/90">
+                  店舗の方はこちら
+                </Button>
+              </Link>
+              <Link href="/register?role=talent">
+                <Button
+                  variant="outline"
+                  className="h-12 rounded-full border-white/60 bg-transparent px-8 text-sm text-white hover:bg-white/10"
+                >
+                  演者の方はこちら
+                </Button>
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto w-full max-w-6xl px-6 py-16 sm:py-24">
+        <p className="max-w-4xl text-2xl font-medium leading-relaxed text-zinc-900 sm:text-4xl sm:leading-tight">
+          予定を埋めるためではなく、
+          <br className="hidden sm:block" />
+          ブランドを育てるための出会いを。
+        </p>
+      </section>
+
+      <section className="bg-[#f6f4ef] py-20 sm:py-28">
+        <div className="mx-auto grid w-full max-w-6xl gap-10 px-6 lg:grid-cols-[1.15fr_1fr] lg:items-center">
+          <Image
+            src="/images/point1.png"
+            alt="現場でのコミュニケーション"
+            width={1400}
+            height={1000}
+            className="h-[340px] w-full object-cover sm:h-[460px]"
+          />
+          <div>
+            <p className="text-xs uppercase tracking-[0.24em] text-zinc-500">Concept</p>
+            <h2 className="mt-4 text-3xl font-semibold leading-tight sm:text-5xl">非効率を、品位ある標準へ。</h2>
+            <p className="mt-6 text-sm leading-loose text-zinc-700 sm:text-base">
+              断片的な連絡、属人的な判断、積み上がらない実績。
+              <br />
+              Talentifyは、業界に残る“見えない摩擦”を減らし、店舗と演者の関係を次の時代の基盤へ整えます。
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto w-full max-w-6xl space-y-20 px-6 py-20 sm:space-y-28 sm:py-28">
+        <div className="grid gap-8 lg:grid-cols-2 lg:gap-14">
+          <div className="border-t border-zinc-300 pt-5">
+            <p className="text-xs uppercase tracking-[0.24em] text-zinc-500">For Stores</p>
+            <h3 className="mt-3 text-2xl font-semibold sm:text-4xl">選びたい人材に、迷わず届く。</h3>
+            <p className="mt-4 text-sm leading-loose text-zinc-700 sm:text-base">
+              依頼の条件整理、進行の可視化、履歴の蓄積。
+              <br />
+              担当者の経験値に頼らない、再現性ある運用を実現します。
+            </p>
+          </div>
+          <Image
+            src="/images/point2.png"
+            alt="店舗側の価値を示すシーン"
+            width={1400}
+            height={1000}
+            className="h-[280px] w-full object-cover sm:h-[380px]"
+          />
+        </div>
+
+        <div className="grid gap-8 lg:grid-cols-2 lg:gap-14">
+          <Image
+            src="/images/point3.png"
+            alt="演者側の価値を示すシーン"
+            width={1400}
+            height={1000}
+            className="order-2 h-[280px] w-full object-cover sm:h-[380px] lg:order-1"
+          />
+          <div className="order-1 border-t border-zinc-300 pt-5 lg:order-2">
+            <p className="text-xs uppercase tracking-[0.24em] text-zinc-500">For Talents</p>
+            <h3 className="mt-3 text-2xl font-semibold sm:text-4xl">活動の価値が、正しく積み上がる。</h3>
+            <p className="mt-4 text-sm leading-loose text-zinc-700 sm:text-base">
+              条件の不透明さを減らし、交渉や調整の時間を最小化。
+              <br />
+              目の前の出演だけでなく、長期的な信頼と実績形成に集中できます。
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="relative overflow-hidden bg-zinc-950 py-24 text-white sm:py-32">
+        <Image
+          src="/images/hero-bg.png"
+          alt="夜の現場風景"
+          fill
+          className="object-cover opacity-30"
+        />
+        <div className="relative mx-auto grid w-full max-w-6xl gap-8 px-6 lg:grid-cols-[1fr_0.9fr] lg:items-end">
+          <h2 className="text-3xl font-semibold leading-tight sm:text-5xl">曖昧なやり取りを、信頼の設計に変える。</h2>
+          <p className="text-sm leading-loose text-zinc-200 sm:text-base">
+            誰が、いつ、何を、どこまで合意したのか。
+            <br />
+            Talentifyは、日々のコミュニケーションを構造化し、案件ごとの品質を高め続けられる環境をつくります。
           </p>
-          <div className="flex flex-col md:flex-row gap-4 justify-center">
+        </div>
+      </section>
+
+      <section className="mx-auto w-full max-w-6xl px-6 py-20 sm:py-28">
+        <div className="mb-10 max-w-3xl border-t border-zinc-300 pt-5 sm:mb-14">
+          <p className="text-xs uppercase tracking-[0.24em] text-zinc-500">Feature Highlights</p>
+          <h2 className="mt-3 text-3xl font-semibold sm:text-5xl">必要な機能だけを、美しく。</h2>
+        </div>
+        <div className="grid gap-8 lg:grid-cols-[1fr_1.2fr] lg:items-start">
+          <div className="space-y-7">
+            {['Matching', 'Offer / Request', 'Condition Check', 'Schedule', 'Track Record'].map((item) => (
+              <div key={item} className="border-b border-zinc-200 pb-5">
+                <p className="text-xs uppercase tracking-[0.2em] text-zinc-500">{item}</p>
+                <p className="mt-2 text-sm text-zinc-700">
+                  情報を散らさず、判断を速くするための基本動線を一体化。
+                </p>
+              </div>
+            ))}
+          </div>
+          <div className="overflow-hidden border border-zinc-200 bg-[#f8f8f7] p-4 sm:p-7">
+            <p className="mb-4 text-xs uppercase tracking-[0.2em] text-zinc-500">Product View</p>
+            <Image
+              src="/images/point2.png"
+              alt="TalentifyのUIイメージ"
+              width={1600}
+              height={1100}
+              className="h-[260px] w-full border border-zinc-200 object-cover sm:h-[430px]"
+            />
+            <p className="mt-4 text-xs leading-relaxed text-zinc-600">
+              ※ ここは将来的に `public/images/lp/ui-dashboard.jpg` などの実際のUIスクリーンショットへ差し替えを想定しています。
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-[#f7f7f6] py-20 sm:py-28">
+        <div className="mx-auto w-full max-w-6xl px-6">
+          <p className="text-xs uppercase tracking-[0.24em] text-zinc-500">Trust / Network</p>
+          <h2 className="mt-4 max-w-3xl text-3xl font-semibold leading-tight sm:text-5xl">
+            参加者が増えるほど、
+            <br className="hidden sm:block" />
+            プラットフォームは賢くなる。
+          </h2>
+          <p className="mt-6 max-w-3xl text-sm leading-loose text-zinc-700 sm:text-base">
+            店舗と演者の接点が重なるほど、適切なマッチングと透明な取引が育つ。
+            <br />
+            Talentifyは、単発のツールではなく、信頼のネットワークとして機能します。
+          </p>
+        </div>
+      </section>
+
+      <section className="mx-auto w-full max-w-6xl px-6 py-20 sm:py-28" id="branch">
+        <div className="mb-10 sm:mb-12">
+          <p className="text-xs uppercase tracking-[0.24em] text-zinc-500">Choose Your Path</p>
+          <h2 className="mt-3 text-3xl font-semibold sm:text-5xl">次の一歩を、ここで選ぶ。</h2>
+        </div>
+        <div className="grid gap-6 md:grid-cols-2">
+          {branchCards.map((card) => (
+            <article key={card.title} className="group border border-zinc-200 bg-white p-7 transition hover:border-zinc-400 sm:p-9">
+              <p className="text-xs uppercase tracking-[0.2em] text-zinc-500">{card.eyebrow}</p>
+              <h3 className="mt-3 text-2xl font-semibold">{card.title}</h3>
+              <p className="mt-4 min-h-16 text-sm leading-loose text-zinc-700">{card.description}</p>
+              <Link href={card.href} className="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-zinc-900">
+                {card.cta}
+                <span className="transition group-hover:translate-x-1">→</span>
+              </Link>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="bg-[#faf9f7] py-20 sm:py-24">
+        <div className="mx-auto w-full max-w-5xl px-6">
+          <p className="text-xs uppercase tracking-[0.24em] text-zinc-500">FAQ</p>
+          <h2 className="mt-3 text-3xl font-semibold sm:text-4xl">よくある質問</h2>
+          <div className="mt-10 space-y-4">
+            {faqItems.map((item) => (
+              <details key={item.question} className="border border-zinc-200 bg-white px-5 py-4 open:bg-zinc-50 sm:px-7">
+                <summary className="cursor-pointer list-none text-base font-medium">{item.question}</summary>
+                <p className="mt-3 text-sm leading-loose text-zinc-700">{item.answer}</p>
+              </details>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto w-full max-w-6xl px-6 py-16 sm:py-24">
+        <div className="border border-zinc-200 bg-white p-8 text-center sm:p-14">
+          <p className="text-xs uppercase tracking-[0.24em] text-zinc-500">Final CTA</p>
+          <h2 className="mt-3 text-3xl font-semibold sm:text-5xl">Talentifyに参加する。</h2>
+          <p className="mx-auto mt-5 max-w-2xl text-sm leading-loose text-zinc-700 sm:text-base">
+            店舗としての成長も、演者としての挑戦も。
+            <br />
+            次のステージへ進む準備は、ここから始まります。
+          </p>
+          <div className="mt-8 flex flex-col justify-center gap-3 sm:flex-row">
             <Link href="/register?role=store">
-              <Button className="px-8 py-3 text-base rounded-full bg-white text-gray-900 hover:bg-gray-100 shadow-md">
-                店舗として登録
-              </Button>
+              <Button className="h-12 rounded-full bg-zinc-900 px-8 text-sm text-white hover:bg-zinc-800">店舗としてはじめる</Button>
             </Link>
             <Link href="/register?role=talent">
-              <Button className="px-8 py-3 text-base rounded-full bg-white text-gray-900 hover:bg-gray-100 shadow-md">
-                演者として登録
+              <Button variant="outline" className="h-12 rounded-full border-zinc-400 px-8 text-sm text-zinc-900 hover:bg-zinc-100">
+                演者としてはじめる
               </Button>
             </Link>
           </div>
         </div>
       </section>
-
-{/* 特徴セクション（POINT 1・2） */}
-<section className="w-full bg-white py-20 px-6">
-  <div className="max-w-6xl mx-auto space-y-16 md:space-y-24">
-
-    {/* POINT 1 */}
-    <div className="flex flex-col md:flex-row items-center gap-10">
-      <Image src="/images/point1.png" alt="POINT 1" width={1536} height={1024} className="w-full md:w-1/2 rounded-xl shadow-md" priority/>
-      <div className="md:w-1/2">
-        <div className="text-green-600 font-bold text-xl mb-2">POINT 1</div>
-        <h3 className="text-2xl md:text-3xl font-bold leading-snug mb-4">
-          出演者掲載数No.1の<br className="hidden md:block" />マッチングサービス
-        </h3>
-        <p className="text-gray-700 text-lg leading-relaxed">
-          Talentifyは全国のホールと演者をつなぐ、完全無料のマッチングプラットフォーム。案件掲載、プロフィール作成、スケジュール管理まで、すべてオンラインで完結します。
-        </p>
-      </div>
-    </div>
-
-    {/* POINT 2 */}
-    <div className="flex flex-col md:flex-row-reverse items-center gap-10">
-      <Image src="/images/point2.png" alt="POINT 2" width={1536} height={1024} className="w-full md:w-1/2 rounded-xl shadow-md" priority/>
-      <div className="md:w-1/2">
-        <div className="text-green-600 font-bold text-xl mb-2">POINT 2</div>
-        <h3 className="text-2xl md:text-3xl font-bold leading-snug mb-4">
-          オファー送信から契約まで<br className="hidden md:block" />すべてオンラインで完結
-        </h3>
-        <p className="text-gray-700 text-lg leading-relaxed">
-          演者へのオファー送信やスケジュール確認、契約確定まで一元管理。やり取りもメッセージ機能で完結するから、電話やFAXは一切不要です。
-        </p>
-      </div>
-    </div>
-
-    {/* POINT 3 */}
-    <div className="flex flex-col md:flex-row items-center gap-10">
-      <Image src="/images/point3.png" alt="POINT 3" width={1536} height={1024} className="w-full md:w-1/2 rounded-xl shadow-md" priority/>
-      <div className="md:w-1/2">
-        <div className="text-green-600 font-bold text-xl mb-2">POINT 3</div>
-        <h3 className="text-2xl md:text-3xl font-bold leading-snug mb-4">
-          すべて0円でカンタンに使える！
-        </h3>
-        <p className="text-gray-700 text-lg leading-relaxed">
-          初期費用・月額費用・成功報酬、すべて無料。掲載も契約も人数制限なく使えるから、コストゼロで最大のリーチが可能です。
-        </p>
-      </div>
-    </div>
-
-  </div>
-</section>
-
-
-
-      {/* ナビ代わりセクション */}
-      <section className="w-full bg-gray-100 py-4 text-sm text-center text-gray-500 tracking-wide">
-        ブランド｜演者｜利用方法｜FAQ｜お問い合わせ
-      </section>
-
-      {/* 店舗向けセクション */}
-      <SectionBox title="パチンコ店様へ" bg="white">
-        <li>最適な演者と出会える</li>
-        <li>イベント告知の規制に配慮したサポート</li>
-        <li>契約・決済をスムーズに</li>
-        <CTA link="/register?role=store" label="店舗として利用開始する" />
-      </SectionBox>
-
-      {/* 演者向けセクション */}
-      <SectionBox title="演者の皆様へ" bg="gray-50">
-        <li>安定した仕事機会の獲得</li>
-        <li>自身のブランド力向上</li>
-        <li>適切なギャラ交渉をサポート</li>
-        <CTA link="/register?role=talent" label="演者として利用開始する" />
-      </SectionBox>
-
-      {/* FAQセクション */}
-      <SimpleSection title="よくある質問" link="/faq" bg="white" />
-
-      {/* お問い合わせセクション */}
-      <SimpleSection title="お問い合わせ" link="/contact" bg="gray-50" />
-
-    </div>
-  );
-}
-
-// セクションBox
-function SectionBox({ title, children, bg }: { title: string; children: React.ReactNode; bg?: string }) {
-  return (
-    <section className={`py-16 w-full px-4 sm:px-6 ${bg ? `bg-${bg}` : ''}`}>
-  <div className="max-w-4xl mx-auto border border-gray-200 rounded-2xl p-6 sm:p-8 shadow-sm bg-white">
-    <h2 className="text-2xl sm:text-3xl font-bold text-center mb-6 border-l-4 border-gray-800 pl-4">{title}</h2>
-    <ul className="space-y-2 text-gray-700 list-disc list-inside leading-relaxed text-base sm:text-lg">{children}</ul>
-  </div>
-</section>
-  );
-}
-
-// CTAリンクボタン
-function CTA({ link, label }: { link: string; label: string }) {
-  return (
-    <div className="text-center mt-6">
-      <Link href={link}>
-        <Button variant="link" className="text-base text-gray-800 font-semibold hover:underline">
-          {label}
-        </Button>
-      </Link>
-    </div>
-  );
-}
-
-// シンプルセクション（FAQ・Contact）
-function SimpleSection({ title, link, bg }: { title: string; link: string; bg?: string }) {
-  return (
-    <section className={`py-16 w-full px-6 ${bg ? `bg-${bg}` : ''}`}>
-      <div className="max-w-4xl mx-auto text-center">
-        <h2 className="text-2xl font-semibold mb-4">{title}</h2>
-        <Link href={link}>
-          <Button variant="link" className="text-base text-gray-800 font-semibold hover:underline">
-            {title}ページへ
-          </Button>
-        </Link>
-      </div>
-    </section>
-  );
+    </main>
+  )
 }


### PR DESCRIPTION
### Motivation
- Deliver a 0‑base redesign of the common top LP to present Talentify as a premium, trustable brand rather than a feature-listing SaaS page. 
- Create a photo-first, spacious rhythm that communicates sophistication and supports clear branching to both `店舗` (stores) and `演者` (talents) flows. 
- Ensure the page is easy to swap images into later and is implemented in the existing Next.js/Tailwind stack for responsive delivery.

### Description
- Rewrote `app/page.tsx` to implement a brand-first landing page with sections: Hero (large image + dual CTA), Intro/Concept, Value for Stores & Talents, Story/Why, Feature Highlights (minimal), Trust/Network, Branch (store/talent two-column), FAQ, and Final CTA. 
- Added small data arrays (`branchCards`, `faqItems`) and inline comments indicating expected `public/images/lp/*` assets for straightforward image replacement. 
- Built using Next.js `Image`, `Link`, the existing `Button` component, and Tailwind utility classes to enforce responsive spacing, typography contrast, photo-led sections, and subtle hover states. 
- Kept feature copy concise and brand-focused; included a UI screenshot placeholder area intended for future `public/images/lp/ui-dashboard.jpg` replacement.

### Testing
- Ran `cd talentify-next-frontend && npm run lint`; the lint run completed successfully with no new errors introduced by the modified file. 
- Lint output contained existing warnings in unrelated files but nothing failing related to the updated `app/page.tsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e04999fe5483328fcdb7daf9f498fe)