### PR TITLE
Improve talent search cards for comparison-friendly list UI

### DIFF
--- a/talentify-next-frontend/components/talent-search/TalentCard.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentCard.tsx
@@ -1,53 +1,104 @@
 import Image from 'next/image'
 import Link from 'next/link'
-import { Badge } from '@/components/ui/badge'
 import type { PublicTalent } from '@/types/talent'
-import { ZoomIn } from 'lucide-react'
 
-export default function TalentCard({ talent }: { talent: PublicTalent }) {
-  const isValidHttpUrl = (url: string) => {
-    try {
-      const parsed = new URL(url)
-      return parsed.protocol === 'http:' || parsed.protocol === 'https:'
-    } catch {
-      return false
-    }
+function isValidHttpUrl(url: string) {
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+function getTalentName(talent: PublicTalent) {
+  return talent.stage_name || talent.display_name || '名前未設定'
+}
+
+function getTalentAffiliation(talent: PublicTalent) {
+  return talent.affiliation || talent.agency || talent.company_name || null
+}
+
+function getTalentCapabilities(talent: PublicTalent) {
+  if (Array.isArray(talent.capabilities) && talent.capabilities.length > 0) {
+    return talent.capabilities
   }
 
+  if (Array.isArray(talent.skills) && talent.skills.length > 0) {
+    return talent.skills
+  }
+
+  return []
+}
+
+function formatRateEstimate(rate: number | null) {
+  if (rate == null) {
+    return '料金目安：要相談'
+  }
+
+  const manYen = rate / 10000
+  const rounded = Number.isInteger(manYen)
+    ? manYen.toString()
+    : manYen.toFixed(1).replace(/\.0$/, '')
+
+  return `料金目安：${rounded}万円〜`
+}
+
+export default function TalentCard({ talent }: { talent: PublicTalent }) {
   const imageSrc = talent.avatar_url && isValidHttpUrl(talent.avatar_url)
     ? talent.avatar_url
     : '/avatar-default.svg'
-  const subInfo =
-    talent.rate != null
-      ? `料金: ${talent.rate}`
-      : talent.genre || talent.area || ''
+
+  const name = getTalentName(talent)
+  const affiliation = getTalentAffiliation(talent)
+  const capabilities = getTalentCapabilities(talent)
+  const subInfo = [talent.genre, affiliation, talent.area].filter(Boolean)
 
   return (
     <Link
       href={`/talents/${talent.id}`}
-      className="block group focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 rounded-2xl"
+      className="block rounded-2xl border border-gray-200 bg-white shadow-sm transition overflow-hidden hover:shadow-md hover:-translate-y-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
     >
-      <div className="overflow-hidden rounded-2xl border bg-white transition hover:translate-y-[-2px] hover:shadow-lg">
-        <div className="relative aspect-[4/5] bg-gray-100">
-          <Image
-            src={imageSrc}
-            alt={talent.stage_name ?? 'Avatar'}
-            fill
-            className="object-cover"
-            loading="lazy"
-            sizes="(min-width: 1024px) 20vw, (min-width: 768px) 30vw, 45vw"
-          />
-          <div className="absolute inset-0 bg-black/0 group-hover:bg-black/10 flex items-end justify-end p-2 transition">
-            <ZoomIn className="h-5 w-5 text-white opacity-0 group-hover:opacity-100" />
+      <div className="relative aspect-[4/3] bg-gray-100">
+        <Image
+          src={imageSrc}
+          alt={name}
+          fill
+          className="object-cover"
+          loading="lazy"
+          sizes="(min-width: 1280px) 24vw, (min-width: 1024px) 32vw, (min-width: 640px) 48vw, 100vw"
+        />
+      </div>
+
+      <div className="p-4">
+        <p className="text-lg font-bold line-clamp-1">{name}</p>
+
+        {subInfo.length > 0 && (
+          <p className="mt-1 text-sm text-gray-500 line-clamp-1">{subInfo.join(' / ')}</p>
+        )}
+
+        {capabilities.length > 0 && (
+          <div className="mt-3 flex flex-wrap gap-2">
+            {capabilities.slice(0, 4).map(capability => (
+              <span
+                key={capability}
+                className="rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-600"
+              >
+                #{capability}
+              </span>
+            ))}
           </div>
-        </div>
-        <div className="p-3 space-y-1">
-          <p className="text-base font-semibold line-clamp-2">{talent.stage_name}</p>
-          {subInfo && (
-            <p className="text-sm text-muted-foreground line-clamp-1">{subInfo}</p>
-          )}
-          {talent.genre && <Badge className="mt-1">{talent.genre}</Badge>}
-        </div>
+        )}
+
+        {talent.bio && (
+          <p className="mt-3 text-sm text-gray-600 line-clamp-2">{talent.bio}</p>
+        )}
+
+        <p className="mt-4 text-sm font-medium text-gray-600">{formatRateEstimate(talent.rate)}</p>
+
+        <span className="mt-4 flex h-10 w-full items-center justify-center rounded-lg bg-blue-600 text-sm font-medium text-white transition hover:bg-blue-700">
+          詳細を見る
+        </span>
       </div>
     </Link>
   )

--- a/talentify-next-frontend/components/talent-search/TalentCardSkeleton.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentCardSkeleton.tsx
@@ -2,11 +2,15 @@ import { Skeleton } from '@/components/ui/skeleton'
 
 export default function TalentCardSkeleton() {
   return (
-    <div className="rounded-2xl border bg-white p-3 shadow-md space-y-3">
-      <Skeleton className="w-full aspect-[4/5] rounded-2xl" />
-      <Skeleton className="h-4 w-3/4" />
-      <Skeleton className="h-3 w-1/2" />
+    <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+      <Skeleton className="w-full aspect-[4/3]" />
+      <div className="space-y-3 p-4">
+        <Skeleton className="h-5 w-1/2" />
+        <Skeleton className="h-4 w-2/3" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-5/6" />
+        <Skeleton className="h-10 w-full rounded-lg" />
+      </div>
     </div>
   )
 }
-

--- a/talentify-next-frontend/components/talent-search/TalentList.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentList.tsx
@@ -17,8 +17,13 @@ export default function TalentList({ talents }: { talents: PublicTalent[] }) {
 
   return (
     <>
-      <p className="mb-4 text-sm text-gray-700">検索結果：{talents.length}件</p>
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-5">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <p className="text-sm text-gray-700">検索結果：{talents.length}件</p>
+        <div className="h-9 min-w-28 rounded-md border border-dashed border-gray-300 bg-gray-50 px-3 text-xs text-gray-400 flex items-center justify-center">
+          並び替え（準備中）
+        </div>
+      </div>
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
         {talents.map(t => (
           <TalentCard key={t.id} talent={t} />
         ))}

--- a/talentify-next-frontend/components/talent-search/TalentSearchPage.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentSearchPage.tsx
@@ -68,7 +68,7 @@ export default function TalentSearchPage() {
     <main className="mx-auto px-6 md:px-8 lg:px-12 space-y-6">
       <TalentSearchForm onSearch={handleSearch} />
       {isLoading ? (
-        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-5">
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
           {Array.from({ length: ITEMS_PER_PAGE }).map((_, i) => (
             <TalentCardSkeleton key={i} />
           ))}

--- a/talentify-next-frontend/types/talent.ts
+++ b/talentify-next-frontend/types/talent.ts
@@ -8,4 +8,9 @@ export type PublicTalent = {
   rate: number | null
   bio: string | null
   display_name?: string | null
+  affiliation?: string | null
+  agency?: string | null
+  company_name?: string | null
+  capabilities?: string[] | null
+  skills?: string[] | null
 }


### PR DESCRIPTION
### Motivation
- Make the talent listing more comparison-friendly by surfacing key signals (who they are, what they do, where they operate, and a soft price cue) in each card so store managers can judge fit from the list view.
- Keep existing data model and link behavior intact while enabling future extensions for capability tags and sorting UI.

### Description
- Redesigned card layout in `components/talent-search/TalentCard.tsx` to use a larger top image (`aspect-[4/3]`), `rounded-2xl / border-gray-200 / shadow-sm / hover:shadow-md / hover:-translate-y-0.5 / overflow-hidden` styling, and a full-width CTA `詳細を見る` while preserving `href=/talents/${talent.id}` and avatar fallback `/avatar-default.svg`.
- Added helper functions `getTalentName`, `getTalentAffiliation`, `getTalentCapabilities`, `formatRateEstimate` and implemented name fallback (`stage_name` → `display_name`), one-line sub info (`genre / affiliation / area`), optional capability tags from `capabilities` or `skills` only, clamped bio preview, and softer rate display (`料金目安：xx万円〜` or `料金目安：要相談`).
- Updated the grid and surrounding UI in `components/talent-search/TalentList.tsx` and `components/talent-search/TalentSearchPage.tsx` to `grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4` with `gap-6` and added a placeholder area for future sort controls while keeping the results count.
- Adjusted loading UI in `components/talent-search/TalentCardSkeleton.tsx` and extended `types/talent.ts` to include optional fields (`affiliation`, `agency`, `company_name`, `capabilities`, `skills`) so new fields are used only when present and do not break typing.

### Testing
- Ran `npm run lint` in the frontend, which could not complete because the `next` binary is not available in the container (failed to run `next lint`).
- Checked types with `npx tsc --noEmit`, which failed due to many pre-existing repo-wide type/dependency issues unrelated to this change (reported numerous missing type/dependency errors).
- Attempted `npm test` and `npm run typecheck` but `jest` is not installed in the environment and `typecheck` script is not defined in `package.json`, so automated test commands did not run successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f00ae42ec08332bfd89c7b6a4a46b8)