### PR TITLE
LP全体のトーンを赤基調＆最終CTA黒背景に統一

### DIFF
--- a/talentify-next-frontend/app/page.tsx
+++ b/talentify-next-frontend/app/page.tsx
@@ -46,10 +46,10 @@ const lpImages = {
 
 export default function HomePage() {
   return (
-    <main className="bg-white pt-16 text-zinc-900">
+    <main className="bg-white pt-16 text-[#1a1a1a]">
       <section className="relative isolate min-h-[72vh] overflow-hidden">
-        <Image src={lpImages.heroMain} alt="複数人で盛り上がるイベント会場のイメージ" fill priority className="object-cover" />
-        <div className="absolute inset-0 bg-black/35" />
+        <Image src={lpImages.heroMain} alt="複数人で盛り上がるイベント会場のイメージ" fill priority className="object-cover brightness-110 contrast-110" />
+        <div className="absolute inset-0 bg-[#111]/35" />
 
         <div className="relative mx-auto flex min-h-[72vh] w-full max-w-6xl items-end px-6 pb-12 pt-24 sm:pb-20 sm:pt-28">
           <div className="max-w-xl text-left text-white">
@@ -68,7 +68,7 @@ export default function HomePage() {
               </Link>
               <Link href="/store">
                 <Button
-                  className="h-12 w-full rounded-2xl border border-white/80 bg-white px-6 py-3 text-sm font-semibold text-zinc-950 hover:bg-zinc-100 sm:w-auto"
+                  className="h-12 w-full rounded-2xl bg-red-500 px-6 py-3 text-sm font-semibold text-white hover:bg-red-600 sm:w-auto"
                 >
                   店舗で依頼する
                 </Button>
@@ -90,7 +90,7 @@ export default function HomePage() {
         </div>
       </section>
 
-      <section className="bg-[#f8f7f4] py-16 sm:py-20">
+      <section className="bg-gray-50 py-16 sm:py-20">
         <div className="mx-auto w-full max-w-6xl px-6">
           <p className="text-xs uppercase tracking-[0.24em] text-zinc-500">Feature Highlights</p>
           <h2 className="mt-3 text-3xl font-semibold sm:text-5xl">必要な価値だけ、短く伝える。</h2>
@@ -110,30 +110,30 @@ export default function HomePage() {
         </div>
       </section>
 
-      <section className="bg-zinc-950 py-20 text-white sm:py-24" id="branch">
+      <section className="bg-white py-20 sm:py-24" id="branch">
         <div className="mx-auto w-full max-w-6xl px-6">
-          <p className="text-xs uppercase tracking-[0.24em] text-white/60">Branch</p>
+          <p className="text-xs uppercase tracking-[0.24em] text-zinc-500">Branch</p>
           <h2 className="mt-3 text-3xl font-semibold sm:text-5xl">どちらに進むかを、ここで決める。</h2>
-          <p className="mt-4 max-w-3xl text-sm leading-7 text-white/80 sm:text-base sm:leading-8">
+          <p className="mt-4 max-w-3xl text-sm leading-7 text-zinc-700 sm:text-base sm:leading-8">
             詳しい説明は各ページにまとめています。あなたに合う入口から進んでください。
           </p>
 
           <div className="mt-10 grid gap-6 md:grid-cols-2">
             {branchCards.map((card) => (
-              <article key={card.title} className="border border-white/15 bg-white/[0.06] p-7 backdrop-blur-sm sm:p-9">
-                <p className="text-xs uppercase tracking-[0.2em] text-white/60">{card.eyebrow}</p>
+              <article key={card.title} className="rounded-2xl border border-zinc-200 bg-gray-50 p-7 sm:p-9">
+                <p className="text-xs uppercase tracking-[0.2em] text-zinc-500">{card.eyebrow}</p>
                 <h3 className="mt-3 text-2xl font-semibold">{card.title}</h3>
-                <p className="mt-4 text-sm leading-7 text-white/85">{card.description}</p>
-                <ul className="mt-5 space-y-2 text-sm text-white/90">
+                <p className="mt-4 text-sm leading-7 text-zinc-700">{card.description}</p>
+                <ul className="mt-5 space-y-2 text-sm text-zinc-700">
                   {card.benefits.map((benefit) => (
                     <li key={benefit} className="flex items-start gap-2">
-                      <span aria-hidden className="mt-1 text-[10px] text-white/60">●</span>
+                      <span aria-hidden className="mt-1 text-[10px] text-red-500">●</span>
                       <span>{benefit}</span>
                     </li>
                   ))}
                 </ul>
                 <Link href={card.href} className="mt-6 inline-block">
-                  <Button className="h-11 rounded-full bg-white px-6 text-sm font-semibold text-zinc-950 hover:bg-white/90">
+                  <Button className="h-11 rounded-full bg-red-500 px-6 text-sm font-semibold text-white hover:bg-red-600">
                     {card.cta}
                   </Button>
                 </Link>
@@ -143,21 +143,21 @@ export default function HomePage() {
         </div>
       </section>
 
-      <section className="mx-auto w-full max-w-6xl px-6 py-20 sm:py-24">
-        <div className="border border-zinc-200 bg-[#faf9f7] px-6 py-12 text-center sm:px-12 sm:py-14">
-          <p className="text-xs uppercase tracking-[0.24em] text-zinc-500">Final CTA</p>
+      <section className="bg-[#111] px-6 py-20 text-white sm:py-24">
+        <div className="mx-auto max-w-6xl border border-white/10 bg-white/5 px-6 py-12 text-center sm:px-12 sm:py-14">
+          <p className="text-xs uppercase tracking-[0.24em] text-white/70">Final CTA</p>
           <h2 className="mt-3 text-3xl font-semibold sm:text-5xl">まずは自分に合うページから。</h2>
-          <p className="mx-auto mt-5 max-w-2xl text-sm leading-7 text-zinc-700 sm:text-base sm:leading-8">
+          <p className="mx-auto mt-5 max-w-2xl text-sm leading-7 text-white/80 sm:text-base sm:leading-8">
             詳しい使い方や登録の流れは、それぞれのページで確認できます。
           </p>
           <div className="mt-8 flex flex-col justify-center gap-3 sm:flex-row sm:gap-4">
             <Link href="/store">
-              <Button className="h-12 w-full rounded-full bg-zinc-900 px-8 text-sm font-semibold text-white hover:bg-zinc-800 sm:w-auto">
+              <Button className="h-12 w-full rounded-full bg-red-500 px-8 text-sm font-semibold text-white hover:bg-red-600 sm:w-auto">
                 店舗向けページを見る
               </Button>
             </Link>
             <Link href="/talent">
-              <Button variant="outline" className="h-12 w-full rounded-full border-zinc-400 px-8 text-sm font-semibold text-zinc-900 hover:bg-zinc-100 sm:w-auto">
+              <Button className="h-12 w-full rounded-full bg-red-500 px-8 text-sm font-semibold text-white hover:bg-red-600 sm:w-auto">
                 演者向けページを見る
               </Button>
             </Link>

--- a/talentify-next-frontend/app/store/page.tsx
+++ b/talentify-next-frontend/app/store/page.tsx
@@ -66,17 +66,17 @@ const lpImages = {
 
 export default function StoreLandingPage() {
   return (
-    <main className="bg-[#f5f4f1] text-zinc-900">
+    <main className="bg-white text-[#1a1a1a]">
       <section className="relative isolate overflow-hidden">
         <Image
           src={lpImages.heroMain}
           alt="来店イベントの現場イメージ"
           fill
           priority
-          className="object-cover"
+          className="object-cover brightness-110 contrast-110"
         />
-        <div className="absolute inset-0 bg-black/40" />
-        <div className="absolute inset-0 bg-gradient-to-r from-black/55 via-black/38 to-black/18" />
+        <div className="absolute inset-0 bg-[#111]/35" />
+        <div className="absolute inset-0 bg-gradient-to-r from-[#111]/40 via-[#111]/35 to-[#111]/20" />
         <div className="relative mx-auto max-w-6xl px-6 py-24 sm:py-32">
           <div className="max-w-3xl text-white">
             <p className="text-xs uppercase tracking-[0.2em] text-white/70">For Pachinko Stores</p>
@@ -93,7 +93,7 @@ export default function StoreLandingPage() {
               依頼条件の整理からやり取り、実績管理まで一元化できます。
             </p>
             <Link href="/register?role=store" className="mt-8 inline-flex">
-              <Button className="h-12 rounded-full bg-white px-8 text-sm font-semibold text-zinc-900 hover:bg-white/90 sm:h-14 sm:text-base">
+              <Button className="h-12 rounded-full bg-red-500 px-8 text-sm font-semibold text-white hover:bg-red-600 sm:h-14 sm:text-base">
                 無料で店舗登録
               </Button>
             </Link>
@@ -118,13 +118,13 @@ export default function StoreLandingPage() {
         </div>
       </section>
 
-      <section className="bg-white py-16 sm:py-24">
+      <section className="bg-gray-50 py-16 sm:py-24">
         <div className="mx-auto w-full max-w-6xl px-6">
           <p className="text-xs uppercase tracking-[0.2em] text-zinc-500">解決</p>
           <h2 className="mt-3 text-3xl font-semibold sm:text-5xl">Talentifyならすべて解決</h2>
           <div className="mt-8 grid gap-4 sm:grid-cols-2">
             {solutions.map((item) => (
-              <div key={item} className="border border-zinc-200 bg-[#f7f7f5] p-5 text-sm leading-7 sm:text-base">
+              <div key={item} className="border border-zinc-200 bg-white p-5 text-sm leading-7 sm:text-base">
                 ・{item}
               </div>
             ))}
@@ -149,13 +149,13 @@ export default function StoreLandingPage() {
         </div>
       </section>
 
-      <section className="bg-white py-16 sm:py-24">
+      <section className="bg-gray-50 py-16 sm:py-24">
         <div className="mx-auto w-full max-w-6xl px-6">
           <p className="text-xs uppercase tracking-[0.2em] text-zinc-500">機能</p>
           <h2 className="mt-3 text-3xl font-semibold sm:text-5xl">必要な機能だけ、明確に。</h2>
           <div className="mt-10 space-y-10">
             {featureCards.map((feature) => (
-              <div key={feature.label} className="grid gap-6 rounded-2xl border border-zinc-200 bg-zinc-50 p-4 sm:p-6 lg:grid-cols-[0.95fr_1.2fr] lg:items-center">
+              <div key={feature.label} className="grid gap-6 rounded-2xl border border-zinc-200 bg-white p-4 sm:p-6 lg:grid-cols-[0.95fr_1.2fr] lg:items-center">
                 <div>
                   <p className="text-xs uppercase tracking-[0.2em] text-zinc-500">{feature.label}</p>
                   <h3 className="mt-3 text-2xl font-semibold sm:text-3xl">{feature.title}</h3>
@@ -184,26 +184,26 @@ export default function StoreLandingPage() {
         </div>
       </section>
 
-      <section className="bg-[#111111] py-16 text-white sm:py-24">
+      <section className="bg-gray-50 py-16 sm:py-24">
         <div className="mx-auto w-full max-w-6xl px-6">
-          <p className="text-xs uppercase tracking-[0.2em] text-white/60">信頼</p>
+          <p className="text-xs uppercase tracking-[0.2em] text-zinc-500">信頼</p>
           <h2 className="mt-3 text-3xl font-semibold sm:text-5xl">導入の不安を、数字と運用で解消。</h2>
           <div className="mt-8 grid gap-4 sm:grid-cols-3">
-            <div className="border border-white/20 p-5">
+            <div className="rounded-xl border border-zinc-200 bg-white p-5">
               <p className="text-3xl font-semibold">導入相談 無料</p>
-              <p className="mt-2 text-sm text-white/80">初期費用0円。まずは運用に合うか確認できます。</p>
+              <p className="mt-2 text-sm text-zinc-700">初期費用0円。まずは運用に合うか確認できます。</p>
             </div>
-            <div className="border border-white/20 p-5">
+            <div className="rounded-xl border border-zinc-200 bg-white p-5">
               <p className="text-3xl font-semibold">履歴を蓄積</p>
-              <p className="mt-2 text-sm text-white/80">案件ごとの条件・評価が残るため、次回判断が早くなります。</p>
+              <p className="mt-2 text-sm text-zinc-700">案件ごとの条件・評価が残るため、次回判断が早くなります。</p>
             </div>
-            <div className="border border-white/20 p-5">
+            <div className="rounded-xl border border-zinc-200 bg-white p-5">
               <p className="text-3xl font-semibold">運用基盤化</p>
-              <p className="mt-2 text-sm text-white/80">担当者変更があっても、同じ品質で依頼を継続できます。</p>
+              <p className="mt-2 text-sm text-zinc-700">担当者変更があっても、同じ品質で依頼を継続できます。</p>
             </div>
           </div>
-          <div className="mt-6 rounded-2xl border border-white/20 bg-white/5 p-3 sm:p-4">
-            <div className="relative aspect-[16/10] w-full overflow-hidden rounded-xl border border-white/20 bg-zinc-900/60">
+          <div className="mt-6 rounded-2xl border border-zinc-200 bg-white p-3 sm:p-4">
+            <div className="relative aspect-[16/10] w-full overflow-hidden rounded-xl border border-zinc-200 bg-zinc-50">
               <Image src={lpImages.operation} alt="店舗運用のイメージ写真" fill className="object-cover" />
             </div>
           </div>
@@ -216,11 +216,11 @@ export default function StoreLandingPage() {
           まずは無料で始めて、運用の変化を確認できます。
         </p>
         <Link href="/register?role=store" className="mt-5 inline-flex">
-          <Button className="h-[54px] rounded-full px-9 text-sm font-semibold sm:h-14 sm:px-10 sm:text-base">無料で店舗登録</Button>
+          <Button className="h-[54px] rounded-full bg-red-500 px-9 text-sm font-semibold text-white hover:bg-red-600 sm:h-14 sm:px-10 sm:text-base">無料で店舗登録</Button>
         </Link>
       </section>
 
-      <section className="bg-zinc-950 px-6 py-20 text-white sm:py-24">
+      <section className="bg-[#111] px-6 py-20 text-white sm:py-24">
         <div className="mx-auto max-w-4xl text-center">
           <h2 className="text-2xl font-semibold leading-snug sm:text-5xl sm:leading-tight">
             今までのやり方を続けますか。
@@ -230,7 +230,7 @@ export default function StoreLandingPage() {
             依頼の属人化を終わらせるなら、最初の一歩は登録です。無料ですぐに始められます。
           </p>
           <Link href="/register?role=store" className="mt-8 inline-flex">
-            <Button className="h-12 rounded-full bg-white px-8 text-sm font-semibold text-zinc-900 hover:bg-white/90 sm:h-14 sm:text-base">
+            <Button className="h-12 rounded-full bg-red-500 px-8 text-sm font-semibold text-white hover:bg-red-600 sm:h-14 sm:text-base">
               無料で店舗登録
             </Button>
           </Link>

--- a/talentify-next-frontend/app/talent/page.tsx
+++ b/talentify-next-frontend/app/talent/page.tsx
@@ -59,10 +59,10 @@ const lpImages = {
 
 export default function TalentLandingPage() {
   return (
-    <main className="bg-[#f6f5f2] pt-16 text-zinc-900">
+    <main className="bg-white pt-16 text-[#1a1a1a]">
       <section className="relative isolate overflow-hidden">
-        <Image src={lpImages.heroMain} alt="演者の活動現場イメージ" fill priority className="object-cover" />
-        <div className="absolute inset-0 bg-black/55" />
+        <Image src={lpImages.heroMain} alt="演者の活動現場イメージ" fill priority className="object-cover brightness-110 contrast-110" />
+        <div className="absolute inset-0 bg-[#111]/35" />
 
         <div className="relative mx-auto max-w-6xl px-6 py-24 sm:py-32">
           <div className="max-w-3xl text-white">
@@ -80,7 +80,7 @@ export default function TalentLandingPage() {
 
             <div className="mt-8 flex flex-col gap-3 sm:flex-row">
               <Link href="/register?role=talent" className="inline-flex">
-                <Button className="h-12 rounded-full bg-white px-8 text-sm font-semibold text-zinc-900 hover:bg-white/90 sm:h-14 sm:text-base">
+                <Button className="h-12 rounded-full bg-red-500 px-8 text-sm font-semibold text-white hover:bg-red-600 sm:h-14 sm:text-base">
                   無料で演者登録
                 </Button>
               </Link>
@@ -99,13 +99,13 @@ export default function TalentLandingPage() {
         </div>
       </section>
 
-      <section className="bg-white py-16 sm:py-24">
+      <section className="bg-gray-50 py-16 sm:py-24">
         <div className="mx-auto w-full max-w-6xl px-6">
           <p className="text-xs uppercase tracking-[0.2em] text-zinc-500">解決</p>
           <h2 className="mt-3 text-3xl font-semibold sm:text-5xl">Talentifyなら、活動がつながる。</h2>
           <div className="mt-8 grid gap-4 sm:grid-cols-2">
             {solutions.map((item) => (
-              <div key={item} className="border border-zinc-200 bg-[#f7f7f5] p-5 text-sm leading-7 sm:text-base">・{item}</div>
+              <div key={item} className="border border-zinc-200 bg-white p-5 text-sm leading-7 sm:text-base">・{item}</div>
             ))}
           </div>
         </div>
@@ -116,12 +116,12 @@ export default function TalentLandingPage() {
         <h2 className="mt-3 text-3xl font-semibold sm:text-5xl">活動の価値が、正しく積み上がる。</h2>
         <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
           {benefits.map((item) => (
-            <div key={item} className="border-t-2 border-zinc-900 bg-white p-5 text-sm font-medium leading-7 sm:text-base">{item}</div>
+            <div key={item} className="border-t-2 border-red-500 bg-white p-5 text-sm font-medium leading-7 sm:text-base">{item}</div>
           ))}
         </div>
       </section>
 
-      <section className="bg-white py-16 sm:py-24">
+      <section className="bg-gray-50 py-16 sm:py-24">
         <div className="mx-auto w-full max-w-6xl px-6">
           <p className="text-xs uppercase tracking-[0.2em] text-zinc-500">機能</p>
           <h2 className="mt-3 text-3xl font-semibold sm:text-5xl">必要な機能だけ、明確に。</h2>
@@ -154,26 +154,26 @@ export default function TalentLandingPage() {
         </div>
       </section>
 
-      <section className="bg-[#111111] py-16 text-white sm:py-24">
+      <section className="bg-gray-50 py-16 sm:py-24">
         <div className="mx-auto w-full max-w-6xl px-6">
-          <p className="text-xs uppercase tracking-[0.2em] text-white/60">信頼 / 将来性</p>
+          <p className="text-xs uppercase tracking-[0.2em] text-zinc-500">信頼 / 将来性</p>
           <h2 className="mt-3 text-3xl font-semibold sm:text-5xl">活動を続けるほど、信頼は積み上がる。</h2>
           <div className="mt-8 grid gap-4 sm:grid-cols-3">
-            <div className="border border-white/20 p-5">
+            <div className="rounded-xl border border-zinc-200 bg-white p-5">
               <p className="text-2xl font-semibold">活動基盤になる</p>
-              <p className="mt-2 text-sm text-white/80">単発で終わらない導線をつくり、継続案件につながる状態へ。</p>
+              <p className="mt-2 text-sm text-zinc-700">単発で終わらない導線をつくり、継続案件につながる状態へ。</p>
             </div>
-            <div className="border border-white/20 p-5">
+            <div className="rounded-xl border border-zinc-200 bg-white p-5">
               <p className="text-2xl font-semibold">実績が資産になる</p>
-              <p className="mt-2 text-sm text-white/80">プロフィールと履歴が残ることで、次の案件で選ばれやすくなります。</p>
+              <p className="mt-2 text-sm text-zinc-700">プロフィールと履歴が残ることで、次の案件で選ばれやすくなります。</p>
             </div>
-            <div className="border border-white/20 p-5">
+            <div className="rounded-xl border border-zinc-200 bg-white p-5">
               <p className="text-2xl font-semibold">見つけてもらえる</p>
-              <p className="mt-2 text-sm text-white/80">営業だけに頼らず、継続的に機会へ届く導線を保てます。</p>
+              <p className="mt-2 text-sm text-zinc-700">営業だけに頼らず、継続的に機会へ届く導線を保てます。</p>
             </div>
           </div>
-          <div className="mt-6 rounded-2xl border border-white/20 bg-white/5 p-3 sm:p-4">
-            <div className="relative aspect-[16/10] w-full overflow-hidden rounded-xl border border-white/20 bg-zinc-900/60">
+          <div className="mt-6 rounded-2xl border border-zinc-200 bg-white p-3 sm:p-4">
+            <div className="relative aspect-[16/10] w-full overflow-hidden rounded-xl border border-zinc-200 bg-zinc-50">
               <Image src={lpImages.activity} alt="演者活動のイメージ写真" fill className="object-cover" />
             </div>
           </div>
@@ -186,18 +186,18 @@ export default function TalentLandingPage() {
           プロフィールを整えるだけでも、次の案件につながる準備になります。
         </p>
         <Link href="/register?role=talent" className="mt-6 inline-flex">
-          <Button className="h-12 rounded-full px-8 text-sm font-semibold sm:text-base">無料で演者登録</Button>
+          <Button className="h-12 rounded-full bg-red-500 px-8 text-sm font-semibold text-white hover:bg-red-600 sm:text-base">無料で演者登録</Button>
         </Link>
       </section>
 
-      <section className="bg-zinc-950 px-6 py-20 text-white sm:py-24">
+      <section className="bg-[#111] px-6 py-20 text-white sm:py-24">
         <div className="mx-auto max-w-4xl text-center">
           <h2 className="text-3xl font-semibold leading-tight sm:text-5xl">見つけてもらえる活動は、ここから始まる。</h2>
           <p className="mx-auto mt-6 max-w-2xl text-sm leading-7 text-white/80 sm:text-base">
             営業だけに頼らず、プロフィール・実績・信頼を積み上げる活動へ。
           </p>
           <Link href="/register?role=talent" className="mt-8 inline-flex">
-            <Button className="h-12 rounded-full bg-white px-8 text-sm font-semibold text-zinc-900 hover:bg-white/90 sm:h-14 sm:text-base">
+            <Button className="h-12 rounded-full bg-red-500 px-8 text-sm font-semibold text-white hover:bg-red-600 sm:h-14 sm:text-base">
               無料で演者登録
             </Button>
           </Link>


### PR DESCRIPTION
### Motivation
- LP全体に統一感を出しつつ「活気・エンタメ感」を強めるため、アクセント色を赤（`red-500`）へ寄せ、CTAを目立たせる変更を行いました。
- 中間で使われていた濃い黒背景を除去し、最終CTAのみ黒背景（`#111`）に限定して視認性と構成を整理しました。
- ヒーロー画像は維持しつつ明るさ/コントラストを上げてオーバーレイ比率を30〜40%相当に調整しました。

### Description
- 主要LPファイルの色調とボタンスタイルを更新（テキスト基調色を`#1a1a1a`へ変更、CTAを`bg-red-500`に統一）。
- ヒーロー画像に`brightness-110 contrast-110`を追加し、オーバーレイを`bg-[#111]/35`等に置換して#000依存を排除。 
- 中間のダークセクションを白/薄グレー基調へ変更し、最後のCTAセクションのみ`bg-[#111]`に統一。 
- 変更ファイル: `talentify-next-frontend/app/page.tsx`, `talentify-next-frontend/app/store/page.tsx`, `talentify-next-frontend/app/talent/page.tsx`.

### Testing
- 実行したLint: `cd talentify-next-frontend && npm run lint -- --file app/page.tsx --file app/store/page.tsx --file app/talent/page.tsx` — 結果: `No ESLint warnings or errors`（成功）。
- 開発サーバ起動: `cd talentify-next-frontend && npm run dev` — Next dev 起動確認（Local: http://localhost:3000 、Ready）。
- Playwright スクリーンショット試行: `npx playwright screenshot --device="Desktop Chrome" http://localhost:3000` — ブラウザ未インストールにより失敗（実行環境で `npx playwright install` が必要）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f02208a40483329c23aae7eae5ebd8)