### PR TITLE
Update landing and feature images to new LP/UI asset paths

### DIFF
--- a/talentify-next-frontend/app/page.tsx
+++ b/talentify-next-frontend/app/page.tsx
@@ -39,9 +39,9 @@ const featureItems = [
 ]
 
 const lpImages = {
-  heroMain: '/images/hero-bg.png',
-  concept: '/images/hero-bg.png',
-  matchingOverview: '/images/point1.png',
+  heroMain: '/images/lp/common/common-hero-main.jpg',
+  concept: '/images/lp/common/common-concept.jpg',
+  matchingOverview: '/images/ui/ui-matching-overview.png',
 }
 
 export default function HomePage() {

--- a/talentify-next-frontend/app/store/page.tsx
+++ b/talentify-next-frontend/app/store/page.tsx
@@ -40,28 +40,28 @@ const featureCards = [
     label: 'マッチング',
     title: '最適な演者が見つかる',
     description: '条件に合う候補を一覧で比較。感覚ではなく情報で選べます。',
-    image: '/images/point1.png',
+    image: '/images/ui/ui-talent-list.png',
     alt: '演者候補を比較するダミー画面',
   },
   {
     label: 'オファー',
     title: '条件を整理して依頼できる',
     description: '日程・予算・要件を整理して送信。確認の往復を減らせます。',
-    image: '/images/point2.png',
+    image: '/images/ui/ui-offer-create.png',
     alt: '依頼条件をまとめるダミー画面',
   },
   {
     label: '管理',
     title: 'やり取りを一元化',
     description: '誰が何を合意したかを見える化。引き継ぎもスムーズです。',
-    image: '/images/point3.png',
+    image: '/images/ui/ui-message.png',
     alt: '案件管理のダミー画面',
   },
 ]
 
 const lpImages = {
-  heroMain: '/images/hero-bg.png',
-  operation: '/images/hero-bg.png',
+  heroMain: '/images/lp/store/store-hero-main.jpg',
+  operation: '/images/lp/store/store-operation.jpg',
 }
 
 export default function StoreLandingPage() {

--- a/talentify-next-frontend/app/talent/page.tsx
+++ b/talentify-next-frontend/app/talent/page.tsx
@@ -26,21 +26,21 @@ const featureCards = [
     label: 'プロフィール',
     title: '自分の強みを、きちんと伝える。',
     description: '活動領域・得意ジャンル・過去実績を整理して、初見でも伝わる状態をつくります。',
-    image: '/images/point1.png',
+    image: '/images/ui/ui-profile.png',
     alt: 'プロフィールを整理するUIイメージ',
   },
   {
     label: 'オファー確認',
     title: '条件を整理して、迷わず進める。',
     description: '日程・報酬・条件をまとめて確認。認識違いを減らし、判断を早くできます。',
-    image: '/images/point2.png',
+    image: '/images/ui/ui-offer-received.png',
     alt: 'オファー条件を確認するUIイメージ',
   },
   {
     label: '実績管理',
     title: '活動の履歴を、次の案件につなげる。',
     description: '毎回の活動を記録として残し、積み上がる信頼を次の機会に変えていけます。',
-    image: '/images/point3.png',
+    image: '/images/ui/ui-history.png',
     alt: '実績履歴を蓄積するUIイメージ',
   },
 ]
@@ -53,8 +53,8 @@ const steps = [
 ]
 
 const lpImages = {
-  heroMain: '/images/hero-bg.png',
-  activity: '/images/hero-bg.png',
+  heroMain: '/images/lp/talent/talent-hero-main.jpg',
+  activity: '/images/lp/talent/talent-activity.jpg',
 }
 
 export default function TalentLandingPage() {


### PR DESCRIPTION
### Motivation

- Replace placeholder generic images with finalized LP and UI-specific assets to match the updated visual design across the site.

### Description

- Updated homepage (`app/page.tsx`) hero and concept images to use `/images/lp/common/...` and replaced the matching overview image with `/images/ui/ui-matching-overview.png`.
- Updated store landing (`app/store/page.tsx`) hero and operation images to `/images/lp/store/...` and swapped feature card images to `/images/ui/ui-talent-list.png`, `/images/ui/ui-offer-create.png`, and `/images/ui/ui-message.png`.
- Updated talent landing (`app/talent/page.tsx`) hero and activity images to `/images/lp/talent/...` and swapped feature card images to `/images/ui/ui-profile.png`, `/images/ui/ui-offer-received.png`, and `/images/ui/ui-history.png`.

### Testing

- Ran `next build` locally to ensure pages compile and all image imports resolve, and the build completed successfully.
- Ran `npm run lint` to validate code style, and it passed without errors.
- Ran the test suite with `npm test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c180895483328e466b3a82f9fbf8)