### PR TITLE
Revamp homepage hero: copy, imagery, and CTA styles/ordering

### DIFF
--- a/talentify-next-frontend/app/page.tsx
+++ b/talentify-next-frontend/app/page.tsx
@@ -48,32 +48,29 @@ export default function HomePage() {
   return (
     <main className="bg-white pt-16 text-zinc-900">
       <section className="relative isolate min-h-[72vh] overflow-hidden">
-        <Image src={lpImages.heroMain} alt="店舗と演者が活躍する現場イメージ" fill priority className="object-cover" />
-        <div className="absolute inset-0 bg-black/55" />
+        <Image src={lpImages.heroMain} alt="複数人で盛り上がるイベント会場のイメージ" fill priority className="object-cover" />
+        <div className="absolute inset-0 bg-black/35" />
 
         <div className="relative mx-auto flex min-h-[72vh] w-full max-w-6xl items-end px-6 pb-12 pt-24 sm:pb-20 sm:pt-28">
-          <div className="max-w-3xl text-white">
-            <p className="text-xs uppercase tracking-[0.24em] text-white/70">Talentify Brand Top</p>
-            <h1 className="mt-4 text-3xl font-semibold leading-tight sm:text-6xl sm:leading-[1.1]">
-              店舗と演者をつなぐ。
-              <br />
-              次の一歩を、ここで選ぶ。
+          <div className="max-w-xl text-left text-white">
+            <p className="text-xs uppercase tracking-[0.24em] text-white/75">Talentify Brand Top</p>
+            <h1 className="mt-4 text-3xl font-semibold leading-[1.3] sm:text-6xl sm:leading-[1.18]">
+              集客が動く。現場が変わる。
             </h1>
-            <p className="mt-5 max-w-2xl text-sm leading-7 text-white/90 sm:text-lg sm:leading-8">
-              Talentifyは、来店演者マッチングのためのサービスです。まずはあなたの立場に合うページから進んでください。
+            <p className="mt-5 max-w-xl text-sm leading-8 text-white/90 sm:text-lg sm:leading-9">
+              来店演者マッチングサービスです。あなたの立場に合わせてご利用ください。
             </p>
-            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
-              <Link href="/store">
-                <Button className="h-12 w-full rounded-full bg-white px-8 text-sm font-semibold text-zinc-900 hover:bg-white/90 sm:w-auto">
-                  店舗向けページを見る
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
+              <Link href="/talent">
+                <Button className="h-12 w-full rounded-2xl bg-red-500 px-6 py-3 text-sm font-semibold text-white hover:bg-red-600 sm:w-auto">
+                  演者を探す
                 </Button>
               </Link>
-              <Link href="/talent">
+              <Link href="/store">
                 <Button
-                  variant="outline"
-                  className="h-12 w-full rounded-full border-white/70 bg-transparent px-8 text-sm font-semibold text-white hover:bg-white/10 sm:w-auto"
+                  className="h-12 w-full rounded-2xl border border-white/80 bg-white px-6 py-3 text-sm font-semibold text-zinc-950 hover:bg-zinc-100 sm:w-auto"
                 >
-                  演者向けページを見る
+                  店舗で依頼する
                 </Button>
               </Link>
             </div>


### PR DESCRIPTION
### Motivation
- Refresh the landing hero to improve messaging clarity and better reflect the service use cases. 
- Improve CTA prominence and conversion by changing labels, visual emphasis, and ordering. 
- Tweak layout and overlay contrast for improved readability across screen sizes. 

### Description
- Replaced the hero image alt text and reduced the overlay opacity from `bg-black/55` to `bg-black/35` to adjust contrast. 
- Updated the hero headline and supporting paragraph copy for a more direct, concise message and adjusted typography (`leading`/`max-w` changes). 
- Reordered and restyled primary CTAs: swapped the buttons and routes so the first button links to `/talent` with label `演者を探す` and a red filled style, and the second links to `/store` with label `店舗で依頼する` and a bordered white style. 
- Minor UI tweaks including changing button corner radii (`rounded-full` → `rounded-2xl`), text color opacities, and image alt text for the concept image. 

### Testing
- Ran `next build` to verify the app compiles successfully and the build completed without errors. 
- Ran `yarn lint` to validate formatting and lint rules and it passed. 
- Ran `yarn test` to execute unit tests and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f00e0b9a30833292fedffb41f1aabd)