### PR TITLE
Refine LP hero typography and layout for Talentify

### DIFF
--- a/talentify-next-frontend/app/globals.css
+++ b/talentify-next-frontend/app/globals.css
@@ -41,3 +41,118 @@ body {
     padding-top: env(safe-area-inset-top);
   }
 }
+
+.talentify-brand-word {
+  margin: 0;
+  font-size: clamp(54px, 6vw, 104px);
+  font-weight: 900;
+  font-style: italic;
+  letter-spacing: -0.06em;
+  line-height: 0.9;
+  color: #fff;
+  transform: rotate(-3deg) skewX(-8deg);
+  transform-origin: left center;
+  text-shadow: 0 4px 0 rgba(0, 0, 0, 0.68), 0 12px 30px rgba(0, 0, 0, 0.82), 0 0 22px rgba(255, 255, 255, 0.22);
+}
+
+.talentify-hero-copy {
+  position: relative;
+  z-index: 2;
+  margin-top: 14px;
+  font-size: clamp(56px, 6.8vw, 112px);
+  font-weight: 900;
+  letter-spacing: -0.06em;
+  line-height: 0.91;
+  color: #fff;
+  transform: rotate(-3deg) skewX(-4deg);
+  transform-origin: left center;
+  text-shadow: 0 4px 0 rgba(0, 0, 0, 0.65), 0 10px 22px rgba(0, 0, 0, 0.8), 0 0 20px rgba(255, 255, 255, 0.18);
+}
+
+.talentify-hero-copy-line {
+  display: block;
+  white-space: nowrap;
+}
+
+.talentify-hero-copy-white {
+  color: #fff;
+}
+
+.talentify-hero-copy-fever {
+  display: inline-block;
+  margin-left: 0.05em;
+  background: linear-gradient(90deg, #fff200 0%, #ffb000 28%, #ff4b2b 55%, #ff2d8f 82%, #d94cff 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  filter: drop-shadow(0 5px 0 rgba(0, 0, 0, 0.7)) drop-shadow(0 12px 22px rgba(255, 45, 143, 0.35));
+  transform: scale(1.1) rotate(2deg);
+  transform-origin: left bottom;
+}
+
+.talentify-hero-subcopy {
+  position: relative;
+  z-index: 2;
+  margin-top: 30px;
+  font-size: clamp(24px, 2.4vw, 40px);
+  font-weight: 800;
+  line-height: 1.38;
+  letter-spacing: -0.02em;
+  color: #fff;
+  transform: rotate(-3deg);
+  text-shadow: 0 3px 0 rgba(0, 0, 0, 0.6), 0 8px 18px rgba(0, 0, 0, 0.65);
+}
+
+.talentify-hero-subcopy span {
+  color: #ff2d8f;
+  text-shadow: 0 0 12px rgba(255, 45, 143, 0.45), 0 3px 0 rgba(0, 0, 0, 0.7);
+}
+
+.talentify-hero-copy-glow {
+  position: absolute;
+  z-index: 1;
+  left: -18%;
+  top: -18%;
+  width: min(860px, 120%);
+  aspect-ratio: 1.2 / 1;
+  background: radial-gradient(circle at 32% 35%, rgba(0, 0, 0, 0.75) 0%, rgba(0, 0, 0, 0.56) 34%, rgba(0, 0, 0, 0.15) 62%, rgba(0, 0, 0, 0) 100%);
+  filter: blur(6px);
+}
+
+@media (max-width: 1024px) {
+  .talentify-hero-copy {
+    font-size: clamp(44px, 7vw, 80px);
+  }
+}
+
+@media (max-width: 768px) {
+  .talentify-brand-word {
+    font-size: clamp(44px, 12vw, 68px);
+    transform: rotate(-2deg) skewX(-5deg);
+  }
+
+  .talentify-hero-copy {
+    margin-top: 10px;
+    font-size: clamp(38px, 11vw, 58px);
+    line-height: 0.96;
+    transform: rotate(-1.5deg) skewX(-2deg);
+  }
+
+  .talentify-hero-copy-line {
+    white-space: normal;
+  }
+
+  .talentify-hero-subcopy {
+    margin-top: 24px;
+    font-size: clamp(20px, 5.8vw, 30px);
+    line-height: 1.35;
+    transform: rotate(-1.5deg);
+  }
+
+  .talentify-hero-copy-glow {
+    left: -24%;
+    top: -22%;
+    width: 140%;
+  }
+}

--- a/talentify-next-frontend/app/page.tsx
+++ b/talentify-next-frontend/app/page.tsx
@@ -223,21 +223,21 @@ export default function HomePage() {
         <div className="pointer-events-none absolute inset-x-0 bottom-0 h-28 bg-[radial-gradient(ellipse_at_bottom,rgba(0,0,0,.88)_20%,rgba(0,0,0,0)_75%)]" />
         <div className="pointer-events-none absolute inset-0 bg-black/30" />
 
-        <div className="relative mx-auto grid w-full max-w-7xl gap-10 px-4 sm:px-6 lg:grid-cols-[1.2fr_.95fr] lg:items-center lg:px-8">
-          <div>
-            <p className="text-sm font-bold uppercase tracking-[0.18em] text-pink-300">Talentify</p>
-            <h1 className="mt-4 text-5xl font-black leading-[0.95] tracking-tight drop-shadow-[0_10px_30px_rgba(0,0,0,.95)] sm:text-6xl lg:text-8xl">
-              お店も、ファンも、
-              <br />
-              もっと
-              <span className="inline-block -rotate-[4deg] bg-gradient-to-r from-yellow-300 via-orange-400 to-pink-500 bg-clip-text pl-1 text-transparent [text-shadow:0_2px_0_rgba(0,0,0,.65),0_0_35px_rgba(255,90,120,.5)]">
-                熱狂！
+        <div className="relative mx-auto grid w-full max-w-7xl gap-10 px-4 sm:px-6 lg:grid-cols-[1.26fr_.94fr] lg:items-center lg:px-8">
+          <div className="relative z-10 pt-3 sm:pt-6 lg:pt-10">
+            <div aria-hidden className="talentify-hero-copy-glow" />
+            <p className="talentify-brand-word">Talentify</p>
+            <h1 className="talentify-hero-copy" aria-label="お店も、ファンも、もっと熱狂！">
+              <span className="talentify-hero-copy-line talentify-hero-copy-white">お店も、ファンも、</span>
+              <span className="talentify-hero-copy-line talentify-hero-copy-white">
+                もっと
+                <span className="talentify-hero-copy-fever">熱狂！</span>
               </span>
             </h1>
-            <p className="mt-5 text-lg font-semibold leading-relaxed text-white/90 sm:text-2xl">
-              タレント × <span className="text-pink-400">店舗</span> × ファンをつなぐ
+            <p className="talentify-hero-subcopy">
+              タレント × <span>店舗</span> × ファンをつなぐ
               <br />
-              エンタメ<span className="text-pink-400">特化</span>型プラットフォーム
+              エンタメ<span>特化</span>型プラットフォーム
             </p>
 
             <div className="mt-7 grid gap-3 sm:grid-cols-3">


### PR DESCRIPTION
### Motivation
- Make the left-side hero copy visually match the provided ad-like design by turning the headline into a typographic visual (large white slanted text, strong shadows, and a vivid gradient for “熱狂！”) and avoid header clipping or background blending issues.
- Keep changes scoped to the hero left column so other sections remain largely untouched while improving the perceived impact of the headline and subcopy.

### Description
- Reworked the hero markup in `app/page.tsx` to a single `h1` with line/word-level spans and an `aria-label` so `もっと` + `熱狂！` can be styled together and responsively; the brand word `Talentify` was also added as a dedicated element.
- Added LP-scoped CSS classes in `app/globals.css` (`.talentify-brand-word`, `.talentify-hero-copy`, `.talentify-hero-copy-line`, `.talentify-hero-copy-fever`, `.talentify-hero-subcopy`, `.talentify-hero-copy-glow`) to implement large responsive `clamp()` sizes, rotation/skew, condensed line-height, strong multi-layer text-shadows, and the yellow→orange→pink gradient for `熱狂！`.
- Inserted an organic radial dark glow behind the left hero text (`.talentify-hero-copy-glow`) to prevent the copy from blending into the background without using a hard rectangle, and adjusted the hero grid ratio and top padding to reduce header overlap/clip risk.
- Implemented responsive fallbacks (reduced skew/rotation, `white-space: normal` on small screens) so the headline keeps impact on desktop and avoids overflow on mobile.

### Testing
- Ran `npm run lint` (Next.js ESLint) and it completed successfully, with unrelated `no-img-element` warnings in other files remaining as before.
- Started the dev server via `npm run dev` and the process launched successfully for local verification during development.
- Ran `npx playwright install chromium` which completed and downloaded browsers successfully, but `npx playwright screenshot` attempts failed to launch Chromium in this environment due to a missing system library (`libatk-1.0.so.0`), so automated screenshots could not be captured here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f150f1b2a88332bbb26d361980f2bf)