### PR TITLE
演者検索の絞り込みUIをサイドパネル化し複数条件検索に対応

### DIFF
--- a/talentify-next-frontend/app/search/calendar/page.tsx
+++ b/talentify-next-frontend/app/search/calendar/page.tsx
@@ -80,7 +80,7 @@ export default function CalendarSearchPage() {
           <Button type='submit'>検索</Button>
         </div>
       </form>
-      <TalentList talents={results} />
+      <TalentList talents={results} totalCount={results.length} />
     </main>
   )
 }

--- a/talentify-next-frontend/components/talent-search/TalentList.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentList.tsx
@@ -3,7 +3,12 @@ import type { PublicTalent } from '@/types/talent'
 import { EmptyState } from '@/components/ui/empty-state'
 import { SearchX } from 'lucide-react'
 
-export default function TalentList({ talents }: { talents: PublicTalent[] }) {
+type TalentListProps = {
+  talents: PublicTalent[]
+  totalCount: number
+}
+
+export default function TalentList({ talents, totalCount }: TalentListProps) {
   if (talents.length === 0) {
     return (
       <EmptyState
@@ -18,12 +23,12 @@ export default function TalentList({ talents }: { talents: PublicTalent[] }) {
   return (
     <>
       <div className="mb-4 flex items-center justify-between gap-3">
-        <p className="text-sm text-gray-700">検索結果：{talents.length}件</p>
-        <div className="h-9 min-w-28 rounded-md border border-dashed border-gray-300 bg-gray-50 px-3 text-xs text-gray-400 flex items-center justify-center">
+        <p className="text-sm text-gray-700">検索結果：{totalCount}件</p>
+        <div className="flex h-9 min-w-28 items-center justify-center rounded-md border border-dashed border-gray-300 bg-gray-50 px-3 text-xs text-gray-400">
           並び替え（準備中）
         </div>
       </div>
-      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3">
         {talents.map(t => (
           <TalentCard key={t.id} talent={t} />
         ))}

--- a/talentify-next-frontend/components/talent-search/TalentSearchForm.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentSearchForm.tsx
@@ -1,50 +1,147 @@
 'use client'
-import { useState } from 'react'
-import { Input } from '@/components/ui/input'
+
+import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+export type RateRange = 'under_200k' | 'between_200k_500k' | 'over_500k' | 'negotiable'
 
 export type SearchFilters = {
   keyword: string
-  genre: string
-  area: string
+  genres: string[]
+  areas: string[]
+  rateRange?: RateRange
 }
 
-const GENRES = ['バラエティ', 'アイドル', 'お笑い', 'レポーター']
-const AREAS = ['東京', '大阪', '福岡', '北海道']
+type TalentSearchFormProps = {
+  onSearch: (f: SearchFilters) => void
+  genreOptions: string[]
+  areaOptions: string[]
+}
 
-export default function TalentSearchForm({ onSearch }: { onSearch: (f: SearchFilters) => void }) {
-  const [keyword, setKeyword] = useState('')
-  const [genre, setGenre] = useState('')
-  const [area, setArea] = useState('')
+const INITIAL_FILTERS: SearchFilters = {
+  keyword: '',
+  genres: [],
+  areas: [],
+  rateRange: undefined,
+}
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
-    onSearch({ keyword, genre, area })
+export default function TalentSearchForm({ onSearch, genreOptions, areaOptions }: TalentSearchFormProps) {
+  const [filters, setFilters] = useState<SearchFilters>(INITIAL_FILTERS)
+  const [isMobileFilterOpen, setIsMobileFilterOpen] = useState(false)
+
+  useEffect(() => {
+    onSearch(filters)
+  }, [filters, onSearch])
+
+  const toggleArrayFilter = (key: 'genres' | 'areas', value: string) => {
+    setFilters(prev => {
+      const currentValues = prev[key]
+      const nextValues = currentValues.includes(value)
+        ? currentValues.filter(item => item !== value)
+        : [...currentValues, value]
+
+      return {
+        ...prev,
+        [key]: nextValues,
+      }
+    })
+  }
+
+  const handleReset = () => {
+    setFilters(INITIAL_FILTERS)
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-2 md:grid md:grid-cols-3 md:gap-3 md:space-y-0">
-      <Input
-        placeholder="キーワード"
-        value={keyword}
-        onChange={e => setKeyword(e.target.value)}
-        className="md:col-span-1"
-      />
-      <select value={genre} onChange={e => setGenre(e.target.value)} className="h-9 rounded-md border px-2 md:col-span-1">
-        <option value="">ジャンル</option>
-        {GENRES.map(g => (
-          <option key={g} value={g}>{g}</option>
-        ))}
-      </select>
-      <select value={area} onChange={e => setArea(e.target.value)} className="h-9 rounded-md border px-2 md:col-span-1">
-        <option value="">居住地</option>
-        {AREAS.map(a => (
-          <option key={a} value={a}>{a}</option>
-        ))}
-      </select>
-      <div className="md:col-span-3 text-right">
-        <Button type="submit">検索</Button>
+    <>
+      <div className="md:hidden rounded-2xl border border-gray-200 bg-white p-4 shadow-sm">
+        <div className="space-y-3">
+          <Input
+            placeholder="名前・PR文で検索"
+            value={filters.keyword}
+            onChange={e => setFilters(prev => ({ ...prev, keyword: e.target.value }))}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full"
+            onClick={() => setIsMobileFilterOpen(prev => !prev)}
+          >
+            {isMobileFilterOpen ? '絞り込みを閉じる' : '絞り込み'}
+          </Button>
+        </div>
       </div>
-    </form>
+
+      <aside className={`rounded-2xl border border-gray-200 bg-white p-5 shadow-sm ${isMobileFilterOpen ? 'block' : 'hidden'} md:sticky md:top-24 md:block md:h-fit`}>
+        <div className="space-y-5">
+          <section className="space-y-2 border-b border-gray-100 pb-4">
+            <h3 className="text-sm font-semibold text-gray-900">キーワード</h3>
+            <Input
+              placeholder="名前・PR文で検索"
+              value={filters.keyword}
+              onChange={e => setFilters(prev => ({ ...prev, keyword: e.target.value }))}
+            />
+          </section>
+
+          <section className="space-y-3 border-b border-gray-100 pb-4">
+            <h3 className="text-sm font-semibold text-gray-900">ジャンル</h3>
+            <div className="space-y-2">
+              {genreOptions.map(option => (
+                <label key={option} className="flex items-center gap-2 text-sm text-gray-700">
+                  <input
+                    type="checkbox"
+                    className="h-5 w-5 rounded border-gray-300"
+                    checked={filters.genres.includes(option)}
+                    onChange={() => toggleArrayFilter('genres', option)}
+                  />
+                  <span>{option}</span>
+                </label>
+              ))}
+            </div>
+          </section>
+
+          <section className="space-y-3 border-b border-gray-100 pb-4">
+            <h3 className="text-sm font-semibold text-gray-900">活動エリア</h3>
+            <div className="space-y-2">
+              {areaOptions.map(option => (
+                <label key={option} className="flex items-center gap-2 text-sm text-gray-700">
+                  <input
+                    type="checkbox"
+                    className="h-5 w-5 rounded border-gray-300"
+                    checked={filters.areas.includes(option)}
+                    onChange={() => toggleArrayFilter('areas', option)}
+                  />
+                  <span>{option}</span>
+                </label>
+              ))}
+            </div>
+          </section>
+
+          <section className="space-y-2 border-b border-gray-100 pb-4">
+            <h3 className="text-sm font-semibold text-gray-900">料金目安</h3>
+            <select
+              value={filters.rateRange ?? ''}
+              onChange={e =>
+                setFilters(prev => ({
+                  ...prev,
+                  rateRange: e.target.value ? (e.target.value as RateRange) : undefined,
+                }))
+              }
+              className="h-10 w-full rounded-md border border-gray-300 px-3 text-sm"
+            >
+              <option value="">指定なし</option>
+              <option value="under_200k">〜20万円</option>
+              <option value="between_200k_500k">20〜50万円</option>
+              <option value="over_500k">50万円〜</option>
+              <option value="negotiable">要相談</option>
+            </select>
+          </section>
+
+          <Button type="button" variant="ghost" className="w-full" onClick={handleReset}>
+            条件をリセット
+          </Button>
+        </div>
+      </aside>
+    </>
   )
 }

--- a/talentify-next-frontend/components/talent-search/TalentSearchPage.tsx
+++ b/talentify-next-frontend/components/talent-search/TalentSearchPage.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { createClient } from '@/utils/supabase/client'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { toast } from 'sonner'
@@ -12,6 +12,38 @@ import { EmptyState } from '@/components/ui/empty-state'
 import { AlertCircle } from 'lucide-react'
 
 const ITEMS_PER_PAGE = 6
+
+const normalizeText = (value: string | null | undefined) => value?.trim().toLowerCase() ?? ''
+
+const extractAreaTokens = (area: string | null | undefined): string[] => {
+  if (!area) return []
+
+  const trimmed = area.trim()
+  if (!trimmed) return []
+
+  const normalized = trimmed.replace(/[\[\]"]+/g, '')
+  return normalized
+    .split(/[,、/\s]+/)
+    .map(part => part.trim())
+    .filter(Boolean)
+}
+
+const matchesRateRange = (rate: number | null, rateRange?: SearchFilters['rateRange']) => {
+  if (!rateRange) return true
+  if (rateRange === 'negotiable') return rate == null
+  if (rate == null) return false
+
+  switch (rateRange) {
+    case 'under_200k':
+      return rate <= 200_000
+    case 'between_200k_500k':
+      return rate > 200_000 && rate <= 500_000
+    case 'over_500k':
+      return rate > 500_000
+    default:
+      return true
+  }
+}
 
 export default function TalentSearchPage() {
   const [talents, setTalents] = useState<PublicTalent[]>([])
@@ -26,7 +58,7 @@ export default function TalentSearchPage() {
       const supabase = createClient() as SupabaseClient<any>
       const { data, error } = await supabase
         .from('public_talent_profiles')
-        .select('id, stage_name, genre, area, avatar_url, rate, rating, bio')
+        .select('id, stage_name, genre, area, avatar_url, rate, rating, bio, display_name')
         .returns<PublicTalent[]>()
 
       if (error) {
@@ -48,56 +80,94 @@ export default function TalentSearchPage() {
     fetchTalents()
   }, [])
 
-  const handleSearch = (f: SearchFilters) => {
-    const keyword = f.keyword.toLowerCase()
-    const filtered = talents.filter(t =>
-      (!f.keyword ||
-        t.stage_name?.toLowerCase().includes(keyword) ||
-        t.bio?.toLowerCase().includes(keyword)) &&
-      (!f.genre || t.genre === f.genre) &&
-      (!f.area || t.area === f.area)
-    )
-    setResults(filtered)
-    setPage(1)
-  }
+  const genreOptions = useMemo(
+    () =>
+      [...new Set(talents.map(talent => talent.genre?.trim()).filter((genre): genre is string => Boolean(genre)))].sort((a, b) =>
+        a.localeCompare(b, 'ja')
+      ),
+    [talents]
+  )
+
+  const areaOptions = useMemo(
+    () =>
+      [...new Set(talents.flatMap(talent => extractAreaTokens(talent.area)))].sort((a, b) => a.localeCompare(b, 'ja')),
+    [talents]
+  )
+
+  const handleSearch = useCallback(
+    (filters: SearchFilters) => {
+      const keyword = normalizeText(filters.keyword)
+      const filtered = talents.filter(talent => {
+        const name = normalizeText(talent.stage_name)
+        const displayName = normalizeText(talent.display_name)
+        const bio = normalizeText(talent.bio)
+
+        const keywordMatch =
+          !keyword || name.includes(keyword) || displayName.includes(keyword) || bio.includes(keyword)
+
+        const genreMatch = !filters.genres.length || (talent.genre ? filters.genres.includes(talent.genre) : false)
+
+        const areaMatch =
+          !filters.areas.length ||
+          filters.areas.some(areaFilter => {
+            const candidate = talent.area ?? ''
+            return candidate.includes(areaFilter) || extractAreaTokens(candidate).includes(areaFilter)
+          })
+
+        const rateMatch = matchesRateRange(talent.rate, filters.rateRange)
+
+        return keywordMatch && genreMatch && areaMatch && rateMatch
+      })
+
+      setResults(filtered)
+      setPage(1)
+    },
+    [talents]
+  )
 
   const totalPages = Math.ceil(results.length / ITEMS_PER_PAGE) || 1
   const paginated = results.slice((page - 1) * ITEMS_PER_PAGE, page * ITEMS_PER_PAGE)
 
   return (
-    <main className="mx-auto px-6 md:px-8 lg:px-12 space-y-6">
-      <TalentSearchForm onSearch={handleSearch} />
-      {isLoading ? (
-        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-          {Array.from({ length: ITEMS_PER_PAGE }).map((_, i) => (
-            <TalentCardSkeleton key={i} />
-          ))}
-        </div>
-      ) : error ? (
-        <EmptyState
-          illustration={<AlertCircle className="h-12 w-12 text-muted-foreground" />}
-          title="エラーが発生しました"
-          actionHref="/search/talents"
-          actionLabel="再読み込み"
-        />
-      ) : (
-        <TalentList talents={paginated} />
-      )}
-      {!isLoading && !error && totalPages > 1 && (
-        <div className="flex justify-center mt-6">
-          <nav className="flex space-x-2">
-            {Array.from({ length: totalPages }, (_, i) => i + 1).map(p => (
-              <button
-                key={p}
-                onClick={() => setPage(p)}
-                className={`px-3 py-1 border rounded ${p === page ? 'bg-blue-600 text-white' : 'bg-white'}`}
-              >
-                {p}
-              </button>
-            ))}
-          </nav>
-        </div>
-      )}
+    <main className="mx-auto space-y-6 px-6 md:px-8 lg:px-12">
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[260px_minmax(0,1fr)] lg:items-start">
+        <TalentSearchForm onSearch={handleSearch} genreOptions={genreOptions} areaOptions={areaOptions} />
+
+        <section className="space-y-4">
+          {isLoading ? (
+            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3">
+              {Array.from({ length: ITEMS_PER_PAGE }).map((_, i) => (
+                <TalentCardSkeleton key={i} />
+              ))}
+            </div>
+          ) : error ? (
+            <EmptyState
+              illustration={<AlertCircle className="h-12 w-12 text-muted-foreground" />}
+              title="エラーが発生しました"
+              actionHref="/search/talents"
+              actionLabel="再読み込み"
+            />
+          ) : (
+            <TalentList talents={paginated} totalCount={results.length} />
+          )}
+
+          {!isLoading && !error && totalPages > 1 && (
+            <div className="mt-6 flex justify-center">
+              <nav className="flex space-x-2">
+                {Array.from({ length: totalPages }, (_, i) => i + 1).map(p => (
+                  <button
+                    key={p}
+                    onClick={() => setPage(p)}
+                    className={`rounded border px-3 py-1 ${p === page ? 'bg-blue-600 text-white' : 'bg-white'}`}
+                  >
+                    {p}
+                  </button>
+                ))}
+              </nav>
+            </div>
+          )}
+        </section>
+      </div>
     </main>
   )
 }


### PR DESCRIPTION
### Motivation
- 演者検索を店舗担当者が比較しやすくするため、PCは左サイドの絞り込みパネル＋右側結果一覧の2カラムにし、モバイルでは開閉できる絞り込みUIにするため。 
- 実データに存在する条件（keyword / genre / area / rate）を中心に、選択肢を固定配列から実データ由来に切り替え、現行DBにない項目は追加しない方針を維持するため。

### Description
- 検索条件を `keyword` / `genres: string[]` / `areas: string[]` / `rateRange?` に拡張し、チェックボックスによる複数選択に対応するように `TalentSearchForm.tsx` を書き換えました。 
- PCは左の白カード型サイドパネル（sticky可, 幅約260px）・右に結果一覧を表示するグリッドレイアウトに変更し、モバイルではキーワード＋「絞り込み」開閉ボタンでパネルを切り替えるようにしました。 
- ジャンル・活動エリアの選択肢は `TalentSearchPage.tsx` 側で取得済み `talents` からユニーク抽出（空値除外・日本語ソート）し `TalentSearchForm` に渡すように変更し、活動エリアは配列風文字列やカンマ等の区切り文字を分解して候補を生成するロジックを追加しました。 
- クライアント側の検索ロジックを更新し、キーワード対象を `stage_name / display_name / bio` に拡張、エリアの部分一致や分解後トークンとの照合、料金目安（〜20万 / 20〜50万 / 50万〜 / 要相談）フィルタを実装しました。 
- `TalentList` の表示ヘッダを右カラム側に集約して `検索結果：◯件` と `並び替え（準備中）` を表示するようにし、`totalCount` prop を追加したため、呼び出し元のカレンダー検索ページを更新しました（`app/search/calendar/page.tsx`）。

### Testing
- 実行した lint: `npm run lint` は実行済みでエラーはなく、既存の `<img>` 関連の警告のみ報告されました。 
- 型チェック代替: `npx tsc --noEmit` を実行し、今回の変更箇所以外の既存テスト/Prisma 型周りの既知のTypeScriptエラーで失敗することを確認しました。 
- `npm run typecheck` はプロジェクトの `package.json` に定義がなく実行できませんでした。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f022a24e6c8332add15027dbd214e7)