### PR TITLE
LP画像参照を .jpg から .png に修正

### DIFF
--- a/talentify-next-frontend/app/page.tsx
+++ b/talentify-next-frontend/app/page.tsx
@@ -39,8 +39,8 @@ const featureItems = [
 ]
 
 const lpImages = {
-  heroMain: '/images/lp/common/common-hero-main.jpg',
-  concept: '/images/lp/common/common-concept.jpg',
+  heroMain: '/images/lp/common/common-hero-main.png',
+  concept: '/images/lp/common/common-concept.png',
   matchingOverview: '/images/ui/ui-matching-overview.png',
 }
 

--- a/talentify-next-frontend/app/store/page.tsx
+++ b/talentify-next-frontend/app/store/page.tsx
@@ -60,8 +60,8 @@ const featureCards = [
 ]
 
 const lpImages = {
-  heroMain: '/images/lp/store/store-hero-main.jpg',
-  operation: '/images/lp/store/store-operation.jpg',
+  heroMain: '/images/lp/store/store-hero-main.png',
+  operation: '/images/lp/store/store-operation.png',
 }
 
 export default function StoreLandingPage() {

--- a/talentify-next-frontend/app/talent/page.tsx
+++ b/talentify-next-frontend/app/talent/page.tsx
@@ -53,8 +53,8 @@ const steps = [
 ]
 
 const lpImages = {
-  heroMain: '/images/lp/talent/talent-hero-main.jpg',
-  activity: '/images/lp/talent/talent-activity.jpg',
+  heroMain: '/images/lp/talent/talent-hero-main.png',
+  activity: '/images/lp/talent/talent-activity.png',
 }
 
 export default function TalentLandingPage() {


### PR DESCRIPTION
### Motivation
- コードが `.jpg` を参照している一方で、実ファイルは `.png` のため本番で画像が表示されない問題を解消するため。 

### Description
- `app/page.tsx`, `app/store/page.tsx`, `app/talent/page.tsx` の LP 画像参照を `.jpg` → `.png` に変更しました。 
- 変更対象の参照は `common-hero-main`, `common-concept`, `store-hero-main`, `store-operation`, `talent-hero-main`, `talent-activity` の6件です。 
- 参照先の拡張子を実ファイルに合わせることで Next.js 側で正しい静的アセットが読み込まれるようにしました。 

### Testing
- 実行したコマンドで参照が更新されていることを確認しました: `rg -n "common-hero-main|common-concept|store-hero-main|store-operation|talent-hero-main|talent-activity" app/page.tsx app/store/page.tsx app/talent/page.tsx`（成功）。
- `npm run -s lint` を実行してコマンドは正常終了し、既存の `<img>` に関する ESLint 警告のみ確認しました（失敗はなし）。
- 実ファイルの存在チェックでは `public/images/lp/common/common-hero-main.png`, `public/images/lp/store/store-hero-main.png`, `public/images/lp/talent/talent-hero-main.png` は存在しましたが、`common-concept.png`, `store-operation.png`, `talent-activity.png` はこのチェック時点のワーキングツリーに存在しないことを確認しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1d6ab1aa88332954f8b92e4ed20b8)